### PR TITLE
[codex] Add tcpdump demo capture and audit log scroll (#15)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,6 @@ WAYFINDER_TRUSTED_KEYS=./crypto/keys/trusted.json
 # --- Logging ---
 LOG_LEVEL=INFO
 LOG_FORMAT=json
+WAYFINDER_AUDIT_LOG=logs/security_audit.jsonl
+WAYFINDER_CAPTURE_DIR=logs/security_demo
+WAYFINDER_TCPDUMP_INTERFACE=any

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help onboard catchup install install-crypto install-voice fmt lint test security ci run demo eval clean
+.PHONY: help onboard catchup install install-crypto install-voice fmt lint test security ci run tcpdump-demo audit-log demo eval clean
 .DEFAULT_GOAL := help
 
 PY := python3.11
@@ -82,6 +82,12 @@ ci: lint test security ## Full CI gate (must pass before push)
 
 run: install ## Start the agent service locally (stub)
 	$(VENV)/bin/uvicorn agent.app:app --host 0.0.0.0 --port 8000 --reload
+
+tcpdump-demo: ## Open tcpdump no-outbound monitor + audit log scroll for the security proof
+	@bash infra/security_demo_monitors.sh
+
+audit-log: ## Tail structured security audit events
+	@bash infra/audit_log_scroll.sh
 
 demo: install ## Run the hero scenario end-to-end (lands by Sun 0500)
 	@echo "make demo: not yet wired - will run hero scenario E2E by Sun 0500"

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -42,6 +42,7 @@ from agent.schemas import (
 )
 from agent.tools import find_pois, route
 from ontology import build_system_prompt, load_route_query_schema
+from security.audit_log import audit_event, prompt_digest
 
 log = structlog.get_logger(__name__)
 
@@ -294,6 +295,14 @@ async def plan(req: PlanRequest, mode: ModeOrAuto = "auto") -> PlanResponse:
         mode=mode,
         source=req.source,
     )
+    audit_event(
+        "prompt_received",
+        request_id=request_id,
+        prompt_sha256=prompt_digest(req.prompt),
+        prompt_len=len(req.prompt),
+        mode=mode,
+        source=req.source,
+    )
 
     # 1. Get the LLM client (profile + mode gated).
     client: LLMClient = get_registry().get(mode)
@@ -320,6 +329,15 @@ async def plan(req: PlanRequest, mode: ModeOrAuto = "auto") -> PlanResponse:
         objective=structured_query.get("objective"),
         destination_type=structured_query.get("destination_type"),
     )
+    audit_event(
+        "route_query_emitted",
+        request_id=request_id,
+        provider=client.name,
+        mission_type=structured_query.get("mission_type"),
+        objective=structured_query.get("objective"),
+        destination_type=structured_query.get("destination_type"),
+        max_distance_km=structured_query.get("max_distance_km"),
+    )
 
     # 3. Security pipeline (Satriyo's 6 stages).
     pipeline_result = await _run_security_pipeline(
@@ -332,14 +350,41 @@ async def plan(req: PlanRequest, mode: ModeOrAuto = "auto") -> PlanResponse:
             "pipeline_blocked",
             blocked_at=pipeline_result["blocked_at"],
         )
+        audit_event(
+            "security_pipeline_blocked",
+            request_id=request_id,
+            blocked_at=pipeline_result["blocked_at"],
+            stage_count=len(pipeline_result.get("stages", [])),
+            atak_display=pipeline_result.get("atak_display"),
+        )
         raise PlanBlockedError(
             blocked_at=pipeline_result["blocked_at"] or "unknown",
             stages=pipeline_result["stages"],
             reason=pipeline_result.get("atak_display", "blocked by security pipeline"),
         )
 
+    audit_event(
+        "security_pipeline_allowed",
+        request_id=request_id,
+        stage_count=len(pipeline_result.get("stages", [])),
+        trust_status=(pipeline_result.get("trust_result") or {}).get("trust_status"),
+    )
+
     # 4. Translate RouteQuery -> tool calls -> dispatch.
+    planned_tools = _tool_names_for_query(structured_query)
+    audit_event(
+        "tool_dispatch_started",
+        request_id=request_id,
+        tools=planned_tools,
+    )
     dispatch = _dispatch_tools(structured_query, req.current)
