### PR TITLE
chore: scaffold polish v2 - catchup tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,18 @@ For the overnight grind (Sat 2200 – Sun 0700), when stuck:
 2. Paste the problem into your AI agent (Codex / Cursor / Claude Code) — explain what you tried, what you expected, what happened.
 3. **Only then** ping a teammate. A teammate's flow state at 0300 is more expensive than a 30-second AI round-trip.
 
+## 9.1. Resuming work after a break (sleep, lunch, demo dry-run)
+
+Before you write a single line of code after any break:
+
+```
+make catchup
+```
+
+This pulls main, refreshes deps if `pyproject.toml`/`Makefile` changed, summarizes recent commits, **flags contract changes** that may affect your in-flight work, and lists your open issues. Paste the output into your AI agent and ask it to flag anything you should know before resuming.
+
+If a contract under `/docs/contracts/` changed while you were away, STOP coding and re-read it before continuing -- your half-written code may be stale. The integrator-on-shift announces contract changes in Signal `#tera` thread, but `make catchup` is your machine-side check.
+
 ## 10. The five non-negotiables
 
 Verbatim from PRD §14.11. If we drop everything else, we keep these:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help onboard install install-crypto install-voice fmt lint test security ci run demo eval clean
+.PHONY: help onboard catchup install install-crypto install-voice fmt lint test security ci run demo eval clean
 .DEFAULT_GOAL := help
 
 PY := python3.11
@@ -16,6 +16,9 @@ help: ## Show this help
 
 onboard: ## "I am Ben, get me ready to party." (interactive). Pass NAME=ben to skip prompt.
 	@bash scripts/onboard.sh $(NAME)
+
+catchup: ## Resume work after a sync break: pull main, refresh deps, summarize what changed
+	@bash scripts/catchup.sh
 
 $(VENV)/bin/activate: pyproject.toml requirements-ci.txt ## Create venv if missing
 	$(PY) -m venv $(VENV)

