### PR TITLE
fix(crypto): expose signed cot contract envelope

### DIFF
--- a/crypto/ml_dsa_signer.py
+++ b/crypto/ml_dsa_signer.py
@@ -14,6 +14,7 @@ For dev/demo: keys stored in ./keys/ relative to this file.
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import os
@@ -73,6 +74,22 @@ class SignedPayload:
             "key_id": self.key_id,
             "algorithm": self.algorithm,
             "timestamp": self.timestamp,
+            "payload_hash": self.payload_hash,
+        }
+
+    def to_signature_dict(self, canonicalization: str = "payload-json-v1") -> dict:
+        """
+        Return the signature envelope shape expected by docs/contracts/cot_signed.md.
+
+        The legacy `to_dict()` method remains intentionally unchanged because
+        existing verification code consumes its internal field names.
+        """
+        return {
+            "scheme": self.algorithm,
+            "key_id": self.key_id,
+            "signed_at": self.timestamp,
+            "canonicalization": canonicalization,
+            "value_b64": base64.b64encode(bytes.fromhex(self.signature)).decode("ascii"),
             "payload_hash": self.payload_hash,
         }
 

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import base64
+
+from crypto.ml_dsa_signer import SignedPayload
+
+
+def test_signed_payload_signature_dict_matches_cot_contract() -> None:
+    signed = SignedPayload(
+        payload={"uid": "TERA-001"},
+        signature="deadbeef",
+        key_id="WF-DEV-0001",
+        algorithm="ML-DSA-65",
+        timestamp=1_779_000_000.0,
+        payload_hash="abc123",
+    )
+
+    envelope = signed.to_signature_dict(canonicalization="c14n11")
+
+    assert envelope == {
+        "scheme": "ML-DSA-65",
+        "key_id": "WF-DEV-0001",
+        "signed_at": 1_779_000_000.0,
+        "canonicalization": "c14n11",
+        "value_b64": base64.b64encode(bytes.fromhex("deadbeef")).decode("ascii"),
+        "payload_hash": "abc123",
+    }
+
+
+def test_signed_payload_legacy_dict_is_unchanged() -> None:
+    signed = SignedPayload(
+        payload={"uid": "TERA-001"},
+        signature="deadbeef",
+        key_id="WF-DEV-0001",
+        algorithm="ML-DSA-65",
+        timestamp=1_779_000_000.0,
+        payload_hash="abc123",
+    )
+
+    assert signed.to_dict() == {
+        "payload": {"uid": "TERA-001"},
+        "signature": "deadbeef",
+        "key_id": "WF-DEV-0001",
+        "algorithm": "ML-DSA-65",
+        "timestamp": 1_779_000_000.0,
+        "payload_hash": "abc123",
+    }


### PR DESCRIPTION
## Summary

Adds `SignedPayload.to_signature_dict()` so the signer can emit the signature envelope shape expected by `docs/contracts/cot_signed.md`: `scheme`, `key_id`, `signed_at`, `canonicalization`, and `value_b64`.

This keeps legacy `to_dict()` unchanged for existing verification code while giving the orchestrator/ATAK bridge a contract-shaped output without manual field renaming.

## Issue

Closes #34.

## Test plan

- [x] `python -m pytest -q -m "not slow" tests security crypto`
- [x] `python -m ruff check .`
- [x] `python -m ruff format --check .`
- [x] `python -m mypy agent routing crypto security --ignore-missing-imports --no-error-summary`
- [x] `python -m bandit -r agent routing atak voice security crypto -ll -q`
- [x] `python -m pip_audit -r requirements-ci.txt --desc --fix --dry-run`

## Lane(s)

- [x] security / crypto / infra / CI (P2)