+    audit_event(
+        "tool_dispatch_completed",
+        request_id=request_id,
+        tools=planned_tools,
+        waypoint_count=len(dispatch["waypoints"]),
+        distance_m=dispatch["cost_breakdown"].get("distance_m"),
+    )
 
     # 5. Sign.
     signature = _sign_response(
@@ -351,6 +396,20 @@ async def plan(req: PlanRequest, mode: ModeOrAuto = "auto") -> PlanResponse:
     )
     if signature is None:
         logger.warning("plan_unsigned", note="ML-DSA signer unavailable; degraded mode")
+        audit_event(
+            "route_signing_degraded",
+            request_id=request_id,
+            signed=False,
+            reason="signer_unavailable",
+        )
+    else:
+        audit_event(
+            "route_signed",
+            request_id=request_id,
+            signed=True,
+            scheme=signature.scheme,
+            key_id=signature.key_id,
+        )
 
     # 6. Build response.
     response = PlanResponse(
@@ -367,6 +426,13 @@ async def plan(req: PlanRequest, mode: ModeOrAuto = "auto") -> PlanResponse:
         provider=client.name,
         signed=signature is not None,
         trust_status=(pipeline_result.get("trust_result") or {}).get("trust_status"),
+    )
+    audit_event(
+        "plan_response_ready",
+        request_id=request_id,
+        signed=signature is not None,
+        trust_status=(pipeline_result.get("trust_result") or {}).get("trust_status"),
+        waypoint_count=len(response.waypoints),
     )
     return response
 
@@ -409,6 +475,20 @@ def _pipeline_passed(result: dict[str, Any]) -> bool:
     if "pipeline_passed" in result:
         return bool(result["pipeline_passed"])
     return bool(result.get("allowed", False))
+
+
+def _tool_names_for_query(query: dict[str, Any]) -> list[str]:
+    dest_type = query.get("destination_type", "none")
+    objective = query.get("objective")
+    tools: list[str] = []
+    if dest_type in {"freshwater", "safe_zone", "trailhead"}:
+        tools.append("find_pois")
+    if (
+        objective in {"fastest_route", "fastest_covered_route", "nearest_water"}
+        and dest_type != "none"
+    ):
+        tools.append("route")
+    return tools
 
 
 def _route_hash(route: dict[str, Any], waypoints: list[Waypoint]) -> str:
