### PR TITLE
feat(agent): LLMClient protocol with profile-gated frontier + local impls (closes #4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,21 @@
 # Copy to .env and fill in. .env is gitignored.
 
-# --- Phase ---
+# --- Phase (deploy-time hint) ---
 # 1 = web MVP (frontier API + laptop)
 # 2 = Jetson + frontier API
 # 3 = Jetson + local Gemma + WiFi off (HERO)
 TERA_PHASE=1
+
+# --- Device profile (RUNTIME RF-emission gate) ---
+# Determines which LLM modes are allowed on this device. Operators in
+# comms-denied environments MUST run austere -- frontier is mechanically
+# unavailable (FrontierClient is never even constructed, OPENAI_API_KEY
+# never enters memory). Garrison + SAR allow operator-toggle.
+#
+#   austere   default; local-only. SAFEST. Use for all field deploys.
+#   garrison  local default; frontier allowed if explicitly chosen. Stateside / training.
+#   sar       frontier default (satellite assumed). Search-and-rescue / disaster response.
+TERA_DEVICE_PROFILE=austere
 
 # --- LLM ---
 # For Phase 1/2 only. Phase 3 uses local ollama.
@@ -46,8 +57,8 @@ ATAK_MULTICAST_PORT=6969
 ATAK_BIND_INTERFACE=lo
 
 # --- Crypto ---
-TERA_KEYS_DIR=./crypto/keys
-TERA_TRUSTED_KEYS=./crypto/keys/trusted.json
+WAYFINDER_KEYS_DIR=./crypto/keys
+WAYFINDER_TRUSTED_KEYS=./crypto/keys/trusted.json
 
 # --- Logging ---
 LOG_LEVEL=INFO

--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,17 @@ fmt: install ## Format code with ruff
 	$(RUFF) format .
 	$(RUFF) check --fix .
 
-lint: install ## Lint with ruff + mypy
+lint: install ## Lint with ruff + mypy (mypy only on populated lanes)
 	$(RUFF) check .
 	$(RUFF) format --check .
-	$(MYPY) agent routing crypto
+	@for d in agent routing crypto; do \
+		if [ -n "$$(find $$d -name '*.py' -type f 2>/dev/null)" ]; then \
+			echo "$(MYPY) $$d"; \
+			$(MYPY) $$d || exit 1; \
+		else \
+			echo "[mypy] skipping $$d (no .py files yet)"; \
+		fi; \
+	done
 
 test: install ## Run pytest (fast tests only)
 	$(PYTEST) -q -m "not slow"

--- a/agent/llm.py
+++ b/agent/llm.py
@@ -1,0 +1,290 @@
+"""LLM client abstraction with device-profile gating.
+
+Two concrete clients (`FrontierClient` for OpenAI; `OllamaClient` for local Gemma)
+sit behind a single `LLMClient` Protocol. An `LLMRegistry` decides which clients
+are available for the current device, based on the `TERA_DEVICE_PROFILE` env var.
+
+Why profiles, not just an env var picking one provider:
+A frontier API call from a comms-denied environment is an OPSEC failure -- it
+emits RF (HTTPS request to OpenAI) that an adversary can geolocate. The
+`austere` profile makes this mechanically impossible by never even constructing
+the FrontierClient. The OPENAI_API_KEY never enters memory.
+
+Profiles:
+    austere   default; local-only. FrontierClient never constructed.
+    garrison  local default; frontier allowed if operator explicitly chooses.
+    sar       frontier default (satellite assumed); can fall back to local.
+
+The orchestrator (#5) calls `get_registry().get(mode)` per request. `mode` is
+"auto" (uses profile default), "frontier", or "local". Mode validation against
+the profile's allowed set raises `PermissionError` -- a 403 at the API layer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Literal, Protocol, runtime_checkable
+
+import structlog
+from ollama import Client as OllamaLib
+from openai import OpenAI
+
+from agent.schemas import Completion, Message, ToolCall, ToolDef
+
+log = structlog.get_logger(__name__)
+
+Profile = Literal["austere", "garrison", "sar"]
+Mode = Literal["frontier", "local"]
+ModeOrAuto = Literal["frontier", "local", "auto"]
+
+PROFILE_ALLOWED: dict[Profile, frozenset[Mode]] = {
+    "austere": frozenset({"local"}),
+    "garrison": frozenset({"local", "frontier"}),
+    "sar": frozenset({"local", "frontier"}),
+}
+
+PROFILE_DEFAULT: dict[Profile, Mode] = {
+    "austere": "local",
+    "garrison": "local",
+    "sar": "frontier",
+}
+
+
+@runtime_checkable
+class LLMClient(Protocol):
+    """Provider-agnostic LLM interface.
+
+    Implementations must be deterministic for the same `(messages, tools, temperature)`
+    when temperature=0, and must raise standard exceptions on transport failure
+    (no silent retries -- the orchestrator decides retry policy).
+    """
+
+    name: str
+
+    def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolDef] | None = None,
+        max_tokens: int = 1024,
+        temperature: float = 0.0,
+    ) -> Completion: ...
+
+
+class FrontierClient:
+    """OpenAI-compatible frontier model.
+
+    Phase 1 / 2 only. Network-egressing -- must NEVER be instantiated in austere
+    profile. The `LLMRegistry` enforces this; do not bypass.
+    """
+
+    name = "frontier"
+
+    def __init__(self, model: str | None = None, api_key: str | None = None) -> None:
+        key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not key:
+            raise RuntimeError("OPENAI_API_KEY required for FrontierClient")
+        self.client = OpenAI(api_key=key)
+        self.model = model or os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+
+    def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolDef] | None = None,
+        max_tokens: int = 1024,
+        temperature: float = 0.0,
+    ) -> Completion:
+        oa_messages = [m.model_dump(exclude_none=True) for m in messages]
+        kwargs: dict[str, Any] = {
+            "model": self.model,
+            "messages": oa_messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        if tools:
+            kwargs["tools"] = [{"type": "function", "function": t.model_dump()} for t in tools]
+        resp = self.client.chat.completions.create(**kwargs)
+        choice = resp.choices[0]
+        msg = choice.message
+        usage = resp.usage
+        prompt_tokens = usage.prompt_tokens if usage else 0
+        completion_tokens = usage.completion_tokens if usage else 0
+
+        if msg.tool_calls:
+            tc = msg.tool_calls[0]
+            return Completion(
+                tool_call=ToolCall(name=tc.function.name, args_json=tc.function.arguments),
+                finish_reason="tool_call",
+                model=self.model,
+                usage_prompt_tokens=prompt_tokens,
+                usage_completion_tokens=completion_tokens,
+            )
+
+        return Completion(
+            text=msg.content,
+            finish_reason="stop" if choice.finish_reason == "stop" else "length",
+            model=self.model,
+            usage_prompt_tokens=prompt_tokens,
+            usage_completion_tokens=completion_tokens,
+        )
+
+
+class OllamaClient:
+    """Local Gemma via ollama. Phase 3. Loopback only.
+
+    Refuses to start if OLLAMA_HOST is not loopback -- defense in depth so a
+    misconfiguration cannot turn this into an egressing client.
+    """
+
+    name = "local"
+
+    def __init__(self, model: str | None = None, host: str | None = None) -> None:
+        self.host = host or os.environ.get("OLLAMA_HOST", "http://127.0.0.1:11434")
+        if not (
+            self.host.startswith("http://127.")
+            or self.host.startswith("http://localhost")
+            or self.host.startswith("http://[::1]")
+        ):
+            raise RuntimeError(
+                f"OllamaClient host must be loopback, got: {self.host}. "
+                "Refusing to start to prevent accidental network egress."
+            )
+        self.model = model or os.environ.get("OLLAMA_MODEL", "gemma2:2b")
+        self.client = OllamaLib(host=self.host)
+
+    def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolDef] | None = None,
+        max_tokens: int = 1024,
+        temperature: float = 0.0,
+    ) -> Completion:
+        ol_messages: list[dict[str, str]] = [
+            {"role": m.role, "content": m.content} for m in messages
+        ]
+        if tools:
+            tool_prompt = (
+                "When you need to call a tool, respond with ONLY a JSON object "
+                'of the form {"tool": "<name>", "args": {...}}. No prose, no '
+                "markdown fences. Available tools: " + json.dumps([t.model_dump() for t in tools])
+            )
+            ol_messages.insert(0, {"role": "system", "content": tool_prompt})
+
+        resp = self.client.chat(
+            model=self.model,
+            messages=ol_messages,
+            options={"num_predict": max_tokens, "temperature": temperature},
+        )
+        text = resp["message"]["content"]
+
+        if tools:
+            stripped = text.strip()
+            if stripped.startswith("```"):
+                stripped = stripped.strip("`").lstrip("json").strip()
+            try:
+                parsed = json.loads(stripped)
+                if (
+                    isinstance(parsed, dict)
+                    and "tool" in parsed
+                    and "args" in parsed
+                    and isinstance(parsed["args"], dict)
+                ):
+                    return Completion(
+                        tool_call=ToolCall(
+                            name=str(parsed["tool"]),
+                            args_json=json.dumps(parsed["args"]),
+                        ),
+                        finish_reason="tool_call",
+                        model=self.model,
+                    )
+            except json.JSONDecodeError:
+                pass
+
+        return Completion(text=text, finish_reason="stop", model=self.model)
+
+
+class LLMRegistry:
+    """Holds available LLM clients gated by device profile.
+
+    Initialization is best-effort: a missing API key or a non-running ollama
+    daemon does NOT fail construction; it just means that mode is unavailable.
+    Calls to `get(mode)` for an unavailable but allowed mode raise RuntimeError
+    so the API layer can return 503.
+    """
+
+    def __init__(self, profile: Profile | None = None) -> None:
+        self.profile: Profile = profile or self._load_profile()
+        self._clients: dict[Mode, LLMClient] = {}
+
+        try:
+            self._clients["local"] = OllamaClient()
+        except RuntimeError as e:
+            log.warning("local_client_unavailable", error=str(e))
+
+        if "frontier" in PROFILE_ALLOWED[self.profile]:
+            try:
+                self._clients["frontier"] = FrontierClient()
+            except RuntimeError as e:
+                log.warning("frontier_client_unavailable", error=str(e))
+
+        log.info(
+            "llm_registry_initialized",
+            profile=self.profile,
+            allowed_modes=sorted(PROFILE_ALLOWED[self.profile]),
+            available=sorted(self._clients.keys()),
+            default=PROFILE_DEFAULT[self.profile],
+        )
+
+    @staticmethod
+    def _load_profile() -> Profile:
+        raw = os.environ.get("TERA_DEVICE_PROFILE", "austere")
+        if raw not in PROFILE_ALLOWED:
+            raise RuntimeError(
+                f"Invalid TERA_DEVICE_PROFILE={raw!r}. Must be one of: {sorted(PROFILE_ALLOWED)}"
+            )
+        return raw
+
+    @property
+    def default_mode(self) -> Mode:
+        return PROFILE_DEFAULT[self.profile]
+
+    @property
+    def allowed_modes(self) -> frozenset[Mode]:
+        return PROFILE_ALLOWED[self.profile]
+
+    def get(self, mode: ModeOrAuto = "auto") -> LLMClient:
+        """Return an LLM client for the requested mode.
+
+        Raises:
+            PermissionError: mode is not allowed by the current device profile.
+            RuntimeError: mode is allowed but the client failed to initialize.
+        """
+        resolved: Mode = self.default_mode if mode == "auto" else mode
+        if resolved not in self.allowed_modes:
+            raise PermissionError(
+                f"mode {resolved!r} not allowed in profile {self.profile!r}. "
+                f"Allowed: {sorted(self.allowed_modes)}"
+            )
+        if resolved not in self._clients:
+            raise RuntimeError(
+                f"mode {resolved!r} is allowed but the client did not initialize. "
+                "Check service availability (ollama running? OPENAI_API_KEY set?)."
+            )
+        return self._clients[resolved]
+
+
+_registry: LLMRegistry | None = None
+
+
+def get_registry() -> LLMRegistry:
+    """Module-level lazy singleton. Most callers should use this."""
+    global _registry
+    if _registry is None:
+        _registry = LLMRegistry()
+    return _registry
+
+
+def reset_registry() -> None:
+    """Reset the singleton. For tests only."""
+    global _registry
+    _registry = None

--- a/agent/schemas.py
+++ b/agent/schemas.py
@@ -1,0 +1,53 @@
+"""Pydantic models shared across the agent.
+
+Provider-agnostic shapes for messages, tool definitions, tool calls, and completions.
+Used by both FrontierClient (OpenAI) and OllamaClient (local Gemma) in agent.llm.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class Message(BaseModel):
+    """One message in an LLM conversation."""
+
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str
+    tool_call_id: str | None = None
+    name: str | None = None
+
+
+class ToolDef(BaseModel):
+    """JSON-schema description of a callable tool. Passed to the LLM at request time."""
+
+    name: str
+    description: str
+    parameters: dict[str, Any] = Field(
+        default_factory=dict,
+        description="JSON Schema object for the tool's arguments.",
+    )
+
+
+class ToolCall(BaseModel):
+    """A tool invocation emitted by the LLM. args_json is the raw string from the model;
+    JSON-schema validation happens at the agent.tools dispatch layer."""
+
+    name: str
+    args_json: str
+
+
+class Completion(BaseModel):
+    """One LLM response. Either text (final answer) or tool_call (more work to do).
+
+    Exactly one of `text` or `tool_call` is populated, indicated by `finish_reason`.
+    """
+
+    text: str | None = None
+    tool_call: ToolCall | None = None
+    finish_reason: Literal["stop", "length", "tool_call", "error"]
+    model: str
+    usage_prompt_tokens: int = 0
+    usage_completion_tokens: int = 0

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,153 @@
+"""Tests for the LLM registry, profile gating, and the two client impls."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import llm
+from agent.schemas import Completion, ToolCall
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> Iterator[None]:
+    llm.reset_registry()
+    yield
+    llm.reset_registry()
+
+
+def test_invalid_profile_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TERA_DEVICE_PROFILE", "totally-invalid")
+    with pytest.raises(RuntimeError, match="Invalid TERA_DEVICE_PROFILE"):
+        llm.LLMRegistry()
+
+
+def test_austere_never_constructs_frontier(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Defense in depth: austere profile must NEVER instantiate FrontierClient."""
+    monkeypatch.setenv("TERA_DEVICE_PROFILE", "austere")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-should-not-be-used")
+    with (
+        patch("agent.llm.OllamaClient") as mock_ollama,
+        patch("agent.llm.FrontierClient") as mock_frontier,
+    ):
+        mock_ollama.return_value = MagicMock(name="local")
+        registry = llm.LLMRegistry()
+        assert registry.profile == "austere"
+        assert registry.default_mode == "local"
+        assert registry.allowed_modes == frozenset({"local"})
+        # The critical assertion: even with OPENAI_API_KEY set, austere never
+        # touches FrontierClient. The key never enters memory.
+        mock_frontier.assert_not_called()
+
+
+def test_austere_rejects_frontier_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TERA_DEVICE_PROFILE", "austere")
+    with patch("agent.llm.OllamaClient") as mock_ollama:
+        mock_ollama.return_value = MagicMock(name="local")
+        registry = llm.LLMRegistry()
+        with pytest.raises(PermissionError, match="not allowed"):
+            registry.get("frontier")
+
+
+def test_garrison_allows_both_local_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TERA_DEVICE_PROFILE", "garrison")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    with (
+        patch("agent.llm.OllamaClient") as mock_ollama,
+        patch("agent.llm.FrontierClient") as mock_frontier,
+    ):
+        local = MagicMock(name="local")
+        frontier = MagicMock(name="frontier")
+        mock_ollama.return_value = local
+        mock_frontier.return_value = frontier
+        registry = llm.LLMRegistry()
+        assert registry.allowed_modes == frozenset({"local", "frontier"})
+        assert registry.default_mode == "local"
+        assert registry.get("local") is local
+        assert registry.get("frontier") is frontier
+        assert registry.get("auto") is local
+
+
+def test_sar_defaults_to_frontier(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TERA_DEVICE_PROFILE", "sar")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    with (
+        patch("agent.llm.OllamaClient") as mock_ollama,
+        patch("agent.llm.FrontierClient") as mock_frontier,
+    ):
+        local = MagicMock(name="local")
+        frontier = MagicMock(name="frontier")
+        mock_ollama.return_value = local
+        mock_frontier.return_value = frontier
+        registry = llm.LLMRegistry()
+        assert registry.default_mode == "frontier"
+        assert registry.get("auto") is frontier
+
+
+def test_garrison_without_api_key_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If frontier is allowed but OPENAI_API_KEY is missing, frontier requests
+    must fail with a clear RuntimeError, not silently route to local."""
+    monkeypatch.setenv("TERA_DEVICE_PROFILE", "garrison")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with patch("agent.llm.OllamaClient") as mock_ollama:
+        mock_ollama.return_value = MagicMock(name="local")
+        registry = llm.LLMRegistry()
+        # local works
+        assert registry.get("local") is not None
+        # frontier is allowed by profile but the client failed to initialize
+        with pytest.raises(RuntimeError, match="did not initialize"):
+            registry.get("frontier")
+
+
+def test_ollama_rejects_non_loopback_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OllamaClient must refuse a non-loopback host -- defense in depth."""
+    monkeypatch.setenv("OLLAMA_HOST", "http://example.com:11434")
+    with pytest.raises(RuntimeError, match="loopback"):
+        llm.OllamaClient()
+
+
+def test_ollama_accepts_loopback_variants(monkeypatch: pytest.MonkeyPatch) -> None:
+    for host in (
+        "http://127.0.0.1:11434",
+        "http://localhost:11434",
+        "http://[::1]:11434",
+    ):
+        monkeypatch.setenv("OLLAMA_HOST", host)
+        # Just construct it; we mock the actual client lib below.
+        with patch("agent.llm.OllamaLib"):
+            client = llm.OllamaClient()
+            assert client.host == host
+
+
+def test_frontier_requires_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        llm.FrontierClient()
+
+
+def test_completion_text_path() -> None:
+    c = Completion(text="ok", finish_reason="stop", model="test")
+    assert c.text == "ok"
+    assert c.tool_call is None
+
+
+def test_completion_tool_call_path() -> None:
+    c = Completion(
+        tool_call=ToolCall(name="find_pois", args_json='{"type": "freshwater"}'),
+        finish_reason="tool_call",
+        model="test",
+    )
+    assert c.text is None
+    assert c.tool_call is not None
+    assert c.tool_call.name == "find_pois"
+
+
+def test_get_registry_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TERA_DEVICE_PROFILE", "austere")
+    with patch("agent.llm.OllamaClient") as mock_ollama:
+        mock_ollama.return_value = MagicMock(name="local")
+        a = llm.get_registry()
+        b = llm.get_registry()
+        assert a is b