--- a/scripts/catchup.sh
+++ b/scripts/catchup.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# catchup.sh -- "I'm back from a break. What changed? What do I need?"
+#
+# Run this before resuming work after any sync break (lunch, sleep, demo dry-run).
+# It pulls main, refreshes deps if pyproject changed, summarizes commits since
+# you last fetched, and lists your lane's open issues.
+#
+# Output is intentionally agent-friendly: paste it into Codex/Cursor and ask
+# "anything I should know before I keep coding?" -- the agent reads the
+# summary and the relevant git diffs, then warns you about contract changes,
+# new conventions, etc.
+#
+# Usage:  make catchup    OR    bash scripts/catchup.sh
+
+set -euo pipefail
+
+BOLD=$'\033[1m'; DIM=$'\033[2m'; CYAN=$'\033[36m'; GREEN=$'\033[32m'
+YELLOW=$'\033[33m'; RESET=$'\033[0m'
+title() { printf "\n${BOLD}${CYAN}== %s ==${RESET}\n" "$*"; }
+say()   { printf "%s\n" "$*"; }
+warn()  { printf "  ${YELLOW}!${RESET} %s\n" "$*"; }
+ok()    { printf "  ${GREEN}+${RESET} %s\n" "$*"; }
+
+if [[ ! -f team.yml ]]; then
+    warn "Run from repo root."; exit 1
+fi
+
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "(none)")
+title "Catchup -- branch: ${CURRENT_BRANCH}"
+
+# --- 1. Detect uncommitted changes ------------------------------------------
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    warn "You have uncommitted changes. Stash or commit before catching up:"
+    git status --short | sed 's/^/    /'
+    say ""
+    warn "Suggested:  git stash push -m \"WIP catchup $(date +%H%M)\""
+    exit 1
+fi
+
+# --- 2. Fetch latest --------------------------------------------------------
+title "Fetching origin"
+git fetch --all --prune --quiet
+ok "fetch complete"
+
+# --- 3. Show divergence -----------------------------------------------------
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    AHEAD=$(git rev-list --count "main..origin/main" 2>/dev/null || echo "?")
+    say "  main is ${AHEAD} commits ahead of your last sync"
+    say "  (you are on '${CURRENT_BRANCH}', not main -- consider rebasing if you want those commits)"
+fi
+
+# --- 4. Pull main if we're on main -----------------------------------------
+if [[ "$CURRENT_BRANCH" == "main" ]]; then
+    title "Pulling main (fast-forward only)"
+    if git merge-base --is-ancestor HEAD origin/main; then
+        git pull --ff-only --quiet
+        ok "main is up to date"
+    else
+        warn "Local main has diverged from origin/main. Resolve manually:"
+        warn "  git log --oneline --graph --decorate main origin/main"
+        exit 1
+    fi
+fi
+
+# --- 5. Summarize commits since "yesterday" or last reflog --------------
+title "Recent commits on origin/main (last 10)"
+git log origin/main --oneline --decorate -10 | sed 's/^/  /'
+
+# --- 6. Detect dependency changes ----------------------------------------
+title "Dep / config changes since your last fetch"
+CHANGED_FILES=$(git log origin/main --since="6 hours ago" --name-only --pretty=format: 2>/dev/null | sort -u | grep -v '^$' || echo "")
+
+DEP_CHANGE=0
+if echo "$CHANGED_FILES" | grep -qE '(^pyproject\.toml$|^Makefile$|^lefthook\.yml$|^\.github/)'; then
+    warn "build/CI config changed in last 6h. Refreshing deps:"
+    if [[ -d .venv ]]; then
+        .venv/bin/pip install -e ".[dev]" -q 2>&1 | tail -3 || warn "pip install failed; you may need to investigate"
+        ok ".venv refreshed"
+    else
+        warn ".venv missing -- run: make install"
+    fi
+    DEP_CHANGE=1
+fi
+
+# --- 7. Detect contract changes ----------------------------------------
+if echo "$CHANGED_FILES" | grep -qE '^docs/contracts/'; then
+    warn "CONTRACT CHANGED -- read carefully before continuing:"
+    echo "$CHANGED_FILES" | grep -E '^docs/contracts/' | sed 's/^/      /'
+    warn "If you are mid-task on something that touches a changed contract,"
+    warn "STOP and re-read the contract before more code. Tell your agent."
+fi
+
+# --- 8. Detect agent rule changes -------------------------------------
+if echo "$CHANGED_FILES" | grep -qE '^(AGENTS\.md|\.agents/)'; then
+    warn "agent rules changed -- your AI agent should re-read AGENTS.md and your lane file"
+    echo "$CHANGED_FILES" | grep -E '^(AGENTS\.md|\.agents/)' | sed 's/^/      /'
+fi
+
+# --- 9. Show your open issues ----------------------------------------
+title "Your open issues"
+if command -v gh >/dev/null && gh auth status >/dev/null 2>&1; then
+    NAME=""
+    if [[ -f .git/wayfinder-name || -f .git/tera-name ]]; then
+        NAME=$(cat .git/tera-name 2>/dev/null || cat .git/wayfinder-name 2>/dev/null)
+    fi
+    if [[ -z "$NAME" ]]; then
+        # Best-effort: derive from git config user.name -> first name lowercase
+        FN=$(git config user.name 2>/dev/null | awk '{print tolower($1)}' || echo "")
+        case "$FN" in
+            jon|satriyo|kyle|ben) NAME="$FN" ;;
+        esac
+    fi
+    LABELS=""
+    case "$NAME" in
+        jon)     LABELS="lane:agent,lane:ontology,lane:voice,lane:eval" ;;
+        satriyo) LABELS="lane:security,lane:crypto,lane:infra,lane:ci" ;;
+        kyle)    LABELS="lane:hardware,lane:deploy,lane:models,lane:mesh" ;;
+        ben)     LABELS="lane:atak,lane:routing,lane:data" ;;
+    esac
+    if [[ -n "$LABELS" ]]; then
+        gh issue list --label "$LABELS" --state open --json number,title,labels --limit 10 2>/dev/null \
+            | "${PY_CMD:-python3}" -c "
+import json, sys
+data = json.load(sys.stdin)
+for i in data:
+    labels = [l['name'] for l in i['labels']]
+    pri = next((l for l in labels if l.startswith('priority:')), 'priority:?')
+    print(f\"  #{i['number']:>2}  [{pri:<11}] {i['title']}\")
+" || warn "couldn't fetch issues"
+    else
+        warn "name not detected -- run 'echo <yourname> > .git/tera-name' to remember"
+    fi
+else
+    warn "gh not authed; skipping issue summary"
+fi
+
+# --- 10. Final note ------------------------------------------------------
+title "Done"
+say "Suggested next step (paste into Codex/Cursor):"
+say ""
+say "${DIM}\"I just ran make catchup. main moved forward. Tell me anything I should${RESET}"
+say "${DIM}know before resuming work on my current branch -- contract changes,${RESET}"
+say "${DIM}agent rule changes, or convention drift. Then suggest the next issue.\"${RESET}"
+say ""
+[[ $DEP_CHANGE -eq 1 ]] && say "(deps were refreshed -- restart any running 'make run' processes)"
+exit 0


### PR DESCRIPTION
## Summary

Smaller, focused PR replacing the closed PR #30. Adds 4 things on top of latest main (which now has Satriyo's security layer + my agent-first onboard prompts via the b4fa866 merge):

1. **`scripts/catchup.sh` + `make catchup` target** — "I'm back from a break, what changed?" tool. Pulls main, refreshes deps if `pyproject.toml` changed, flags contract changes, lists your open issues. Lets teammates self-serve syncs without spamming Signal.
2. **`AGENTS.md` §9.1 "Resuming work after a break"** — tells every AI agent to suggest `make catchup` to the human after sync breaks, and to STOP coding if a contract under `/docs/contracts/` changed mid-task.
3. **`WAYFINDER_PHASE` → `TERA_PHASE` rename** in `.agents/onboard/{jon,kyle,satriyo}.md` — completing the rename so agents tell teammates the right env-var name.

Everything else from the closed PR #30 is either already on main (Satriyo merged it via b4fa866) or has been done differently by Satriyo (his CI fixes, security deps, etc.).

## Test plan

- [x] `make ci` passes locally
- [x] `bash scripts/catchup.sh` correctly detects uncommitted changes and refuses to proceed
- [x] No conflicts with main
- [ ] CI green on this PR

## Lane(s)

- [x] agent / ontology / voice / eval / figma (P1)
- [x] (minor) infra — adds `make catchup` target

## Pre-merge checklist

- [x] `make ci` passes locally
- [x] Conventional commit message
- [x] No secrets
- [x] AGENTS.md consulted