@@ -461,12 +541,26 @@ def _sign_operator_commit(
 def approve_plan(req: PlanApprovalRequest) -> PlanApprovalResponse:
     """Commit a provisional device-signed route after operator review."""
     route_hash = _route_hash(req.route, req.waypoints)
+    audit_event(
+        "operator_approval_requested",
+        route_id=req.route_id,
+        route_hash=route_hash,
+        operator_key_id=req.operator_key_id,
+        waypoint_count=len(req.waypoints),
+    )
     operator_signature = _sign_operator_commit(
         route_id=req.route_id,
         route_hash=route_hash,
         device_signature=req.device_signature,
         operator_key_id=req.operator_key_id,
         approved_by=req.approved_by,
+    )
+    audit_event(
+        "operator_approval_committed",
+        route_id=req.route_id,
+        route_hash=route_hash,
+        operator_key_id=operator_signature.key_id,
+        scheme=operator_signature.scheme,
     )
     return PlanApprovalResponse(
         route_id=req.route_id,

--- a/infra/audit_log_scroll.sh
+++ b/infra/audit_log_scroll.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Follow the local security audit log during the demo.
+
+set -euo pipefail
+
+AUDIT_LOG="${WAYFINDER_AUDIT_LOG:-logs/security_audit.jsonl}"
+TAIL_LINES="${TAIL_LINES:-30}"
+
+mkdir -p "$(dirname "$AUDIT_LOG")"
+touch "$AUDIT_LOG"
+
+echo "======================================================"
+echo "  TERA Security Audit Log"
+echo "  File: $AUDIT_LOG"
+echo "======================================================"
+echo ""
+echo "Waiting for structured /plan and /plan/approve events..."
+echo ""
+
+if command -v jq >/dev/null 2>&1; then
+    tail -n "$TAIL_LINES" -F "$AUDIT_LOG" | jq -c .
+else
+    tail -n "$TAIL_LINES" -F "$AUDIT_LOG"
+fi

--- a/infra/security_demo_monitors.sh
+++ b/infra/security_demo_monitors.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Open the two security proof monitors required by issue #15.
+
+set -euo pipefail
+
+INTERFACE="${1:-${WAYFINDER_TCPDUMP_INTERFACE:-any}}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TCPDUMP_CMD="cd '$ROOT_DIR' && sudo bash infra/tcpdump_demo.sh '$INTERFACE'"
+AUDIT_CMD="cd '$ROOT_DIR' && bash infra/audit_log_scroll.sh"
+SESSION_NAME="${WAYFINDER_DEMO_SESSION:-tera-security-demo}"
+
+if command -v tmux >/dev/null 2>&1; then
+    if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+        tmux kill-session -t "$SESSION_NAME"
+    fi
+    tmux new-session -d -s "$SESSION_NAME" "$TCPDUMP_CMD"
+    tmux split-window -v -t "$SESSION_NAME" "$AUDIT_CMD"
+    tmux select-layout -t "$SESSION_NAME" even-vertical >/dev/null
+    tmux attach-session -t "$SESSION_NAME"
+    exit 0
+fi
+
+if command -v gnome-terminal >/dev/null 2>&1; then
+    gnome-terminal -- bash -lc "$TCPDUMP_CMD; exec bash"
+    gnome-terminal -- bash -lc "$AUDIT_CMD; exec bash"
+    exit 0
+fi
+
+if command -v x-terminal-emulator >/dev/null 2>&1; then
+    x-terminal-emulator -e bash -lc "$TCPDUMP_CMD; exec bash" &
+    x-terminal-emulator -e bash -lc "$AUDIT_CMD; exec bash" &
+    exit 0
+fi
+
+cat <<EOF
+No tmux or supported terminal emulator found.
+
+Open two terminals manually:
+
+  Terminal A:
+    $TCPDUMP_CMD
+
+  Terminal B:
+    $AUDIT_CMD
+EOF
+exit 1

--- a/infra/tcpdump_demo.sh
+++ b/infra/tcpdump_demo.sh
@@ -1,57 +1,97 @@
 #!/usr/bin/env bash
-# Demo-day tcpdump capture — P2 owns this.
-# PRD §8.4 proof point #1: "tcpdump window open on a second screen during P3 demo.
-# Shows zero outbound packets while a plan is generated."
+# Demo-day tcpdump capture. P2 owns this proof.
 #
-# Run BEFORE the demo on a second terminal / second monitor:
-#   bash infra/tcpdump_demo.sh
+# Run before the /plan demo:
+#   sudo bash infra/tcpdump_demo.sh any
 #
-# Output: live packet count + alert if ANY outbound non-loopback packet appears.
+# The monitor captures real outbound, non-loopback traffic and stores both a
+# pcap and a text log under logs/security_demo/ for the judges or after-action
+# review.
 
 set -euo pipefail
 
-INTERFACE="${1:-any}"           # network interface to monitor (default: all)
-LOG_FILE="/tmp/wayfinder_demo_capture.pcap"
-ALERT_COLOR="\033[31m"          # red
-OK_COLOR="\033[32m"             # green
+INTERFACE="${1:-${WAYFINDER_TCPDUMP_INTERFACE:-any}}"
+CAPTURE_DIR="${WAYFINDER_CAPTURE_DIR:-logs/security_demo}"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+PCAP_FILE="${CAPTURE_DIR}/no_outbound_${STAMP}.pcap"
+TEXT_LOG="${CAPTURE_DIR}/no_outbound_${STAMP}.log"
+SUMMARY_LOG="${CAPTURE_DIR}/no_outbound_summary.jsonl"
+ALERT_COLOR="\033[31m"
+OK_COLOR="\033[32m"
+WARN_COLOR="\033[33m"
 RESET="\033[0m"
 
+if ! command -v tcpdump >/dev/null 2>&1; then
+    echo "ERROR: tcpdump is not installed. Install tcpdump on the demo host." >&2
+    exit 127
+fi
+
+mkdir -p "$CAPTURE_DIR"
+touch "$TEXT_LOG" "$SUMMARY_LOG"
+
+# The firewall already blocks egress in the hero demo. The capture filter is a
+# second proof surface: it ignores loopback and TAK multicast so local runtime
+# traffic does not obscure external outbound attempts.
+BPF_FILTER="${WAYFINDER_TCPDUMP_FILTER:-not (host 127.0.0.1 or host ::1 or dst net 224.0.0.0/4 or dst host 239.2.3.1)}"
+DIRECTION_ARGS=()
+if tcpdump -h 2>&1 | grep -q -- "-Q "; then
+    DIRECTION_ARGS=(-Q out)
+else
+    echo -e "${WARN_COLOR}[WARN] tcpdump does not advertise -Q; capture may include inbound packets.${RESET}"
+fi
+
 echo "======================================================"
-echo "  Wayfinder — Demo-Day Network Monitor"
+echo "  TERA Demo Network Monitor"
 echo "  Interface : $INTERFACE"
-echo "  Log file  : $LOG_FILE"
+echo "  Filter    : $BPF_FILTER"
+echo "  Pcap      : $PCAP_FILE"
+echo "  Text log  : $TEXT_LOG"
 echo "======================================================"
 echo ""
-echo "Monitoring for outbound non-loopback packets..."
-echo "Expected during demo: ZERO outbound packets."
+echo "Monitoring for outbound non-loopback/non-TAK-multicast packets."
+echo "Expected during Phase 3 /plan demo: ZERO packets."
 echo "Press Ctrl+C to stop."
 echo ""
 
-# Run tcpdump in background, capture to file
-tcpdump -i "$INTERFACE" \
-    -w "$LOG_FILE" \
-    -l \
-    not host 127.0.0.1 and not host ::1 &
+tcpdump -i "$INTERFACE" "${DIRECTION_ARGS[@]}" -nn -U -w "$PCAP_FILE" "$BPF_FILTER" >/dev/null 2>>"$TEXT_LOG" &
 TCPDUMP_PID=$!
+sleep 1
+if ! kill -0 "$TCPDUMP_PID" 2>/dev/null; then
+    echo "ERROR: tcpdump failed to start. Details:" >&2
+    tail -n 20 "$TEXT_LOG" >&2 || true
+    exit 1
+fi
 
-trap "kill $TCPDUMP_PID 2>/dev/null; echo ''; echo 'Capture stopped. Log: $LOG_FILE'; exit 0" INT TERM
+cleanup() {
+    kill "$TCPDUMP_PID" 2>/dev/null || true
+    wait "$TCPDUMP_PID" 2>/dev/null || true
+    echo ""
+    echo "Capture stopped."
+    echo "Pcap: $PCAP_FILE"
+    echo "Text: $TEXT_LOG"
+    exit 0
+}
+trap cleanup INT TERM
 
 LAST_COUNT=0
-OUTBOUND_DETECTED=0
 
 while true; do
     sleep 2
 
-    # Count captured packets
-    CURRENT_COUNT=$(tcpdump -r "$LOG_FILE" 2>/dev/null | grep -c "^" || echo 0)
+    CURRENT_COUNT="$(tcpdump -nn -r "$PCAP_FILE" 2>/dev/null | tee "$TEXT_LOG.tmp" | grep -c "^" || true)"
+    mv "$TEXT_LOG.tmp" "$TEXT_LOG"
 
     DELTA=$((CURRENT_COUNT - LAST_COUNT))
+    TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
     if [ "$DELTA" -gt 0 ]; then
-        OUTBOUND_DETECTED=1
-        echo -e "${ALERT_COLOR}[ALERT] $DELTA new outbound packet(s) detected! Total: $CURRENT_COUNT${RESET}"
+        echo -e "${ALERT_COLOR}[ALERT] $DELTA outbound packet(s) detected. Total: $CURRENT_COUNT${RESET}"
+        printf '{"ts":"%s","event":"tcpdump_outbound_detected","delta":%s,"total":%s,"pcap":"%s"}\n' \
+            "$TS" "$DELTA" "$CURRENT_COUNT" "$PCAP_FILE" >> "$SUMMARY_LOG"
     else
         echo -e "${OK_COLOR}[OK] No outbound packets. Total captured: $CURRENT_COUNT${RESET}"
+        printf '{"ts":"%s","event":"tcpdump_no_outbound","delta":0,"total":%s,"pcap":"%s"}\n' \
+            "$TS" "$CURRENT_COUNT" "$PCAP_FILE" >> "$SUMMARY_LOG"
     fi
 
     LAST_COUNT=$CURRENT_COUNT

--- a/security/audit_log.py
+++ b/security/audit_log.py
@@ -1,0 +1,46 @@
+"""Append-only JSONL audit log for demo-time security proof.
+
+The audit log is intentionally local and file-backed. It gives P2 a real
+second-screen scroll of prompt, tool, policy, signing, and approval events
+without shipping raw prompt text or secrets into a durable artifact.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_AUDIT_LOG = Path("logs/security_audit.jsonl")
+
+
+def audit_log_path() -> Path:
+    return Path(os.environ.get("WAYFINDER_AUDIT_LOG", str(DEFAULT_AUDIT_LOG)))
+
+
+def prompt_digest(prompt: str) -> str:
+    return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+
+def audit_event(event: str, **fields: Any) -> None:
+    """Append one structured audit event.
+
+    This function is fail-closed for security semantics but fail-open for
+    application availability: audit write errors must not break /plan during
+    the demo. Callers should still run tests against the happy path.
+    """
+    record = {
+        "ts": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "event": event,
+        **fields,
+    }
+    path = audit_log_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, sort_keys=True, separators=(",", ":"), default=str) + "\n")
+    except (OSError, TypeError):
+        return

--- a/security/demo_proofs.md
+++ b/security/demo_proofs.md
@@ -115,27 +115,42 @@ or point coordinates and still have ATAK treat the route as trusted.
 
 ## Proof 4: Offline / No-Outbound Traffic
 
-On Jetson or Linux demo hardware, run this in a second terminal before the
-`/plan` demo:
+On Jetson or Linux demo hardware, run this before the `/plan` demo:
 
 ```bash
 sudo bash infra/jetson_firewall.sh enable
-sudo bash infra/tcpdump_demo.sh any
+make tcpdump-demo
 ```
 
-Then run the plan request from the demo terminal.
+`make tcpdump-demo` opens two live proof monitors when `tmux`, `gnome-terminal`,
+or `x-terminal-emulator` is available:
+
+- real `tcpdump` outbound capture from `infra/tcpdump_demo.sh`
+- structured JSONL audit scroll from `infra/audit_log_scroll.sh`
+
+If no terminal multiplexer is installed, the script prints the two commands to
+run manually in separate terminals.
+
+Then run the plan request from the demo terminal. The capture artifacts land in
+`logs/security_demo/`, and structured audit events append to
+`logs/security_audit.jsonl`.
 
 Expected result:
 
 ```text
 [OK] No outbound packets.
+{"event":"prompt_received", ...}
+{"event":"tool_dispatch_completed", ...}
+{"event":"route_signed", ...}
 ```
 
 Security interpretation:
 
 In Phase 3, the agent must not call frontier APIs or external map services.
 The demo should show route planning while WiFi is disabled or outbound egress
-is blocked.
+is blocked. The audit log provides a local, structured scroll of prompt hash,
+security-gate, tool-dispatch, signing, and operator-approval events without
+storing raw prompt text.
 
 Restore connectivity after the demo:
 
@@ -178,6 +193,7 @@ Before merging P2 changes:
 [ ] python -m pytest security crypto -q
 [ ] python security\pipeline.py
 [ ] python crypto\cot_signer.py
+[ ] bash -n infra/tcpdump_demo.sh infra/audit_log_scroll.sh infra/security_demo_monitors.sh
 [ ] No real API keys committed
 [ ] If touching /plan integration, guard runs before routing/signing
 ```

--- a/security/test_audit_log.py
+++ b/security/test_audit_log.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+
+from security.audit_log import audit_event, prompt_digest
+
+
+def test_audit_event_writes_jsonl(tmp_path, monkeypatch) -> None:
+    audit_path = tmp_path / "security_audit.jsonl"
+    monkeypatch.setenv("WAYFINDER_AUDIT_LOG", str(audit_path))
+
+    audit_event(
+        "prompt_received",
+        request_id="req-1",
+        prompt_sha256=prompt_digest("route to freshwater"),
+        prompt_len=len("route to freshwater"),
+    )
+
+    record = json.loads(audit_path.read_text(encoding="utf-8"))
+    assert record["event"] == "prompt_received"
+    assert record["request_id"] == "req-1"
+    assert record["prompt_len"] == 19
+    assert record["prompt_sha256"] == prompt_digest("route to freshwater")
+    assert "route to freshwater" not in audit_path.read_text(encoding="utf-8")
+
+
+def test_demo_shell_scripts_parse() -> None:
+    bash = shutil.which("bash")
+    if bash is None:
+        return
+
+    for script in (
+        "infra/tcpdump_demo.sh",
+        "infra/audit_log_scroll.sh",
+        "infra/security_demo_monitors.sh",
+    ):
+        subprocess.run([bash, "-n", script], check=True)  # noqa: S603

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -6,6 +6,7 @@ require API keys, ollama, liboqs, or SuperAgent.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -223,6 +224,49 @@ async def test_plan_happy_path_returns_route(monkeypatch: pytest.MonkeyPatch) ->
     assert resp.signature is None
     # LLM was called exactly once with structured output.
     mock_client.complete_structured.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_plan_writes_security_audit_log(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setenv("TERA_DEVICE_PROFILE", "austere")
+    audit_path = tmp_path / "security_audit.jsonl"
+    monkeypatch.setenv("WAYFINDER_AUDIT_LOG", str(audit_path))
+    mock_client = _make_mock_llm(VALID_FRESHWATER_QUERY)
+    signature = Signature(
+        scheme="ML-DSA-65",
+        key_id="wayfinder-device-001",
+        value_b64="c2ln",
+        signed_at="2026-05-02T22:30:00Z",
+    )
+
+    async def fake_guard(**kwargs: Any) -> Any:
+        result = MagicMock()
+        result.to_dict.return_value = _passing_pipeline_result(VALID_FRESHWATER_QUERY)
+        return result
+
+    with (
+        patch("agent.orchestrator.get_registry") as mock_reg,
+        patch("agent.orchestrator._sign_response", return_value=signature),
+        patch.dict(
+            "sys.modules",
+            {"security.plan_guard": MagicMock(guard_plan_request=fake_guard)},
+        ),
+    ):
+        mock_reg.return_value.get.return_value = mock_client
+        raw_prompt = "Route me to nearest freshwater within 5km on foot, covered terrain."
+        req = PlanRequest(
+            prompt=raw_prompt,
+            current=Coord(lat=37.7955, lon=-122.3937),
+        )
+        await plan(req)
+
+    audit_text = audit_path.read_text(encoding="utf-8")
+    events = [json.loads(line)["event"] for line in audit_text.splitlines()]
+    assert "prompt_received" in events
+    assert "tool_dispatch_completed" in events
+    assert "route_signed" in events
+    assert "plan_response_ready" in events
+    assert raw_prompt not in audit_text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Implements issue #15: `make tcpdump-demo` now opens/prints the real security proof monitors for the demo.
- Adds a real outbound tcpdump capture path that writes pcap, text log, and JSONL summary artifacts under `logs/security_demo/`.
- Adds a structured local security audit log (`logs/security_audit.jsonl`) and runtime audit events for prompt hash, route query, security gate, tool dispatch, signing, plan response, and operator approval.
- Adds audit log scrolling and monitor launcher scripts for tmux/terminal-based demo display.

## Security report for #15
Acceptance target: `make tcpdump-demo` opens a window showing zero outbound during `/plan`; audit log scrolls structured prompt/tool/sign events.

Implemented proof path:
- `make tcpdump-demo` -> `infra/security_demo_monitors.sh`
- Monitor A: `sudo bash infra/tcpdump_demo.sh any`
- Monitor B: `bash infra/audit_log_scroll.sh`

Real artifacts:
- pcap: `logs/security_demo/no_outbound_<timestamp>.pcap`
- decoded capture log: `logs/security_demo/no_outbound_<timestamp>.log`
- capture summary: `logs/security_demo/no_outbound_summary.jsonl`
- application audit: `logs/security_audit.jsonl`

Privacy/security note: raw prompts are not written to the durable audit log; the audit log records `prompt_sha256` and `prompt_len` instead.

## Test Plan
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m pytest -q -m "not slow" tests security crypto` (`135 passed`)
- `python -m mypy agent routing crypto security --ignore-missing-imports --no-error-summary`
- `python -m bandit -r agent routing atak voice security crypto -ll -q`
- `bash -n infra/tcpdump_demo.sh infra/audit_log_scroll.sh infra/security_demo_monitors.sh`
- `python -m pip_audit -r requirements-ci.txt --desc --fix --dry-run` (`No known vulnerabilities found`)

Notes: local `make ci` could not run because `make` is not installed in this Windows PowerShell session; the Makefile components were run manually. Existing mypy config still prints the known `security.*` override warning tracked by #35.

Closes #15.