### PR TITLE
[codex] Add two-signature approval flow (#42)

### DIFF
--- a/agent/app.py
+++ b/agent/app.py
@@ -15,9 +15,15 @@ from typing import Any
 import structlog
 from fastapi import FastAPI, HTTPException
 
-from agent.orchestrator import PlanBlockedError
+from agent.orchestrator import PlanBlockedError, approve_plan
 from agent.orchestrator import plan as orchestrate_plan
-from agent.schemas import PlanBlocked, PlanRequest, PlanResponse
+from agent.schemas import (
+    PlanApprovalRequest,
+    PlanApprovalResponse,
+    PlanBlocked,
+    PlanRequest,
+    PlanResponse,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -63,4 +69,13 @@ async def plan_endpoint(req: PlanRequest) -> PlanResponse:
     except RuntimeError as e:
         # LLM provider failed, security module failed to import, etc.
         log.exception("plan_failed", error=str(e))
+        raise HTTPException(status_code=503, detail=str(e)) from e
+
+
+@app.post("/plan/approve", response_model=PlanApprovalResponse)
+async def plan_approve_endpoint(req: PlanApprovalRequest) -> PlanApprovalResponse:
+    try:
+        return approve_plan(req)
+    except RuntimeError as e:
+        log.exception("plan_approval_failed", error=str(e))
         raise HTTPException(status_code=503, detail=str(e)) from e

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -19,7 +19,11 @@ If the signer is unavailable -> emit unsigned with warning (never fail open).
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import json
 import uuid
+from datetime import UTC, datetime
 from typing import Any
 
 import structlog
@@ -28,6 +32,9 @@ from agent.llm import LLMClient, ModeOrAuto, get_registry
 from agent.schemas import (
     Coord,
     Message,
+    OperatorSignature,
+    PlanApprovalRequest,
+    PlanApprovalResponse,
     PlanRequest,
     PlanResponse,
     Signature,
@@ -37,6 +44,24 @@ from agent.tools import find_pois, route
 from ontology import build_system_prompt, load_route_query_schema
 
 log = structlog.get_logger(__name__)
+
+
+def _canonical_json(obj: dict[str, Any]) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _timestamp_to_iso(value: Any) -> str:
+    if isinstance(value, int | float):
+        return datetime.fromtimestamp(float(value), UTC).isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def _hex_to_b64(value: str) -> str:
+    return base64.b64encode(bytes.fromhex(value)).decode("ascii")
 
 
 # ---------------------------------------------------------------------------
@@ -224,8 +249,8 @@ def _sign_response(
         return Signature(
             scheme="ML-DSA-65",  # Satriyo's signer uses ML-DSA-65 (Dilithium3)
             key_id=signed["key_id"],
-            value_b64=signed["signature"],
-            signed_at=signed["timestamp"],
+            value_b64=_hex_to_b64(signed["signature"]),
+            signed_at=_timestamp_to_iso(signed["timestamp"]),
         )
     except (ImportError, RuntimeError) as e:
         log.warning("signer_unavailable", error=str(e))
@@ -302,7 +327,7 @@ async def plan(req: PlanRequest, mode: ModeOrAuto = "auto") -> PlanResponse:
         source=req.source,
         structured_query=structured_query,
     )
-    if not pipeline_result["passed"]:
+    if not _pipeline_passed(pipeline_result):
         logger.warning(
             "pipeline_blocked",
             blocked_at=pipeline_result["blocked_at"],
@@ -351,34 +376,101 @@ async def _run_security_pipeline(
     source: str,
     structured_query: dict[str, Any],
 ) -> dict[str, Any]:
-    """Thin wrapper around security.pipeline.run_pipeline.
+    """Thin wrapper around security.plan_guard.guard_plan_request.
 
-    Late import so an import error in the security lane doesn't crash the
-    whole agent at startup -- we degrade to a clear 503 instead.
+    Late import so an import error in the security lane doesn't crash the whole
+    agent at startup. Stage-1 /plan routes are provisional by design; operator
+    approval only happens through /plan/approve.
     """
     try:
-        from security.pipeline import run_pipeline
+        from security.plan_guard import guard_plan_request
     except ImportError as e:
         log.error("security_pipeline_import_failed", error=str(e))
         raise RuntimeError(
-            "security.pipeline import failed -- agent cannot serve requests safely"
+            "security.plan_guard import failed -- agent cannot serve requests safely"
         ) from e
 
-    result = await run_pipeline(
+    result = await guard_plan_request(
         raw_text=raw_text,
         source=source,
         source_type="operator-intent",
         structured_query=structured_query,
-        agent="RoutingAgent",
-        operation="GenerateRoute",
-        context={
-            # operator_approved + policy_valid: stub-true for MVP. In real deploy
-            # operator_approved is set by an out-of-band approval workflow, and
-            # policy_valid comes from an explicit policy lookup. See:
-            #   https://github.com/jdev-02/tera/issues -- "operator-approval flow"
-            "operator_approved": True,
-            "policy_valid": True,
-            "signature_valid": False,  # we sign AFTER the pipeline runs
-        },
+        target_agent="RoutingAgent",
+        operation="ComputeRoute",
+        operator_approved=False,
+        signature_valid=False,
     )
     return result.to_dict()
+
+
+def _pipeline_passed(result: dict[str, Any]) -> bool:
+    if "passed" in result:
+        return bool(result["passed"])
+    if "pipeline_passed" in result:
+        return bool(result["pipeline_passed"])
+    return bool(result.get("allowed", False))
+
+
+def _route_hash(route: dict[str, Any], waypoints: list[Waypoint]) -> str:
+    canonical = _canonical_json(
+        {
+            "route": route,
+            "waypoints": [w.model_dump(exclude_none=True) for w in waypoints],
+        }
+    )
+    return _sha256_hex(canonical)
+
+
+def _sign_operator_commit(
+    *,
+    route_id: str,
+    route_hash: str,
+    device_signature: Signature,
+    operator_key_id: str,
+    approved_by: str | None,
+) -> OperatorSignature:
+    """Create the operator's stage-3 approval signature.
+
+    Fails closed: if the signer cannot load, the route is not operator-committed.
+    """
+    try:
+        from crypto.ml_dsa_signer import create_signer
+    except ImportError as e:
+        raise RuntimeError("operator signer import failed") from e
+
+    payload = {
+        "route_id": route_id,
+        "approves_route_hash": route_hash,
+        "device_signature": device_signature.model_dump(),
+        "approved_by": approved_by,
+    }
+    signed = create_signer(operator_key_id).sign(payload)
+    envelope = signed.to_signature_dict(canonicalization="route-approval-json-v1")
+    canonical_payload_str = _canonical_json(payload).decode("utf-8")
+    return OperatorSignature(
+        scheme=str(envelope["scheme"]),
+        key_id=str(envelope["key_id"]),
+        value_b64=str(envelope["value_b64"]),
+        signed_at=_timestamp_to_iso(envelope["signed_at"]),
+        approves_route_hash=route_hash,
+        payload_hash=str(envelope["payload_hash"]),
+        payload_json=canonical_payload_str,
+    )
+
+
+def approve_plan(req: PlanApprovalRequest) -> PlanApprovalResponse:
+    """Commit a provisional device-signed route after operator review."""
+    route_hash = _route_hash(req.route, req.waypoints)
+    operator_signature = _sign_operator_commit(
+        route_id=req.route_id,
+        route_hash=route_hash,
+        device_signature=req.device_signature,
+        operator_key_id=req.operator_key_id,
+        approved_by=req.approved_by,
+    )
+    return PlanApprovalResponse(
+        route_id=req.route_id,
+        route_hash=route_hash,
+        device_signature=req.device_signature,
+        operator_signature=operator_signature,
+    )

--- a/agent/schemas.py
+++ b/agent/schemas.py
@@ -80,6 +80,21 @@ class Signature(BaseModel):
     signed_at: str
 
 
+class OperatorSignature(BaseModel):
+    """Operator commit signature for ADR-003 two-signature approval."""
+
+    scheme: str
+    key_id: str
+    value_b64: str
+    signed_at: str
+    approves_route_hash: str
+    payload_hash: str
+    # Canonical approval payload JSON (sort_keys, no spaces).
+    # Required for self-contained verification in atak/bridge.py - same
+    # pattern as <payload_json> in CoT XML (cot_signer.py).
+    payload_json: str
+
+
 class PlanResponse(BaseModel):
     """Returned from POST /plan. The route + rationale + trust + signature."""
 
@@ -99,3 +114,24 @@ class PlanBlocked(BaseModel):
     blocked_at: str
     reason: str
     stages: list[dict[str, Any]]
+
+
+class PlanApprovalRequest(BaseModel):
+    """Stage-3 operator approval request from ADR-003."""
+
+    route_id: str = Field(..., min_length=1)
+    route: dict[str, Any]
+    waypoints: list[Waypoint] = Field(default_factory=list)
+    device_signature: Signature
+    operator_key_id: str = Field(default="operator-demo-001", min_length=3)
+    approved_by: str | None = None
+
+
+class PlanApprovalResponse(BaseModel):
+    """Returned from POST /plan/approve when the operator commits a route."""
+
+    route_id: str
+    approval_state: Literal["operator_committed"] = "operator_committed"
+    route_hash: str
+    device_signature: Signature
+    operator_signature: OperatorSignature

--- a/crypto/cot_signer.py
+++ b/crypto/cot_signer.py
@@ -22,6 +22,7 @@ P4 integration: from crypto.cot_signer import sign_cot, verify_cot, CotRoute
 
 from __future__ import annotations
 
+import base64
 import json
 import math
 import os
@@ -318,6 +319,194 @@ def verify_cot(cot_xml: str, trust_list: dict[str, bytes] | None = None) -> Veri
             key_id="",
             algorithm="",
             reason=f"CoT signature parse error: {e}",
+        )
+
+
+# -------------------------------------------------------------------------------
+# Two-signature approval wrapper verification (ADR-003)
+# -------------------------------------------------------------------------------
+
+
+def verify_approval_wrapper(
+    wrapper: dict,
+    trust_list: dict[str, bytes] | None = None,
+) -> VerificationResult:
+    """
+    Verifies the two-signature approval wrapper returned by POST /plan/approve.
+
+    Steps:
+      1. Both device_signature and operator_signature must be present.
+      2. operator_signature.approves_route_hash must equal wrapper.route_hash.
+      3. operator key_id must be in trust_list (if provided).
+      4. payload_json must hash to payload_hash and match the wrapper fields.
+      5. Operator signature must verify over canonical payload_json bytes.
+
+    The device signature is NOT re-verified here — it was verified at /plan
+    time and is bound into the operator's signed payload (so tampering it
+    invalidates the operator signature automatically).
+
+    P4 calls this in atak/bridge.py before forwarding a committed route.
+    """
+    try:
+        op_sig = wrapper.get("operator_signature") or {}
+        dev_sig = wrapper.get("device_signature") or {}
+        route_hash = wrapper.get("route_hash", "")
+
+        if not op_sig or not dev_sig:
+            return VerificationResult(
+                valid=False,
+                key_id="",
+                algorithm="",
+                reason="Missing device_signature or operator_signature — wrapper REJECTED",
+            )
+
+        key_id = op_sig.get("key_id", "")
+        algorithm = op_sig.get("scheme", "")
+        sig_b64 = op_sig.get("value_b64", "")
+        payload_hash = op_sig.get("payload_hash", "")
+        payload_json_str = op_sig.get("payload_json", "")
+
+        if not all([key_id, algorithm, sig_b64, payload_hash, payload_json_str]):
+            return VerificationResult(
+                valid=False,
+                key_id=key_id,
+                algorithm=algorithm,
+                reason="Incomplete operator_signature fields — wrapper REJECTED",
+            )
+
+        # Step 2: route_hash binding
+        approves = op_sig.get("approves_route_hash", "")
+        if approves != route_hash:
+            return VerificationResult(
+                valid=False,
+                key_id=key_id,
+                algorithm=algorithm,
+                reason=(
+                    f"operator_signature.approves_route_hash {approves!r} does not "
+                    f"match wrapper.route_hash {route_hash!r} — replay or tamper REJECTED"
+                ),
+            )
+
+        # Step 3: trust list
+        pub_key: bytes | None = None
+        if trust_list is not None:
+            pub_key = trust_list.get(key_id)
+            if pub_key is None:
+                return VerificationResult(
+                    valid=False,
+                    key_id=key_id,
+                    algorithm=algorithm,
+                    reason=f"operator key_id '{key_id}' not in trust list — wrapper REJECTED",
+                )
+
+        # Step 4: payload integrity and wrapper binding (fast, no crypto)
+        payload = json.loads(payload_json_str)
+        canonical_bytes = _canonical_json(payload)
+        if canonical_bytes != payload_json_str.encode("utf-8"):
+            return VerificationResult(
+                valid=False,
+                key_id=key_id,
+                algorithm=algorithm,
+                reason="Operator payload_json is not canonical JSON — wrapper REJECTED",
+            )
+
+        computed = _sha256(canonical_bytes)
+        if computed != payload_hash:
+            return VerificationResult(
+                valid=False,
+                key_id=key_id,
+                algorithm=algorithm,
+                reason="Operator payload_hash mismatch — payload tampered — wrapper REJECTED",
+            )
+
+        if payload.get("route_id") != wrapper.get("route_id"):
+            return VerificationResult(
+                valid=False,
+                key_id=key_id,
+                algorithm=algorithm,
+                reason="Operator payload route_id does not match wrapper — wrapper REJECTED",
+            )
+
+        if payload.get("approves_route_hash") != route_hash:
+            return VerificationResult(
+                valid=False,
+                key_id=key_id,
+                algorithm=algorithm,
+                reason="Operator payload route_hash does not match wrapper — wrapper REJECTED",
+            )
+
+        if payload.get("device_signature") != dev_sig:
+            return VerificationResult(
+                valid=False,
+                key_id=key_id,
+                algorithm=algorithm,
+                reason=(
+                    "Operator payload device_signature does not match wrapper — wrapper REJECTED"
+                ),
+            )
+
+        # Step 5: signature verification
+        try:
+            sig_bytes = base64.b64decode(sig_b64)
+        except Exception:
+            return VerificationResult(
+                valid=False,
+                key_id=key_id,
+                algorithm=algorithm,
+                reason="Operator signature value_b64 is not valid base64 — wrapper REJECTED",
+            )
+
+        signer = _get_signer()
+
+        if algorithm == "Ed25519-fallback":
+            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+            from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
+            pk = (
+                cast(Ed25519PublicKey, load_pem_public_key(pub_key))
+                if pub_key
+                else cast(Ed25519PublicKey, signer._pk)
+            )
+            try:
+                pk.verify(sig_bytes, canonical_bytes)
+                ok = True
+            except Exception:
+                ok = False
+        else:
+            try:
+                import oqs
+
+                pk_bytes = pub_key if pub_key else signer.public_key_bytes
+                with oqs.Signature("Dilithium3") as s:
+                    ok = s.verify(canonical_bytes, sig_bytes, pk_bytes)
+            except Exception as e:
+                return VerificationResult(
+                    valid=False,
+                    key_id=key_id,
+                    algorithm=algorithm,
+                    reason=f"ML-DSA operator verification error: {e}",
+                )
+
+        if ok:
+            return VerificationResult(
+                valid=True,
+                key_id=key_id,
+                algorithm=algorithm,
+                reason="Both signatures valid — route is operator-committed",
+            )
+        return VerificationResult(
+            valid=False,
+            key_id=key_id,
+            algorithm=algorithm,
+            reason="Operator signature invalid — wrapper REJECTED",
+        )
+
+    except (KeyError, TypeError, ValueError) as e:
+        return VerificationResult(
+            valid=False,
+            key_id="",
+            algorithm="",
+            reason=f"Approval wrapper parse error: {e}",
         )
 
 

--- a/docs/contracts/agent_routing.schema.json
+++ b/docs/contracts/agent_routing.schema.json
@@ -25,13 +25,44 @@
       },
       "additionalProperties": false
     },
+    "OperatorSignature": {
+      "type": "object",
+      "required": [
+        "scheme",
+        "key_id",
+        "value_b64",
+        "signed_at",
+        "approves_route_hash",
+        "payload_hash",
+        "payload_json"
+      ],
+      "properties": {
+        "scheme": { "type": "string" },
+        "key_id": { "type": "string", "minLength": 3 },
+        "value_b64": { "type": "string", "minLength": 1 },
+        "signed_at": { "type": "string", "format": "date-time" },
+        "approves_route_hash": { "type": "string", "minLength": 64, "maxLength": 64 },
+        "payload_hash": { "type": "string", "minLength": 64, "maxLength": 64 },
+        "payload_json": {
+          "type": "string",
+          "minLength": 2,
+          "description": "Canonical route-approval JSON signed by the operator key."
+        }
+      },
+      "additionalProperties": false
+    },
     "PlanRequest": {
       "type": "object",
       "required": ["prompt", "current"],
       "properties": {
         "prompt": { "type": "string", "minLength": 1, "maxLength": 2000 },
         "current": { "$ref": "#/definitions/Coord" },
-        "request_id": { "type": "string" }
+        "request_id": { "type": "string" },
+        "source": {
+          "type": "string",
+          "enum": ["operator_voice", "operator_text", "test"],
+          "default": "operator_text"
+        }
       },
       "additionalProperties": false
     },
@@ -88,12 +119,54 @@
             "elevation_gain_m": { "type": "number" }
           }
         },
+        "trust": { "type": "object" },
         "signature": {
           "oneOf": [
             { "type": "null" },
             { "$ref": "#/definitions/Signature" }
           ]
         }
+      },
+      "additionalProperties": false
+    },
+    "PlanApprovalRequest": {
+      "type": "object",
+      "required": ["route_id", "route", "device_signature"],
+      "properties": {
+        "route_id": { "type": "string", "minLength": 1 },
+        "route": { "type": "object" },
+        "waypoints": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Waypoint" },
+          "default": []
+        },
+        "device_signature": { "$ref": "#/definitions/Signature" },
+        "operator_key_id": {
+          "type": "string",
+          "minLength": 3,
+          "default": "operator-demo-001"
+        },
+        "approved_by": {
+          "oneOf": [{ "type": "null" }, { "type": "string" }]
+        }
+      },
+      "additionalProperties": false
+    },
+    "PlanApprovalResponse": {
+      "type": "object",
+      "required": [
+        "route_id",
+        "approval_state",
+        "route_hash",
+        "device_signature",
+        "operator_signature"
+      ],
+      "properties": {
+        "route_id": { "type": "string", "minLength": 1 },
+        "approval_state": { "type": "string", "const": "operator_committed" },
+        "route_hash": { "type": "string", "minLength": 64, "maxLength": 64 },
+        "device_signature": { "$ref": "#/definitions/Signature" },
+        "operator_signature": { "$ref": "#/definitions/OperatorSignature" }
       },
       "additionalProperties": false
     },

--- a/docs/contracts/cot_signed.md
+++ b/docs/contracts/cot_signed.md
@@ -105,6 +105,35 @@ forward_to_atak(event_xml)
 }
 ```
 
+## Operator approval wrapper (`POST /plan/approve`)
+
+Stage-1 `/plan` responses are device-signed and provisional. After the operator reviews a route, the UI calls `/plan/approve` and receives a stage-3 commit wrapper:
+
+```json
+{
+  "route_id": "TERA-2026-05-02-0001",
+  "approval_state": "operator_committed",
+  "route_hash": "<sha256 of canonical route geometry + waypoints>",
+  "device_signature": {
+    "scheme": "ML-DSA-65",
+    "key_id": "WF-DEV-0001",
+    "value_b64": "...",
+    "signed_at": "2026-05-02T22:30:00Z"
+  },
+  "operator_signature": {
+    "scheme": "ML-DSA-65",
+    "key_id": "OPERATOR-VEGA-001",
+    "value_b64": "...",
+    "signed_at": "2026-05-02T22:31:00Z",
+    "approves_route_hash": "<same route_hash>",
+    "payload_hash": "<sha256 of canonical approval payload>",
+    "payload_json": "{\"approved_by\":\"Sgt. Vega\",\"approves_route_hash\":\"<same route_hash>\",\"device_signature\":{...},\"route_id\":\"TERA-2026-05-02-0001\"}"
+  }
+}
+```
+
+Downstream components must treat device-signed-only routes as suggested/provisional. Only wrappers with a valid device signature and a valid operator signature over the same canonical `payload_json` and `route_hash` may be forwarded as committed routes.
+
 ## Performance budget
 
 - Sign: < 5 ms per CoT message on Jetson Orin Nano.

--- a/docs/cyber_mitigation_contribution.md
+++ b/docs/cyber_mitigation_contribution.md
@@ -1,0 +1,157 @@
+# Novel Cyber-Mitigation Contribution
+
+## Thesis
+
+TERA is not novel because it computes an offline route. Offline routing, local
+geospatial search, and tactical map rendering already exist.
+
+The novel contribution is a cyber-secure cognitive control architecture for a
+natural-language tactical route agent: spoken or typed intent may guide route
+optimization, but natural language, map data, cached context, and adversarial
+annotations cannot become unauthorized executable instruction.
+
+In short:
+
+```text
+Intent != Authority
+Data != Instruction
+```
+
+## Product-Specific Risk
+
+TERA places a language model between an operator and mission-critical
+geospatial functions. That creates a new cyber risk surface: the model must
+interpret ambiguous human intent, but it must not become an uncontrolled command
+interpreter.
+
+Untrusted instructions may arrive through:
+
+- spoken or typed prompts
+- copied mission notes
+- hostile map labels
+- manipulated route metadata
+- corrupted geospatial overlays
+- adversarial text embedded in local files
+- compromised prior session context
+- malformed route requests
+- spoofed agent outputs
+
+The central failure mode is prompt injection crossing a mission boundary. A
+successful attack could cause the system to ignore constraints, alter route
+objectives, prefer unsafe terrain, fabricate confidence, bypass authorization,
+sign an untrusted route, or render a route as trusted when it is not.
+
+## Secure Route-Control Pipeline
+
+TERA's route flow is:
+
+```text
+U -> L -> Q -> G -> R -> S -> M
+```
+
+Where:
+
+- `U` is the operator utterance or typed request
+- `L` is local language interpretation
+- `Q` is the structured geospatial query
+- `G` is the security gate: prompt guard, provenance, schema, policy, trust
+- `R` is the local route engine
+- `S` is the signing and approval layer
+- `M` is the tactical map rendering layer
+
+The important property is that the natural-language input is never direct:
+
+```text
+U !-> R
+U !-> S
+U !-> M
+```
+
+Natural language can only influence routing after it becomes a schema-valid,
+policy-authorized, provenance-tagged query.
+
+## Architecture Mapping
+
+| Concept | Product implementation | Repo artifact |
+|---|---|---|
+| Perceptual input is not command authority | Raw prompts are guarded, redacted, tagged, and converted into structured query objects before routing | `security/plan_guard.py`, `security/superagent_integration.py` |
+| Data is not instruction | Map labels, cached overlays, field reports, routing results, and signed routes retain source type and authority level | `security/data_provenance.py` |
+| Structured query is the security boundary | LLM output must satisfy closed enums, bounded distances, allowed layers, and authority context | `docs/route_query.schema.json`, `security/structured_query_validator.py` |
+| Zero-trust agent orchestration | Intent, policy, geospatial query, routing, signing, and rendering have separate permissions | `security/policy_gate.py` |
+| Route trust is explicit | A route is `trusted`, `needs_review`, or `untrusted` based on schema, policy, approval, signature, and input provenance | `security/route_trust_score.py` |
+| Device origin is cryptographic | Device-signed route artifacts prove known-device origin | `crypto/ml_dsa_signer.py`, `crypto/cot_signer.py` |
+| Operator approval is separate authority | `/plan` creates a provisional route; `/plan/approve` commits it with an operator signature over the route hash | `agent/app.py`, `agent/orchestrator.py`, `docs/adrs/2026-05-02-003-two-signature-approval.md` |
+| Offline resilience | Guard fallback, local routing, local signing, and no-outbound proof run without cloud dependency | `security/demo_proofs.md`, `infra/tcpdump_demo.sh` |
+
+## Security Invariants
+
+TERA preserves these invariants:
+
+1. The LLM cannot directly call the routing engine.
+2. The LLM cannot sign a route.
+3. The routing engine cannot approve its own output.
+4. The rendering layer cannot upgrade an untrusted route to trusted.
+5. A map label is always data, even if it contains imperative text.
+6. Device signature proves origin, not operator commitment.
+7. Operator approval signs the route hash, preventing signature reuse on a
+   different route.
+8. Unsigned, unapproved, or low-provenance routes are downgraded or rejected.
+
+## Route Artifact Model
+
+A route is not just geometry:
+
+```text
+A_p = (p, Q, D, Pi, ID_u, ID_a, tau)
+```
+
+Where:
+
+- `p` is route geometry
+- `Q` is the structured query
+- `D` is the local data used
+- `Pi` is the policy set applied
+- `ID_u` is the operator or device-local authority
+- `ID_a` is the agent identity chain
+- `tau` is the timestamp or local event marker
+
+The signed route is:
+
+```text
+sigma = Sign_sk(H(A_p))
+```
+
+The map should render a route as trusted only when verification and approval
+match the route artifact being displayed.
+
+## Demo Proofs
+
+| Proof | What the judge sees | Security claim |
+|---|---|---|
+| Prompt injection block | A hostile prompt or map label is blocked before routing | Data is not instruction |
+| Schema boundary | Invalid fields such as `transmit_data` or invalid route enums are rejected | LLM output is not arbitrary command execution |
+| Policy gate | `IntentAgent` cannot perform `SignApprovedRoute` | Intent is not authority |
+| Trust downgrade | Unsigned or unapproved route returns `needs_review` | Device output is not operator commitment |
+| Two-signature commit | `/plan/approve` signs the route hash with an operator key | Commitment is explicit and replay-resistant |
+| CoT verification | Unsigned or tampered CoT fails verification | Tactical rendering is provenance-bound |
+| No outbound traffic | `tcpdump` shows no egress during local route generation | Security controls work offline |
+
+## Paper-Ready Contribution Statement
+
+This work contributes a defense-in-depth cyber mitigation architecture for
+offline natural-language tactical route agents. The system separates user
+intent from execution authority by transforming spoken or typed requests into
+schema-bound, provenance-tagged, policy-validated geospatial queries before any
+route computation occurs. It applies control gating, context-aware provenance,
+zero-trust agent orchestration, persona-bound identity, ephemeral route-session
+isolation, and cryptographic route signing to a mission-critical routing
+workflow. As a result, prompt injection, corrupted geospatial annotations,
+compromised local context, or unauthorized agent behavior cannot directly alter
+route computation, signing, or trusted map rendering.
+
+## One-Sentence Claim
+
+TERA contributes a cyber-secure cognitive control architecture for offline
+natural-language tactical route agents, ensuring that operator intent can guide
+route optimization without allowing natural language, map data, or adversarial
+context to become unauthorized executable instruction.

--- a/docs/cyber_trust_boundary.md
+++ b/docs/cyber_trust_boundary.md
@@ -1,5 +1,8 @@
 # Cyber Trust Boundary
 
+For the paper and pitch framing of this contribution, see
+`docs/cyber_mitigation_contribution.md`.
+
 ## Core Principles
 
 1. Intent is not authority.

--- a/security/demo_proofs.md
+++ b/security/demo_proofs.md
@@ -7,6 +7,7 @@ the TERA hackathon demo.
 
 P2 owns the security claim that natural language, map text, compromised local
 context, and unsigned CoT messages cannot become trusted route authority.
+The paper/pitch framing lives in `docs/cyber_mitigation_contribution.md`.
 
 The demo should prove four things:
 
@@ -14,6 +15,8 @@ The demo should prove four things:
 2. Structured route queries are schema-validated before execution.
 3. Unsigned or tampered CoT envelopes are rejected.
 4. Offline mode produces no outbound network traffic.
+5. Device-signed routes remain provisional until `/plan/approve` returns an
+   operator signature over the same route hash.
 
 ## Preflight
 
@@ -156,6 +159,15 @@ One-sentence claim:
 ```text
 TERA does not merely compute a route; it proves whether the route is authorized,
 provenance-bound, and safe to render as trusted.
+```
+
+Paper-ready claim:
+
+```text
+TERA contributes a cyber-secure cognitive control architecture for offline
+natural-language tactical route agents: intent can guide route optimization,
+but natural language, map data, and adversarial context cannot become
+unauthorized executable instruction.
 ```
 
 ## PR Checklist

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -15,10 +15,21 @@ from agent import llm
 from agent.orchestrator import (
     PlanBlockedError,
     _avoid_for,
+    _pipeline_passed,
     _profile_for,
+    _route_hash,
+    _run_security_pipeline,
+    approve_plan,
     plan,
 )
-from agent.schemas import Coord, PlanRequest
+from agent.schemas import (
+    Coord,
+    OperatorSignature,
+    PlanApprovalRequest,
+    PlanRequest,
+    Signature,
+    Waypoint,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -86,6 +97,44 @@ def _blocked_pipeline_result(blocked_at: str) -> dict[str, Any]:
     }
 
 
+def test_pipeline_passed_accepts_plan_guard_key() -> None:
+    assert _pipeline_passed({"allowed": True}) is True
+    assert _pipeline_passed({"allowed": False}) is False
+
+
+@pytest.mark.asyncio
+async def test_run_security_pipeline_uses_plan_guard() -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_guard(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        result = MagicMock()
+        result.to_dict.return_value = {
+            "allowed": True,
+            "blocked_at": None,
+            "stages": [],
+            "atak_display": "Suggested Route - Needs Review",
+            "trust_result": {"trust_status": "needs_review"},
+        }
+        return result
+
+    with patch.dict(
+        "sys.modules",
+        {"security.plan_guard": MagicMock(guard_plan_request=fake_guard)},
+    ):
+        result = await _run_security_pipeline(
+            raw_text="Route me to freshwater.",
+            source="operator_text",
+            structured_query=VALID_FRESHWATER_QUERY,
+        )
+
+    assert result["allowed"] is True
+    assert captured["target_agent"] == "RoutingAgent"
+    assert captured["operation"] == "ComputeRoute"
+    assert captured["operator_approved"] is False
+    assert captured["signature_valid"] is False
+
+
 # ---------------------------------------------------------------------------
 # Canonical RouteQuery JSONs anchored to PRD §6 scenarios. These MIRROR the
 # examples in ontology/route_ontology.yml. If you change them here, change
@@ -145,7 +194,7 @@ async def test_plan_happy_path_returns_route(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setenv("TERA_DEVICE_PROFILE", "austere")
     mock_client = _make_mock_llm(VALID_FRESHWATER_QUERY)
 
-    async def fake_pipeline(**kwargs: Any) -> Any:
+    async def fake_guard(**kwargs: Any) -> Any:
         result = MagicMock()
         result.to_dict.return_value = _passing_pipeline_result(VALID_FRESHWATER_QUERY)
         return result
@@ -156,7 +205,7 @@ async def test_plan_happy_path_returns_route(monkeypatch: pytest.MonkeyPatch) ->
         # Patch the import inside _run_security_pipeline.
         patch.dict(
             "sys.modules",
-            {"security.pipeline": MagicMock(run_pipeline=fake_pipeline)},
+            {"security.plan_guard": MagicMock(guard_plan_request=fake_guard)},
         ),
     ):
         mock_reg.return_value.get.return_value = mock_client
@@ -177,11 +226,35 @@ async def test_plan_happy_path_returns_route(monkeypatch: pytest.MonkeyPatch) ->
 
 
 @pytest.mark.asyncio
+async def test_plan_runs_real_plan_guard_without_operator_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TERA_DEVICE_PROFILE", "austere")
+    monkeypatch.delenv("SUPERAGENT_API_KEY", raising=False)
+    mock_client = _make_mock_llm(VALID_FRESHWATER_QUERY)
+
+    with (
+        patch("agent.orchestrator.get_registry") as mock_reg,
+        patch("agent.orchestrator._sign_response", return_value=None),
+    ):
+        mock_reg.return_value.get.return_value = mock_client
+        req = PlanRequest(
+            prompt="Route me to nearest freshwater within 5km on foot, covered terrain.",
+            current=Coord(lat=37.7955, lon=-122.3937),
+        )
+        resp = await plan(req)
+
+    assert resp.route["type"] == "Feature"
+    assert resp.trust["trust_status"] == "needs_review"
+    assert "Operator approval missing" in resp.trust["reasons"]
+
+
+@pytest.mark.asyncio
 async def test_plan_pipeline_blocked_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TERA_DEVICE_PROFILE", "austere")
     mock_client = _make_mock_llm(VALID_FRESHWATER_QUERY)
 
-    async def fake_pipeline(**kwargs: Any) -> Any:
+    async def fake_guard(**kwargs: Any) -> Any:
         result = MagicMock()
         result.to_dict.return_value = _blocked_pipeline_result("superagent_guard")
         return result
@@ -190,7 +263,7 @@ async def test_plan_pipeline_blocked_raises(monkeypatch: pytest.MonkeyPatch) -> 
         patch("agent.orchestrator.get_registry") as mock_reg,
         patch.dict(
             "sys.modules",
-            {"security.pipeline": MagicMock(run_pipeline=fake_pipeline)},
+            {"security.plan_guard": MagicMock(guard_plan_request=fake_guard)},
         ),
     ):
         mock_reg.return_value.get.return_value = mock_client
@@ -317,7 +390,7 @@ async def test_prd_scenario_end_to_end_with_mock_llm(
     monkeypatch.setenv("TERA_DEVICE_PROFILE", "austere")
     mock_client = _make_mock_llm(query)
 
-    async def fake_pipeline(**kwargs: Any) -> Any:
+    async def fake_guard(**kwargs: Any) -> Any:
         result = MagicMock()
         result.to_dict.return_value = _passing_pipeline_result(query)
         return result
@@ -327,7 +400,7 @@ async def test_prd_scenario_end_to_end_with_mock_llm(
         patch("agent.orchestrator._sign_response", return_value=None),
         patch.dict(
             "sys.modules",
-            {"security.pipeline": MagicMock(run_pipeline=fake_pipeline)},
+            {"security.plan_guard": MagicMock(guard_plan_request=fake_guard)},
         ),
     ):
         mock_reg.return_value.get.return_value = mock_client
@@ -363,7 +436,7 @@ async def test_plan_no_pois_returns_empty_with_rationale(
 
     mock_client = _make_mock_llm(too_small_query)
 
-    async def fake_pipeline(**kwargs: Any) -> Any:
+    async def fake_guard(**kwargs: Any) -> Any:
         result = MagicMock()
         result.to_dict.return_value = _passing_pipeline_result(too_small_query)
         return result
@@ -373,7 +446,7 @@ async def test_plan_no_pois_returns_empty_with_rationale(
         patch("agent.orchestrator._sign_response", return_value=None),
         patch.dict(
             "sys.modules",
-            {"security.pipeline": MagicMock(run_pipeline=fake_pipeline)},
+            {"security.plan_guard": MagicMock(guard_plan_request=fake_guard)},
         ),
     ):
         mock_reg.return_value.get.return_value = mock_client
@@ -383,3 +456,54 @@ async def test_plan_no_pois_returns_empty_with_rationale(
         )
         resp = await plan(req)
     assert "No freshwater found" in resp.rationale or "expanding radius" in resp.rationale
+
+
+def test_approve_plan_returns_operator_commit(monkeypatch: pytest.MonkeyPatch) -> None:
+    route = {
+        "type": "Feature",
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [[-122.3937, 37.7955], [-122.415, 37.803]],
+        },
+        "properties": {},
+    }
+    waypoints = [Waypoint(lat=37.803, lon=-122.415, label="HLZ open field")]
+    device_signature = Signature(
+        scheme="ML-DSA-65",
+        key_id="wayfinder-device-001",
+        value_b64="ZGV2aWNlLXNpZw==",
+        signed_at="2026-05-02T22:30:00Z",
+    )
+    expected_hash = _route_hash(route, waypoints)
+
+    def fake_sign(**kwargs: Any) -> OperatorSignature:
+        return OperatorSignature(
+            scheme="ML-DSA-65",
+            key_id=kwargs["operator_key_id"],
+            value_b64="b3BlcmF0b3Itc2ln",
+            signed_at="2026-05-02T22:31:00Z",
+            approves_route_hash=kwargs["route_hash"],
+            payload_hash="b" * 64,
+            payload_json=(
+                '{"approved_by":"Sgt. Vega","approves_route_hash":"'
+                + kwargs["route_hash"]
+                + '","route_id":"TERA-approval-test"}'
+            ),
+        )
+
+    monkeypatch.setattr("agent.orchestrator._sign_operator_commit", fake_sign)
+    response = approve_plan(
+        PlanApprovalRequest(
+            route_id="TERA-approval-test",
+            route=route,
+            waypoints=waypoints,
+            device_signature=device_signature,
+            operator_key_id="OPERATOR-VEGA-001",
+            approved_by="Sgt. Vega",
+        )
+    )
+
+    assert response.approval_state == "operator_committed"
+    assert response.route_hash == expected_hash
+    assert response.operator_signature.approves_route_hash == expected_hash
+    assert response.operator_signature.key_id == "OPERATOR-VEGA-001"

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import base64
+import json
+import os
+
+import pytest
 
 from crypto.ml_dsa_signer import SignedPayload
 
@@ -45,3 +49,212 @@ def test_signed_payload_legacy_dict_is_unchanged() -> None:
         "timestamp": 1_779_000_000.0,
         "payload_hash": "abc123",
     }
+
+
+# ---------------------------------------------------------------------------
+# ADR-003 two-signature approval flow — integration tests (FallbackSigner)
+# These run without liboqs. If liboqs lands on CI these tests still pass
+# because FallbackSigner path is gated by _PQC_AVAILABLE.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _operator_key_dir(tmp_path, monkeypatch):
+    """Redirect key storage to a temp dir so tests don't pollute crypto/keys/."""
+    monkeypatch.setenv("WAYFINDER_KEY_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _make_approval_wrapper(
+    *,
+    route_id: str = "TERA-test-001",
+    route_hash: str,
+    device_sig_b64: str = "ZGV2aWNlLXNpZw==",
+    operator_key_id: str = "OPERATOR-VEGA-TEST",
+    approved_by: str | None = "Sgt. Vega",
+    key_dir: str,
+) -> tuple[dict, bytes]:
+    """Build a real approval wrapper. Returns (wrapper_dict, operator_public_key_bytes).
+
+    The caller passes operator_public_key_bytes in the trust_list when calling
+    verify_approval_wrapper — same as the ATAK bridge does in production.
+    """
+    os.environ["WAYFINDER_KEY_DIR"] = key_dir
+
+    # Reset the module-level singleton so it picks up the new key dir.
+    import crypto.cot_signer as _cs
+
+    _cs._signer = None
+
+    from agent.orchestrator import _sign_operator_commit
+    from agent.schemas import Signature
+    from crypto.ml_dsa_signer import FallbackSigner, create_signer
+
+    device_signature = Signature(
+        scheme="ML-DSA-65",
+        key_id="wayfinder-device-test",
+        value_b64=device_sig_b64,
+        signed_at="2026-05-02T22:30:00Z",
+    )
+    op_sig = _sign_operator_commit(
+        route_id=route_id,
+        route_hash=route_hash,
+        device_signature=device_signature,
+        operator_key_id=operator_key_id,
+        approved_by=approved_by,
+    )
+
+    # Extract the operator's public key so the caller can build a trust_list.
+    op_signer = create_signer(operator_key_id)
+    op_pub_key = (
+        op_signer.public_key_pem
+        if isinstance(op_signer, FallbackSigner)
+        else op_signer.public_key_bytes
+    )
+
+    wrapper = {
+        "route_id": route_id,
+        "approval_state": "operator_committed",
+        "route_hash": route_hash,
+        "device_signature": device_signature.model_dump(),
+        "operator_signature": op_sig.model_dump(),
+    }
+    return wrapper, op_pub_key
+
+
+def test_sign_operator_commit_real_fallback_signer(
+    _operator_key_dir, monkeypatch, tmp_path
+) -> None:
+    """_sign_operator_commit produces a valid OperatorSignature without mocking."""
+    import crypto.cot_signer as _cs
+
+    _cs._signer = None
+
+    from agent.orchestrator import _sign_operator_commit
+    from agent.schemas import Signature
+
+    device_sig = Signature(
+        scheme="ML-DSA-65",
+        key_id="wayfinder-device-001",
+        value_b64="ZGV2aWNlLXNpZw==",
+        signed_at="2026-05-02T22:30:00Z",
+    )
+    route_hash = "a" * 64  # fake sha256 hex
+
+    op_sig = _sign_operator_commit(
+        route_id="TERA-real-test",
+        route_hash=route_hash,
+        device_signature=device_sig,
+        operator_key_id="OPERATOR-VEGA-001",
+        approved_by="Sgt. Vega",
+    )
+
+    assert op_sig.key_id == "OPERATOR-VEGA-001"
+    assert op_sig.approves_route_hash == route_hash
+    assert op_sig.value_b64  # non-empty signature
+    assert op_sig.payload_json is not None
+    # payload_json must contain the approves_route_hash
+    payload = json.loads(op_sig.payload_json)
+    assert payload["approves_route_hash"] == route_hash
+    assert payload["route_id"] == "TERA-real-test"
+    assert payload["approved_by"] == "Sgt. Vega"
+    # payload_hash must match sha256 of canonical payload_json bytes
+    import hashlib
+
+    computed = hashlib.sha256(op_sig.payload_json.encode("utf-8")).hexdigest()
+    assert op_sig.payload_hash == computed
+
+
+def test_verify_approval_wrapper_valid(_operator_key_dir, monkeypatch, tmp_path) -> None:
+    """Round-trip: sign then verify the approval wrapper — should be valid."""
+    import crypto.cot_signer as _cs
+
+    _cs._signer = None
+
+    route_hash = "b" * 64
+    wrapper, op_pub_key = _make_approval_wrapper(
+        route_hash=route_hash,
+        key_dir=str(tmp_path),
+    )
+    _cs._signer = None  # force re-init with same key dir
+    trust_list = {"OPERATOR-VEGA-TEST": op_pub_key}
+
+    result = _cs.verify_approval_wrapper(wrapper, trust_list=trust_list)
+    assert result.valid, f"Expected valid but got: {result.reason}"
+    assert "operator-committed" in result.reason or "valid" in result.reason.lower()
+
+
+def test_verify_approval_wrapper_tampered_route_hash(
+    _operator_key_dir, monkeypatch, tmp_path
+) -> None:
+    """Replay attack: changing route_hash after signing must be rejected."""
+    import crypto.cot_signer as _cs
+
+    _cs._signer = None
+
+    route_hash = "c" * 64
+    wrapper, op_pub_key = _make_approval_wrapper(route_hash=route_hash, key_dir=str(tmp_path))
+
+    # Attacker swaps in a different route_hash (e.g. a different route).
+    wrapper["route_hash"] = "d" * 64
+
+    _cs._signer = None
+    trust_list = {"OPERATOR-VEGA-TEST": op_pub_key}
+    result = _cs.verify_approval_wrapper(wrapper, trust_list=trust_list)
+    assert not result.valid
+    assert (
+        "replay" in result.reason.lower()
+        or "tamper" in result.reason.lower()
+        or "REJECTED" in result.reason
+    )
+
+
+def test_verify_approval_wrapper_tampered_device_signature(
+    _operator_key_dir, monkeypatch, tmp_path
+) -> None:
+    """Changing the outer device signature after approval must be rejected."""
+    import crypto.cot_signer as _cs
+
+    _cs._signer = None
+
+    route_hash = "d" * 64
+    wrapper, op_pub_key = _make_approval_wrapper(route_hash=route_hash, key_dir=str(tmp_path))
+
+    wrapper["device_signature"]["value_b64"] = "dGFtcGVyZWQ="
+
+    _cs._signer = None
+    trust_list = {"OPERATOR-VEGA-TEST": op_pub_key}
+    result = _cs.verify_approval_wrapper(wrapper, trust_list=trust_list)
+    assert not result.valid
+    assert "device_signature" in result.reason or "REJECTED" in result.reason
+
+
+def test_verify_approval_wrapper_unknown_key(_operator_key_dir, monkeypatch, tmp_path) -> None:
+    """If the operator key_id is not in the trust list, wrapper must be rejected."""
+    import crypto.cot_signer as _cs
+
+    _cs._signer = None
+
+    route_hash = "f" * 64
+    wrapper, _ = _make_approval_wrapper(route_hash=route_hash, key_dir=str(tmp_path))
+
+    _cs._signer = None
+    # Pass a trust_list that doesn't include the operator key.
+    result = _cs.verify_approval_wrapper(wrapper, trust_list={"SOME-OTHER-KEY": b"pubkey"})
+    assert not result.valid
+    assert "trust list" in result.reason.lower() or "REJECTED" in result.reason
+
+
+def test_verify_approval_wrapper_missing_operator_sig(tmp_path) -> None:
+    """Wrapper without operator_signature must be rejected immediately."""
+    from crypto.cot_signer import verify_approval_wrapper
+
+    wrapper = {
+        "route_id": "TERA-001",
+        "route_hash": "g" * 64,
+        "device_signature": {"scheme": "ML-DSA-65", "key_id": "dev"},
+        # operator_signature intentionally absent
+    }
+    result = verify_approval_wrapper(wrapper)
+    assert not result.valid
+    assert "REJECTED" in result.reason

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -12,6 +12,12 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from agent.app import app
+from agent.schemas import (
+    OperatorSignature,
+    PlanApprovalRequest,
+    PlanApprovalResponse,
+    Signature,
+)
 
 client = TestClient(app)
 
@@ -40,3 +46,58 @@ def test_plan_validation_rejects_empty_prompt() -> None:
         json={"prompt": "", "current": {"lat": 37.7, "lon": -122.4}},
     )
     assert r.status_code == 422
+
+
+def test_plan_approve_validation_requires_device_signature() -> None:
+    r = client.post(
+        "/plan/approve",
+        json={
+            "route_id": "TERA-test",
+            "route": {"type": "Feature", "geometry": {"type": "LineString", "coordinates": []}},
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_plan_approve_endpoint_returns_commit(
+    monkeypatch,
+) -> None:
+    def fake_approve(req: PlanApprovalRequest) -> PlanApprovalResponse:
+        return PlanApprovalResponse(
+            route_id=req.route_id,
+            route_hash="a" * 64,
+            device_signature=req.device_signature,
+            operator_signature=OperatorSignature(
+                scheme="ML-DSA-65",
+                key_id=req.operator_key_id,
+                value_b64="b3BlcmF0b3I=",
+                signed_at="2026-05-02T22:31:00Z",
+                approves_route_hash="a" * 64,
+                payload_hash="b" * 64,
+                payload_json='{"approves_route_hash":"' + ("a" * 64) + '"}',
+            ),
+        )
+
+    monkeypatch.setattr("agent.app.approve_plan", fake_approve)
+    r = client.post(
+        "/plan/approve",
+        json={
+            "route_id": "TERA-test",
+            "route": {
+                "type": "Feature",
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [[-122.39, 37.79], [-122.40, 37.80]],
+                },
+            },
+            "device_signature": Signature(
+                scheme="ML-DSA-65",
+                key_id="wayfinder-device-001",
+                value_b64="ZGV2aWNl",
+                signed_at="2026-05-02T22:30:00Z",
+            ).model_dump(),
+            "operator_key_id": "OPERATOR-VEGA-001",
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["approval_state"] == "operator_committed"


### PR DESCRIPTION
## Summary
- Implements issue #42 two-signature approval flow: `/plan` remains device-signed/provisional and `/plan/approve` returns an operator-signed commit wrapper.
- Binds operator approval to canonical route hash, route id, device signature, payload hash, and canonical approval payload JSON.
- Adds downstream verifier for approval wrappers so ATAK/bridge consumers can reject missing, replayed, unknown-key, or tampered approvals.
- Updates agent-routing and CoT signing contracts plus cyber mitigation/demo proof docs.

## Security report for #42
Observed: the previous operator approval state was effectively conflated with device origin and route generation. This PR separates origin (`device_signature`) from execution commitment (`operator_signature`).

Boundary crossed: a route is no longer eligible for committed downstream handling solely because the device signed it. The operator key must sign the exact route hash and the device signature seen by the wrapper.

Validation added:
- valid approval wrapper round trip
- route hash replay/tamper rejection
- device signature tamper rejection
- unknown operator key rejection
- missing operator signature rejection
- `/plan/approve` FastAPI validation and response contract tests

## Test Plan
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m pytest -q -m "not slow" tests security crypto` (`119 passed`)
- `python -m mypy agent routing crypto security --ignore-missing-imports --no-error-summary`
- `python -m bandit -r agent routing atak voice security crypto -ll -q`
- `python -m pip_audit -r requirements-ci.txt --desc --fix --dry-run` (`No known vulnerabilities found`)

Notes: local `make ci` could not run because `make` is not installed in this Windows PowerShell session; the Makefile components were run manually. `gitleaks` is not installed locally, so CI should still run the repository gitleaks gate.

Closes #42.