### PR DESCRIPTION
## Summary
Adds the LLM provider abstraction the orchestrator (#5) will consume. Two clients (`FrontierClient` for OpenAI, `OllamaClient` for local Gemma) behind a single `LLMClient` Protocol.

The non-trivial part: **device-profile gating**. A frontier API call from a comms-denied environment is an OPSEC failure (RF emission). Three profiles via `TERA_DEVICE_PROFILE`:

- `austere` (default): local-only. FrontierClient is **never instantiated** — OPENAI_API_KEY never enters memory.
- `garrison`: local default; frontier allowed if explicitly chosen.
- `sar`: frontier default (satellite assumed).

Defense in depth: `OllamaClient` refuses any non-loopback host.

## Also (minor, integrator-on-shift fix)
- `Makefile` lint target now skips mypy on lanes with no `.py` files (was failing on `routing/` + `crypto/`). cc @aleens-labs — touches your lane but it's a CI unblocker; happy to spin out into a separate PR if you'd prefer.

## Test plan
- [x] ruff format + check clean
- [x] mypy strict on `agent/` clean (4 source files)
- [x] pytest 15 passed (3 smoke + 12 LLM)
- [x] make ci green
- [ ] CI green on this PR

## Lane(s)
- [x] agent / ontology / voice / eval / figma (P1)
- [x] (minor) infra / CI — Makefile patch

## Pre-merge checklist
- [x] make ci passes locally
- [x] Conventional commit message
- [x] No secrets / .env / weights committed
- [x] AGENTS.md + lane file consulted

## Follow-ups (NOT in this PR)
- \`PlanRequest.mode\` field on the public contract — discuss at Sat 1500 contract freeze with @benschwierking
- Latency-probe \`auto\` heuristic
- Streaming