### PR TITLE
feat(voice): Piper TTS voice-out + glossary explain path (#26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ crypto/keys/
 models/*.gguf
 models/*.bin
 models/*.safetensors
+models/piper/*.onnx
+models/piper/*.onnx.json
 data/runtime/
 data/cache/
 data/extracts/*.osm.pbf

--- a/agent/app.py
+++ b/agent/app.py
@@ -48,9 +48,16 @@ def health() -> dict[str, Any]:
 
 
 @app.post("/plan", response_model=PlanResponse, responses={403: {"model": PlanBlocked}})
-async def plan_endpoint(req: PlanRequest) -> PlanResponse:
+async def plan_endpoint(req: PlanRequest, tts: bool = False) -> PlanResponse:
+    """POST /plan with optional TTS.
+
+    `?tts=true` makes the orchestrator synthesize the rationale via Piper
+    and return it base64-encoded in `audio_b64`. Defaults to False so the
+    web frontend can keep doing what it does without surprise audio payloads.
+    The hero demo (PRD §6) sets `?tts=true`.
+    """
     try:
-        return await orchestrate_plan(req)
+        return await orchestrate_plan(req, with_tts=tts)
     except PlanBlockedError as e:
         # 403 with structured detail so operator UI can show *which* stage
         # blocked and why -- transparency over opacity.

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -154,7 +154,9 @@ def _dispatch_tools(query: dict[str, Any], origin: Coord) -> dict[str, Any]:
     )
 
     # Step 3: build waypoints + rationale.
-    waypoints = [{"lat": dest_coord["lat"], "lon": dest_coord["lon"], "label": dest_label}]
+    waypoints = [
+        {"lat": dest_coord["lat"], "lon": dest_coord["lon"], "label": dest_label}
+    ]
     rationale = _build_rationale(
         dest_label=dest_label,
         cost=route_result["cost_breakdown"],
@@ -191,7 +193,9 @@ def _build_rationale(
     """
     distance_km = cost.get("distance_m", 0.0) / 1000.0
     time_min = cost.get("time_s", 0.0) / 60.0
-    avoid_str = f" Avoiding {', '.join(a.replace('_', ' ') for a in avoid)}." if avoid else ""
+    avoid_str = (
+        f" Avoiding {', '.join(a.replace('_', ' ') for a in avoid)}." if avoid else ""
+    )
     return (
         f"Routed to {dest_label}, distance {distance_km:.1f} kilometers, "
         f"ETA {time_min:.0f} minutes on {profile.replace('_', ' ')}.{avoid_str}"
@@ -277,13 +281,19 @@ class PlanBlockedError(Exception):
         self.reason = reason
 
 
-async def plan(req: PlanRequest, mode: ModeOrAuto = "auto") -> PlanResponse:
+async def plan(
+    req: PlanRequest, mode: ModeOrAuto = "auto", with_tts: bool = False
+) -> PlanResponse:
     """End-to-end /plan handler.
 
     Args:
         req: validated PlanRequest from the HTTP layer.
         mode: which LLM mode to use ("auto" -> profile default).
               In this PR `mode` is server-controlled (not yet on PlanRequest).
+        with_tts: if True, synthesize the operator-cadence rationale via
+              Piper TTS and embed it in PlanResponse.audio_b64. Defaults to
+              False so existing callers see no behavior change. Hands-free
+              path (#21) sets this from the `?tts=true` query param.
               That contract change goes through Ben + Satriyo signoff at the
               Sat 1500 freeze and lands in a follow-up PR.
     """
@@ -411,7 +421,20 @@ async def plan(req: PlanRequest, mode: ModeOrAuto = "auto") -> PlanResponse:
             key_id=signature.key_id,
         )
 
-    # 6. Build response.
+    # 6. Optional TTS (hands-free path). Synthesize the rationale into a
+    #    base64-encoded WAV in operator cadence. Lazy-imported so machines
+    #    without piper-tts installed (e.g. CI without the [voice] extra) don't
+    #    even load the module.
+    audio_b64: str | None = None
+    if with_tts:
+        try:
+            from voice.tts import synthesize_rationale_b64
+
+            audio_b64 = synthesize_rationale_b64(dispatch["rationale"])
+        except Exception as e:  # noqa: BLE001 -- TTS failure must not fail /plan
+            logger.warning("tts_synth_failed", error=str(e))
+
+    # 7. Build response.
     response = PlanResponse(
         request_id=request_id,
         route=dispatch["feature"],
@@ -420,11 +443,13 @@ async def plan(req: PlanRequest, mode: ModeOrAuto = "auto") -> PlanResponse:
         cost_breakdown=dispatch["cost_breakdown"],
         trust=pipeline_result.get("trust_result") or {},
         signature=signature,
+        audio_b64=audio_b64,
     )
     logger.info(
         "plan_response",
         provider=client.name,
         signed=signature is not None,
+        spoken=audio_b64 is not None,
         trust_status=(pipeline_result.get("trust_result") or {}).get("trust_status"),
     )
     audit_event(

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -154,9 +154,7 @@ def _dispatch_tools(query: dict[str, Any], origin: Coord) -> dict[str, Any]:
     )
 
     # Step 3: build waypoints + rationale.
-    waypoints = [
-        {"lat": dest_coord["lat"], "lon": dest_coord["lon"], "label": dest_label}
-    ]
+    waypoints = [{"lat": dest_coord["lat"], "lon": dest_coord["lon"], "label": dest_label}]
     rationale = _build_rationale(
         dest_label=dest_label,
         cost=route_result["cost_breakdown"],
@@ -193,9 +191,7 @@ def _build_rationale(
     """
     distance_km = cost.get("distance_m", 0.0) / 1000.0
     time_min = cost.get("time_s", 0.0) / 60.0
-    avoid_str = (
-        f" Avoiding {', '.join(a.replace('_', ' ') for a in avoid)}." if avoid else ""
-    )
+    avoid_str = f" Avoiding {', '.join(a.replace('_', ' ') for a in avoid)}." if avoid else ""
     return (
         f"Routed to {dest_label}, distance {distance_km:.1f} kilometers, "
         f"ETA {time_min:.0f} minutes on {profile.replace('_', ' ')}.{avoid_str}"
@@ -281,9 +277,7 @@ class PlanBlockedError(Exception):
         self.reason = reason
 
 
-async def plan(
-    req: PlanRequest, mode: ModeOrAuto = "auto", with_tts: bool = False
-) -> PlanResponse:
+async def plan(req: PlanRequest, mode: ModeOrAuto = "auto", with_tts: bool = False) -> PlanResponse:
     """End-to-end /plan handler.
 
     Args:

--- a/agent/schemas.py
+++ b/agent/schemas.py
@@ -96,7 +96,13 @@ class OperatorSignature(BaseModel):
 
 
 class PlanResponse(BaseModel):
-    """Returned from POST /plan. The route + rationale + trust + signature."""
+    """Returned from POST /plan. The route + rationale + trust + signature.
+
+    `audio_b64` holds an optional base64-encoded WAV of the rationale spoken
+    in operator cadence (Piper TTS, voice/tts.py). Populated when the request
+    arrives with `?tts=true` AND Piper is available locally; null otherwise.
+    Field is optional so a missing TTS layer never breaks the route response.
+    """
 
     request_id: str
     route: dict[str, Any]  # GeoJSON Feature with LineString geometry
@@ -105,6 +111,7 @@ class PlanResponse(BaseModel):
     cost_breakdown: dict[str, float] = Field(default_factory=dict)
     trust: dict[str, Any] = Field(default_factory=dict)  # from security/route_trust_score
     signature: Signature | None = None
+    audio_b64: str | None = None
 
 
 class PlanBlocked(BaseModel):

--- a/docs/SUBMISSION_NOTES.md
+++ b/docs/SUBMISSION_NOTES.md
@@ -1,0 +1,50 @@
+# TERA — Submission Notes (Eligibility & Ethics)
+
+**Team:** TruePoint
+**Product:** TERA — Tactical Edge Route Agent
+**Event:** 3rd Annual National Security Hackathon (Cerebral Valley × US Army xTech), 2026
+**Affiliation:** Naval Postgraduate School Foundation, Entrepreneurship Club
+
+This document captures the team's posture on participation in an Army-sponsored event. Maintained for transparency to event organizers and to satisfy any internal command / JAG inquiry. Not legal advice; team members should additionally consult their respective unit ethics counselors before final submission.
+
+## Affiliation
+
+The team is competing as members of the **NPS Foundation Entrepreneurship Club**, not in a representative US Army (or other-service) capacity. The NPS Foundation — a 501(c)(3) non-profit affiliated with the Naval Postgraduate School — funded the team's travel to the event in support of the Entrepreneurship Club program. We do not represent the US Army, Navy, or any DoD entity in our pitch, branding, or submission.
+
+## Resources
+
+- **Time.** All work is performed on the team's personal time, outside of duty hours.
+- **Equipment.** Development on personal laptops and personal compute. No government devices, accounts, networks, or workspaces are used.
+- **Software.** Third-party tools and APIs are paid for by team members or use free / open-source licenses.
+- **Data.** OpenStreetMap (ODbL), publicly available Cesium Ion imagery (provided as a partner resource by the event organizer), and public CC-licensed terrain (SRTM / Copernicus). No government data sources.
+
+## Information
+
+- The pitch and demo use **only unclassified operator vocabulary** (CASEVAC, HLZ, MGRS, golden hour, etc.) that appears in public US Army and joint doctrine.
+- No classified information, sources, methods, tactics, techniques, or procedures (TTPs) are referenced or derivable from the submission.
+- Hero scenario locations (urban San Francisco; austere training-environment AOI) are public, non-sensitive geographies.
+- Reverse-engineering of the system would not yield any classified or controlled-unclassified information.
+
+## Branding
+
+- Team name ("TruePoint") and product codename ("TERA") are not affiliated with any DoD designator or program of record.
+- No team member uses rank or unit affiliation in the pitch deck, demo, or written submission.
+- No team member appears in uniform in any team-produced media.
+
+## Prize handling
+
+Should the team place in the competition and be awarded a prize:
+
+- **Monetary prizes** will be directed to the **NPS Foundation** (501(c)(3)), which is authorized to receive gifts on behalf of the affiliated educational program. This avoids any DoD 5500.07-R / Joint Ethics Regulation conflict regarding individual acceptance of non-federal gifts above the de minimis threshold.
+- **Non-monetary recognition** (mentorship, follow-on partnership conversations, technical accelerator placement) will be coordinated through xTech and the NPS Foundation.
+- Any individual team member required by their command to obtain prior outside-activity approval (DA Form 3433 or equivalent) will do so before accepting recognition that flows to them personally.
+
+## Disclosures
+
+- Active-duty status of team members is disclosed to the event organizer and is reflected in team materials submitted to xTech.
+- The NPS Foundation faculty advisor for the Entrepreneurship Club is aware of the team's participation.
+
+## Contacts
+
+- For event organizer questions: see `PRD.md` §1 (team contacts).
+- For internal command / JAG inquiry: refer to the NPS Foundation Entrepreneurship Club faculty advisor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,8 @@ ignore = [
 "crypto/*" = ["T201"]
 # eval/runner.py is a CLI tool that prints to stdout intentionally.
 "eval/runner.py" = ["T201"]
+# scripts/ are CLI demo tools that print to stdout intentionally.
+"scripts/*" = ["T201"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["agent", "routing", "atak", "voice", "crypto", "security", "eval", "ontology"]

--- a/scripts/demo_voice.py
+++ b/scripts/demo_voice.py
@@ -27,11 +27,15 @@ Usage
   python scripts/demo_voice.py --dry-run
 
 In interactive mode (default), at each phrase prompt:
-  [Enter]  -> next phrase
-  r        -> replay current phrase
-  s        -> slow down (length_scale +0.05)
-  f        -> speed up (length_scale -0.05)
-  q        -> quit
+  [Enter]   -> next phrase (no notes captured)
+  r         -> replay current phrase
+  s         -> slow down (length_scale +0.05)
+  f         -> speed up (length_scale -0.05)
+  q         -> quit and write notes file
+  any text  -> save as a note for THIS phrase, then advance
+
+At the end (or on q), notes are written to a markdown file in /tmp and the
+path is printed. Paste that file back to chat to triage cadence fixes.
 
 Listen-for checklist (printed once at start):
 - clarity, pace, comma pause, sentence pause
@@ -50,6 +54,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from datetime import datetime
 from pathlib import Path
 
 from voice.phrases import PHRASES, by_category, by_id, categories
@@ -107,6 +112,38 @@ def _show_phrase(phrase: tuple[str, str, str, str]) -> None:
     print(f"  listen:  {listen_for}")
 
 
+def _write_notes(
+    notes: list[tuple[str, str, str, str]], length_scale: float
+) -> Path:
+    """Write captured notes to a timestamped markdown file. Returns the path.
+
+    Format mirrors what's useful when triaging cadence rules: phrase id,
+    category, the cadence-transformed text (so I can see what Piper actually
+    received), and the operator's note.
+    """
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")  # noqa: DTZ005 -- local time fine for filename
+    out = Path(tempfile.gettempdir()) / f"tera_voice_notes_{stamp}.md"
+
+    lines: list[str] = []
+    lines.append(f"# TERA voice notes — {stamp}")
+    lines.append("")
+    lines.append(f"- length_scale (final): {length_scale:.2f}")
+    lines.append(f"- phrases noted: {len(notes)}")
+    lines.append("")
+    if not notes:
+        lines.append("_No notes captured. All phrases sounded clean._")
+    else:
+        lines.append("| id | category | cadence | note |")
+        lines.append("|---|---|---|---|")
+        for pid, cat, cadence, note in notes:
+            # Escape pipes inside cadence/note for markdown table safety.
+            cadence_safe = cadence.replace("|", "\\|")
+            note_safe = note.replace("|", "\\|")
+            lines.append(f"| `{pid}` | {cat} | {cadence_safe} | {note_safe} |")
+    out.write_text("\n".join(lines) + "\n")
+    return out
+
+
 def _interactive_loop(
     phrases: list[tuple[str, str, str, str]], length_scale: float
 ) -> int:
@@ -121,14 +158,26 @@ def _interactive_loop(
 
     print(CHECKLIST)
     print(f"phrases: {len(phrases)}, starting length_scale={length_scale:.2f}")
-    print("controls: [Enter]=next  r=replay  s=slower  f=faster  q=quit\n")
+    print("controls:")
+    print("  [Enter]   -> next phrase (no note)")
+    print("  r         -> replay")
+    print("  s / f     -> slower / faster")
+    print("  q         -> quit + write notes file")
+    print("  any text  -> save as note for THIS phrase, then advance\n")
+
+    notes: list[tuple[str, str, str, str]] = []  # (id, category, cadence, note)
+
+    def _commands_help() -> None:
+        print("  -- single-char commands: r=replay s=slower f=faster q=quit; "
+              "any other text becomes a note for this phrase --")
 
     i = 0
     while i < len(phrases):
         phrase = phrases[i]
+        pid, cat, raw_text, _ = phrase
         _show_phrase(phrase)
 
-        wav = _synth_to_tempfile(phrase[2], length_scale)
+        wav = _synth_to_tempfile(raw_text, length_scale)
         if wav is None:
             print("  ! synth failed, skipping")
             i += 1
@@ -138,38 +187,49 @@ def _interactive_loop(
         wav.unlink(missing_ok=True)
 
         try:
-            cmd = input(
-                f"  [{i + 1}/{len(phrases)}] length_scale={length_scale:.2f} > "
-            ).strip().lower()
+            raw = input(
+                f"  [{i + 1}/{len(phrases)}] note (or r/s/f/q, Enter=next) > "
+            )
         except EOFError:
             print()
-            return 0
+            break
 
-        if cmd == "q":
-            return 0
-        if cmd == "r":
-            continue  # replay same phrase
-        if cmd == "s":
-            length_scale = min(2.0, length_scale + 0.05)
-            # Rebuild client with new length_scale default and play again.
+        cmd = raw.strip()
+        cmd_lower = cmd.lower()
+
+        # Single-char commands.
+        if cmd_lower == "q":
+            break
+        if cmd_lower == "r":
+            continue
+        if cmd_lower in ("s", "f"):
+            delta = 0.05 if cmd_lower == "s" else -0.05
+            length_scale = max(0.5, min(2.0, length_scale + delta))
             reset_piper()
             from voice import piper_client
 
             piper_client._client = piper_client.PiperClient(length_scale=length_scale)
-            print(f"  -> length_scale {length_scale:.2f} (slower)")
+            label = "slower" if cmd_lower == "s" else "faster"
+            print(f"  -> length_scale {length_scale:.2f} ({label}); replaying")
             continue
-        if cmd == "f":
-            length_scale = max(0.5, length_scale - 0.05)
-            reset_piper()
-            from voice import piper_client
+        if cmd_lower in ("h", "help", "?"):
+            _commands_help()
+            continue
 
-            piper_client._client = piper_client.PiperClient(length_scale=length_scale)
-            print(f"  -> length_scale {length_scale:.2f} (faster)")
+        # Empty Enter -> advance, no note.
+        if cmd == "":
+            i += 1
             continue
-        # Anything else (including blank Enter) -> next phrase
+
+        # Anything else -> capture as note, then advance.
+        cadence = to_operator_cadence(raw_text)
+        notes.append((pid, cat, cadence, cmd))
+        print(f"  noted: {cmd}")
         i += 1
 
-    print("\nEnd of corpus. Take notes on which phrases need cadence rule fixes.")
+    out = _write_notes(notes, length_scale)
+    print(f"\nWrote {len(notes)} note(s) to {out}")
+    print("Paste that file back to chat to triage cadence fixes.")
     return 0
 
 

--- a/scripts/demo_voice.py
+++ b/scripts/demo_voice.py
@@ -1,0 +1,49 @@
+"""Quick voice-out demo. Writes a WAV of the canonical PRD rationale to disk
+and prints a one-liner to play it on macOS. For Jon's pre-demo smoke test.
+
+    python scripts/demo_voice.py
+    afplay /tmp/tera_demo.wav
+"""
+
+from __future__ import annotations
+
+import base64
+import sys
+import tempfile
+from pathlib import Path
+
+from voice.piper_client import get_piper
+from voice.rationale import to_operator_cadence
+from voice.tts import synthesize_rationale_b64
+
+
+def main() -> int:
+    rationale = (
+        "Routed to Lobos Creek, distance 2.1 kilometers, "
+        "ETA 38 minutes on foot covered."
+    )
+    if len(sys.argv) > 1:
+        rationale = " ".join(sys.argv[1:])
+
+    print(f"input:    {rationale}")
+    print(f"cadence:  {to_operator_cadence(rationale)}")
+
+    client = get_piper()
+    if not client.is_available():
+        print("ERROR: Piper not available. Run `make install-voice` and download the voice model.")
+        return 1
+
+    audio_b64 = synthesize_rationale_b64(rationale)
+    if audio_b64 is None:
+        print("ERROR: synthesis returned None.")
+        return 1
+
+    out = Path(tempfile.gettempdir()) / "tera_demo.wav"
+    out.write_bytes(base64.b64decode(audio_b64))
+    print(f"wrote:    {out} ({out.stat().st_size:,} bytes)")
+    print(f"play:     afplay {out}  # macOS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/demo_voice.py
+++ b/scripts/demo_voice.py
@@ -120,9 +120,7 @@ def _show_phrase(phrase: tuple[str, str, str, str]) -> None:
     print(f"  listen:  {listen_for}")
 
 
-def _write_notes(
-    notes: list[tuple[str, str, str, str]], length_scale: float
-) -> Path:
+def _write_notes(notes: list[tuple[str, str, str, str]], length_scale: float) -> Path:
     """Write captured notes to a timestamped markdown file. Returns the path.
 
     Format mirrors what's useful when triaging cadence rules: phrase id,
@@ -152,9 +150,7 @@ def _write_notes(
     return out
 
 
-def _interactive_loop(
-    phrases: list[tuple[str, str, str, str]], length_scale: float
-) -> int:
+def _interactive_loop(phrases: list[tuple[str, str, str, str]], length_scale: float) -> int:
     """Walk through phrases. Returns exit code."""
     client = get_piper()
     if not client.is_available():
@@ -176,8 +172,10 @@ def _interactive_loop(
     notes: list[tuple[str, str, str, str]] = []  # (id, category, cadence, note)
 
     def _commands_help() -> None:
-        print("  -- single-char commands: r=replay s=slower f=faster q=quit; "
-              "any other text becomes a note for this phrase --")
+        print(
+            "  -- single-char commands: r=replay s=slower f=faster q=quit; "
+            "any other text becomes a note for this phrase --"
+        )
 
     i = 0
     while i < len(phrases):
@@ -195,9 +193,7 @@ def _interactive_loop(
         wav.unlink(missing_ok=True)
 
         try:
-            raw = input(
-                f"  [{i + 1}/{len(phrases)}] note (or r/s/f/q, Enter=next) > "
-            )
+            raw = input(f"  [{i + 1}/{len(phrases)}] note (or r/s/f/q, Enter=next) > ")
         except EOFError:
             print()
             break

--- a/scripts/demo_voice.py
+++ b/scripts/demo_voice.py
@@ -26,6 +26,13 @@ Usage
   # Print-only (no audio) to dry-run the cadence transform.
   python scripts/demo_voice.py --dry-run
 
+  # On-demand acronym explain (deterministic, no LLM):
+  python scripts/demo_voice.py --explain HLZ
+  python scripts/demo_voice.py --explain CASEVAC
+
+  # List every term the glossary can explain:
+  python scripts/demo_voice.py --explain-list
+
 In interactive mode (default), at each phrase prompt:
   [Enter]   -> next phrase (no notes captured)
   r         -> replay current phrase
@@ -57,10 +64,11 @@ import tempfile
 from datetime import datetime
 from pathlib import Path
 
+from voice.glossary import known_terms
 from voice.phrases import PHRASES, by_category, by_id, categories
 from voice.piper_client import get_piper, reset_piper
 from voice.rationale import to_operator_cadence
-from voice.tts import synthesize_rationale_b64
+from voice.tts import synthesize_explanation_b64, synthesize_rationale_b64
 
 CHECKLIST = """
 Listen-for checklist (operator-radio):
@@ -253,11 +261,46 @@ def main() -> int:
     )
     p.add_argument("--dry-run", action="store_true", help="print cadence transform only, no audio")
     p.add_argument("--list", action="store_true", help="list phrases and exit")
+    p.add_argument(
+        "--explain",
+        metavar="TERM",
+        help="speak a deterministic explanation of the given acronym (e.g. 'HLZ')",
+    )
+    p.add_argument(
+        "--explain-list",
+        action="store_true",
+        help="print every term the glossary can explain, and exit",
+    )
     args = p.parse_args()
 
     if args.list:
         for pid, cat, text, _ in PHRASES:
             print(f"  {pid:12s} ({cat:10s}) {text}")
+        return 0
+
+    if args.explain_list:
+        for term in known_terms():
+            print(f"  {term}")
+        return 0
+
+    if args.explain:
+        result = synthesize_explanation_b64(args.explain, length_scale=args.rate)
+        if result is None:
+            print(
+                f"  '{args.explain}' is not in the glossary. "
+                "Operator hears nothing or 'term not recognized'."
+            )
+            print("  Run --explain-list to see all known terms.")
+            return 1
+        print(f"  term:  {result['term']}")
+        print(f"  text:  {result['text']}")
+        if result["audio_b64"]:
+            out = Path(tempfile.gettempdir()) / f"tera_explain_{result['term']}.wav"
+            out.write_bytes(base64.b64decode(result["audio_b64"]))
+            print(f"  wav:   {out}")
+            _play(out)
+        else:
+            print("  (audio unavailable -- text-only explanation)")
         return 0
 
     # Set the global length_scale for this session.

--- a/scripts/demo_voice.py
+++ b/scripts/demo_voice.py
@@ -1,49 +1,234 @@
-"""Quick voice-out demo. Writes a WAV of the canonical PRD rationale to disk
-and prints a one-liner to play it on macOS. For Jon's pre-demo smoke test.
+"""Voice-out listen-test harness.
 
-    python scripts/demo_voice.py
-    afplay /tmp/tera_demo.wav
+Run interactively to evaluate Piper TTS quality across the phrase corpus
+in voice/phrases.py. Plays each phrase, prints the cadence-transformed
+input + a checklist of what to listen for, and lets you advance / repeat
+/ adjust pace.
+
+Usage
+-----
+
+  # Default: walk through every phrase, ops cadence (length_scale=1.15).
+  python scripts/demo_voice.py
+
+  # One phrase by id.
+  python scripts/demo_voice.py --id prd-A
+
+  # All phrases in one category.
+  python scripts/demo_voice.py --category mgrs
+
+  # Custom phrase from CLI.
+  python scripts/demo_voice.py --text "Heading 030 for 2.5 kilometers."
+
+  # Adjust pace. Higher = slower. 1.0 = piper default, 1.15 = ops, 1.3 = slow.
+  python scripts/demo_voice.py --rate 1.25
+
+  # Print-only (no audio) to dry-run the cadence transform.
+  python scripts/demo_voice.py --dry-run
+
+In interactive mode (default), at each phrase prompt:
+  [Enter]  -> next phrase
+  r        -> replay current phrase
+  s        -> slow down (length_scale +0.05)
+  f        -> speed up (length_scale -0.05)
+  q        -> quit
+
+Listen-for checklist (printed once at start):
+- clarity, pace, comma pause, sentence pause
+- number disambiguation (5/9, 3/free, 2/to, 4/for)
+- phonetic precision on MGRS letters
+- stress on critical tokens (DANGER CLOSE, BREAK, BE ADVISED)
+- compound cardinal smoothness (north-northeast)
+- end-of-utterance clean stop, no clipping
 """
 
 from __future__ import annotations
 
+import argparse
 import base64
+import shutil
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
-from voice.piper_client import get_piper
+from voice.phrases import PHRASES, by_category, by_id, categories
+from voice.piper_client import get_piper, reset_piper
 from voice.rationale import to_operator_cadence
 from voice.tts import synthesize_rationale_b64
 
+CHECKLIST = """
+Listen-for checklist (operator-radio):
+  [pace]      cadence slow enough to copy on the fly?
+  [pause]     comma -> beat between MGRS halves; period -> sentence gap
+  [numbers]   five vs nine, three vs free, two vs to, four vs for
+  [phonetic]  sierra/mike/foxtrot crisp, not slurred
+  [stress]    DANGER CLOSE / BREAK / BE ADVISED land with weight?
+  [cardinal]  'north-northeast' smooth or weird?
+  [end]       clean final stop, no clipped phoneme
+  [volume]    no clipping on long phrases
+"""
 
-def main() -> int:
-    rationale = (
-        "Routed to Lobos Creek, distance 2.1 kilometers, "
-        "ETA 38 minutes on foot covered."
-    )
-    if len(sys.argv) > 1:
-        rationale = " ".join(sys.argv[1:])
 
-    print(f"input:    {rationale}")
-    print(f"cadence:  {to_operator_cadence(rationale)}")
+def _play(wav_path: Path) -> None:
+    """Play a WAV file using whatever's on PATH. Cross-platform best effort.
 
+    S603/S607 are suppressed because the args are fixed strings and we
+    require the executable to exist on PATH (shutil.which check above).
+    """
+    cmd: list[str] | None = None
+    if shutil.which("afplay"):  # macOS
+        cmd = ["afplay", str(wav_path)]
+    elif shutil.which("aplay"):  # linux
+        cmd = ["aplay", "-q", str(wav_path)]
+    elif shutil.which("ffplay"):  # ffmpeg
+        cmd = ["ffplay", "-nodisp", "-autoexit", "-loglevel", "quiet", str(wav_path)]
+    if cmd is None:
+        print(f"  (no audio player on PATH; play manually: {wav_path})")
+        return
+    subprocess.run(cmd, check=False)  # noqa: S603
+
+
+def _synth_to_tempfile(text: str, length_scale: float) -> Path | None:
+    """Synthesize text and return path to a temp WAV. None if synth failed."""
+    audio_b64 = synthesize_rationale_b64(text, length_scale=length_scale)
+    if audio_b64 is None:
+        return None
+    out = Path(tempfile.mkstemp(prefix="tera_demo_", suffix=".wav")[1])
+    out.write_bytes(base64.b64decode(audio_b64))
+    return out
+
+
+def _show_phrase(phrase: tuple[str, str, str, str]) -> None:
+    pid, cat, text, listen_for = phrase
+    print(f"\n[{pid}] ({cat})")
+    print(f"  text:    {text}")
+    print(f"  cadence: {to_operator_cadence(text)}")
+    print(f"  listen:  {listen_for}")
+
+
+def _interactive_loop(
+    phrases: list[tuple[str, str, str, str]], length_scale: float
+) -> int:
+    """Walk through phrases. Returns exit code."""
     client = get_piper()
     if not client.is_available():
-        print("ERROR: Piper not available. Run `make install-voice` and download the voice model.")
+        print(
+            "ERROR: Piper not available. Run `make install-voice` and "
+            "ensure models/piper/en_US-libritts_r-medium.onnx exists."
+        )
         return 1
 
-    audio_b64 = synthesize_rationale_b64(rationale)
-    if audio_b64 is None:
-        print("ERROR: synthesis returned None.")
-        return 1
+    print(CHECKLIST)
+    print(f"phrases: {len(phrases)}, starting length_scale={length_scale:.2f}")
+    print("controls: [Enter]=next  r=replay  s=slower  f=faster  q=quit\n")
 
-    out = Path(tempfile.gettempdir()) / "tera_demo.wav"
-    out.write_bytes(base64.b64decode(audio_b64))
-    print(f"wrote:    {out} ({out.stat().st_size:,} bytes)")
-    print(f"play:     afplay {out}  # macOS")
+    i = 0
+    while i < len(phrases):
+        phrase = phrases[i]
+        _show_phrase(phrase)
+
+        wav = _synth_to_tempfile(phrase[2], length_scale)
+        if wav is None:
+            print("  ! synth failed, skipping")
+            i += 1
+            continue
+
+        _play(wav)
+        wav.unlink(missing_ok=True)
+
+        try:
+            cmd = input(
+                f"  [{i + 1}/{len(phrases)}] length_scale={length_scale:.2f} > "
+            ).strip().lower()
+        except EOFError:
+            print()
+            return 0
+
+        if cmd == "q":
+            return 0
+        if cmd == "r":
+            continue  # replay same phrase
+        if cmd == "s":
+            length_scale = min(2.0, length_scale + 0.05)
+            # Rebuild client with new length_scale default and play again.
+            reset_piper()
+            from voice import piper_client
+
+            piper_client._client = piper_client.PiperClient(length_scale=length_scale)
+            print(f"  -> length_scale {length_scale:.2f} (slower)")
+            continue
+        if cmd == "f":
+            length_scale = max(0.5, length_scale - 0.05)
+            reset_piper()
+            from voice import piper_client
+
+            piper_client._client = piper_client.PiperClient(length_scale=length_scale)
+            print(f"  -> length_scale {length_scale:.2f} (faster)")
+            continue
+        # Anything else (including blank Enter) -> next phrase
+        i += 1
+
+    print("\nEnd of corpus. Take notes on which phrases need cadence rule fixes.")
     return 0
 
 
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--id", help="run a single phrase by id (e.g. 'prd-A')")
+    p.add_argument(
+        "--category",
+        choices=categories(),
+        help="run all phrases in one category",
+    )
+    p.add_argument("--text", help="custom phrase to synthesize (skips corpus)")
+    p.add_argument(
+        "--rate",
+        type=float,
+        default=1.15,
+        help="length_scale (default 1.15 = ops cadence; 1.0 = piper default)",
+    )
+    p.add_argument("--dry-run", action="store_true", help="print cadence transform only, no audio")
+    p.add_argument("--list", action="store_true", help="list phrases and exit")
+    args = p.parse_args()
+
+    if args.list:
+        for pid, cat, text, _ in PHRASES:
+            print(f"  {pid:12s} ({cat:10s}) {text}")
+        return 0
+
+    # Set the global length_scale for this session.
+    reset_piper()
+    from voice import piper_client
+
+    piper_client._client = piper_client.PiperClient(length_scale=args.rate)
+
+    if args.text:
+        phrases = [("custom", "custom", args.text, "your phrase")]
+    elif args.id:
+        hit = by_id(args.id)
+        if hit is None:
+            print(f"unknown phrase id: {args.id}")
+            print("Use --list to see all ids.")
+            return 1
+        phrases = [hit]
+    elif args.category:
+        phrases = by_category(args.category)
+    else:
+        phrases = list(PHRASES)
+
+    if args.dry_run:
+        for pid, cat, text, _ in phrases:
+            print(f"[{pid}] ({cat})")
+            print(f"  text:    {text}")
+            print(f"  cadence: {to_operator_cadence(text)}")
+        return 0
+
+    return _interactive_loop(phrases, args.rate)
+
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    sys.exit(main())

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -86,7 +86,7 @@ def test_render_includes_reading_first() -> None:
     entry = glossary.explain("HLZ")
     assert entry is not None
     text = glossary.render_explanation_text(entry)
-    assert text.startswith("hotel lima zulu stands for ")
+    assert text.startswith("hotel lee-mah zulu stands for ")
     assert "Helicopter Landing Zone" in text
     assert "rotary-wing landing" in text  # context appended
     assert text.endswith(".")

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -1,0 +1,157 @@
+"""Glossary lookup + explain-text rendering tests.
+
+The glossary is the single source of truth for both:
+  - cadence reading of acronyms in /plan rationales
+  - on-demand explanation when the operator asks "what does X mean"
+
+Anything the orchestrator or voice path renders must be deterministic and
+auditable. These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from voice import glossary
+from voice.tts import synthesize_explanation_b64
+
+# ---------------------------------------------------------------------------
+# Glossary structural invariants
+# ---------------------------------------------------------------------------
+
+
+def test_every_term_has_required_fields() -> None:
+    """Every entry must declare a reading, kind, and full expansion."""
+    for term, entry in glossary.GLOSSARY.items():
+        assert entry.reading, f"{term} missing reading"
+        assert entry.reading_kind in ("spell", "word"), f"{term} bad reading_kind"
+        assert entry.full, f"{term} missing full expansion"
+        # Capitalization sanity: full should start uppercase, term should be uppercase.
+        assert term == term.upper(), f"{term} key must be uppercase"
+
+
+def test_reading_kind_alignment() -> None:
+    """spell-kind readings should be multi-word; word-kind should be single."""
+    for term, entry in glossary.GLOSSARY.items():
+        n_words = len(entry.reading.split())
+        if entry.reading_kind == "spell":
+            assert n_words >= 2, f"{term} spell-kind reading must be multi-word"
+        elif entry.reading_kind == "word":
+            assert n_words == 1, f"{term} word-kind reading must be a single word"
+
+
+def test_known_terms_sorted_alphabetical() -> None:
+    """known_terms() must return alphabetical order for stable UI/help output."""
+    terms = glossary.known_terms()
+    assert terms == sorted(terms)
+
+
+# ---------------------------------------------------------------------------
+# Lookup behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "term,expected_full",
+    [
+        ("HLZ", "Helicopter Landing Zone"),
+        ("hlz", "Helicopter Landing Zone"),  # case-insensitive
+        ("  HLZ  ", "Helicopter Landing Zone"),  # whitespace-tolerant
+        ("CASEVAC", "Casualty Evacuation"),
+        ("ETA", "Estimated Time of Arrival"),
+        ("MEDEVAC", "Medical Evacuation"),
+    ],
+)
+def test_explain_known_terms(term: str, expected_full: str) -> None:
+    entry = glossary.explain(term)
+    assert entry is not None, f"{term} should be in glossary"
+    assert entry.full == expected_full
+
+
+@pytest.mark.parametrize("term", ["", "   ", "XYZZY", "asdf", "PLATYPUS"])
+def test_explain_unknown_terms_returns_none(term: str) -> None:
+    """Unknown terms must return None -- never fabricate a definition."""
+    assert glossary.explain(term) is None
+
+
+# ---------------------------------------------------------------------------
+# Render explanation text
+# ---------------------------------------------------------------------------
+
+
+def test_render_includes_reading_first() -> None:
+    """The reading (what the operator HEARD) leads, then 'stands for'."""
+    entry = glossary.explain("HLZ")
+    assert entry is not None
+    text = glossary.render_explanation_text(entry)
+    assert text.startswith("hotel lima zulu stands for ")
+    assert "Helicopter Landing Zone" in text
+    assert "rotary-wing landing" in text  # context appended
+    assert text.endswith(".")
+
+
+def test_render_no_context_no_trailing_clause() -> None:
+    """When `context` is None, the explanation is just '<reading> stands for <full>.'."""
+    entry = glossary.GLOSSARY["ETA"]  # ETA has no context field
+    text = glossary.render_explanation_text(entry)
+    assert text == "echo tango alpha stands for Estimated Time of Arrival."
+
+
+# ---------------------------------------------------------------------------
+# synthesize_explanation_b64 -- glue path
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_explanation_unknown_returns_none() -> None:
+    """Unknown terms must return None; never call Piper, never invent text."""
+    with patch("voice.tts.get_piper") as mock_get_piper:
+        result = synthesize_explanation_b64("ZZZTOP")
+    assert result is None
+    mock_get_piper.assert_not_called()
+
+
+def test_synthesize_explanation_known_returns_text_when_piper_unavailable() -> None:
+    """Even without Piper, the deterministic explanation TEXT must be returned.
+
+    This is intentional: the operator might be on a degraded device where
+    audio synth fails, but the text-only explanation is still useful (e.g.
+    show in the ATAK panel).
+    """
+    fake = MagicMock()
+    fake.is_available.return_value = False
+    with patch("voice.tts.get_piper", return_value=fake):
+        result = synthesize_explanation_b64("HLZ")
+    assert result is not None
+    assert result["term"] == "HLZ"
+    assert "Helicopter Landing Zone" in result["text"]
+    assert result["audio_b64"] == ""
+    fake.synthesize_wav.assert_not_called()
+
+
+def test_synthesize_explanation_known_returns_audio_when_piper_available() -> None:
+    fake = MagicMock()
+    fake.is_available.return_value = True
+    fake.synthesize_wav.return_value = b"RIFF\x00\x00\x00\x00WAVE_fake"
+    with patch("voice.tts.get_piper", return_value=fake):
+        result = synthesize_explanation_b64("CASEVAC")
+    assert result is not None
+    assert result["term"] == "CASEVAC"
+    assert "Casualty Evacuation" in result["text"]
+    assert result["audio_b64"]  # non-empty
+    # Verify the spoken text begins with the reading (operator-anchored).
+    sent = fake.synthesize_wav.call_args.args[0]
+    assert sent.startswith("case-vac stands for")
+
+
+def test_synthesize_explanation_swallows_piper_errors() -> None:
+    """If Piper raises, we still return the text-only explanation."""
+    fake = MagicMock()
+    fake.is_available.return_value = True
+    fake.synthesize_wav.side_effect = RuntimeError("synth boom")
+    with patch("voice.tts.get_piper", return_value=fake):
+        result = synthesize_explanation_b64("HLZ")
+    assert result is not None
+    assert result["audio_b64"] == ""
+    assert "Helicopter Landing Zone" in result["text"]

--- a/tests/test_orchestrator_tts.py
+++ b/tests/test_orchestrator_tts.py
@@ -1,0 +1,69 @@
+"""End-to-end test that POST /plan?tts=true populates audio_b64 in the response."""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agent.app import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _fake_orchestrate_response(*_args: Any, **_kwargs: Any) -> Any:
+    """Stand-in for orchestrate_plan that the FastAPI handler will see.
+
+    This sidesteps the LLM, security pipeline, and tool dispatch entirely --
+    we're testing the wiring of the `tts` query param + audio_b64 field, not
+    the upstream stages (those have their own tests).
+    """
+    from agent.schemas import PlanResponse, Waypoint
+
+    audio = base64.b64encode(b"RIFF\x00\x00\x00\x00WAVE_fake_audio").decode("ascii")
+    return PlanResponse(
+        request_id="test-req-1",
+        route={"type": "Feature", "geometry": {"type": "LineString", "coordinates": []}},
+        waypoints=[Waypoint(label="origin", lat=37.78, lon=-122.46)],
+        rationale="Routed to Lobos Creek, distance 2.1 kilometers.",
+        cost_breakdown={},
+        trust={"trust_status": "PASS"},
+        signature=None,
+        audio_b64=audio if _kwargs.get("with_tts") else None,
+    )
+
+
+def test_plan_without_tts_omits_audio(client: TestClient) -> None:
+    with patch("agent.app.orchestrate_plan", side_effect=_fake_orchestrate_response):
+        r = client.post(
+            "/plan",
+            json={
+                "prompt": "route to nearest creek",
+                "current": {"lat": 37.78, "lon": -122.46},
+            },
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["audio_b64"] is None
+
+
+def test_plan_with_tts_query_returns_audio(client: TestClient) -> None:
+    with patch("agent.app.orchestrate_plan", side_effect=_fake_orchestrate_response):
+        r = client.post(
+            "/plan?tts=true",
+            json={
+                "prompt": "route to nearest creek",
+                "current": {"lat": 37.78, "lon": -122.46},
+            },
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["audio_b64"] is not None
+    decoded = base64.b64decode(body["audio_b64"])
+    assert decoded.startswith(b"RIFF")

--- a/tests/test_rationale.py
+++ b/tests/test_rationale.py
@@ -39,11 +39,19 @@ _CASES: list[tuple[str, str, str]] = [
         "MGRS with two 4-digit halves",
     ),
 
-    # MGRS grid -- inline 4-digit precision (no space)
+    # MGRS grid -- 4-digit no-space form (1km precision, 2+2 split).
+    # The standard read inserts a beat between easting and northing.
     (
         "Hill at 11SMS1234",
-        "Hill at one one sierra mike sierra one two three four",
-        "MGRS without the second half",
+        "Hill at one one sierra mike sierra one two, three four",
+        "MGRS no-space 4-digit precision (split 2+2)",
+    ),
+
+    # MGRS grid -- 8-digit no-space form (10m precision, 4+4 split).
+    (
+        "Hill at 11SMS12345678.",
+        "Hill at one one sierra mike sierra one two three four, five six seven eight.",
+        "MGRS no-space 8-digit precision",
     ),
 
     # The flagship rationale from PRD §6 (hero scenario A)

--- a/tests/test_rationale.py
+++ b/tests/test_rationale.py
@@ -1,0 +1,86 @@
+"""Operator-cadence transformer tests. Table-driven so adding a rule = adding a row."""
+
+from __future__ import annotations
+
+import pytest
+
+from voice.rationale import to_operator_cadence
+
+# Each entry: (input rationale, expected operator-cadence output, comment).
+_CASES: list[tuple[str, str, str]] = [
+    # Empty / no-op cases
+    ("", "", "empty stays empty"),
+    ("Hello operator.", "Hello operator.", "no numbers, no transform"),
+
+    # Cardinal abbreviations
+    ("Heading NE.", "Heading northeast.", "NE -> northeast"),
+    ("Bearing SW from origin.", "Bearing southwest from origin.", "SW -> southwest"),
+    ("Move NNE through draw.", "Move north-northeast through draw.", "3-letter cardinal"),
+
+    # Decimal expansion
+    ("2.1 kilometers", "two point one kilometers", "decimal expanded"),
+    ("0.5", "zero point five", "leading zero"),
+    ("12.345", "one two point three four five", "multi-digit decimal"),
+
+    # Plain integer expansion (digit-by-digit)
+    ("ETA 38 minutes", "ETA three eight minutes", "two-digit count"),
+    ("over 4 kilometers per hour", "over four kilometers per hour", "single digit"),
+
+    # Unit expansion
+    ("2 km", "two kilometers", "km -> kilometers"),
+    ("4 kph", "four kilometers per hour", "kph -> kilometers per hour"),
+    ("500 m", "five zero zero meters", "m -> meters"),
+
+    # MGRS grid -- single 8-digit precision pair (phonetics are lowercase
+    # because Piper synthesizes the same regardless of case).
+    (
+        "Grid 11SMS1234 5678",
+        "Grid one one sierra mike sierra one two three four, five six seven eight",
+        "MGRS with two 4-digit halves",
+    ),
+
+    # MGRS grid -- inline 4-digit precision (no space)
+    (
+        "Hill at 11SMS1234",
+        "Hill at one one sierra mike sierra one two three four",
+        "MGRS without the second half",
+    ),
+
+    # The flagship rationale from PRD §6 (hero scenario A)
+    (
+        "Routed to Lobos Creek, distance 2.1 kilometers, ETA 38 minutes on foot covered.",
+        (
+            "Routed to Lobos Creek, distance two point one kilometers, "
+            "ETA three eight minutes on foot covered."
+        ),
+        "PRD scenario A canonical rationale",
+    ),
+
+    # Combined: cardinal + decimal + integer
+    (
+        "Selected creek 2.1 km NE; ETA 38 min.",
+        "Selected creek two point one kilometers northeast; ETA three eight min.",
+        "multiple transforms in one string",
+    ),
+]
+
+
+@pytest.mark.parametrize("text,expected,comment", _CASES, ids=[c[2] for c in _CASES])
+def test_operator_cadence_cases(text: str, expected: str, comment: str) -> None:
+    actual = to_operator_cadence(text)
+    assert actual == expected, f"{comment}: {actual!r} != {expected!r}"
+
+
+def test_idempotent_on_already_spoken_form() -> None:
+    """Running the transformer twice should not change the output further.
+    (Defensive: catches accidental double-substitution bugs.)"""
+    text = "Routed to Lobos Creek, distance 2.1 kilometers, ETA 38 minutes."
+    once = to_operator_cadence(text)
+    twice = to_operator_cadence(once)
+    assert twice == once, "transformer is not idempotent"
+
+
+def test_preserves_no_number_text() -> None:
+    """Strings without numbers / cardinals / units should pass through cleanly."""
+    text = "Operator approved. Standby for confirmation."
+    assert to_operator_cadence(text) == text

--- a/tests/test_rationale.py
+++ b/tests/test_rationale.py
@@ -23,7 +23,7 @@ _CASES: list[tuple[str, str, str]] = [
     ("12.345", "one two point three four five", "multi-digit decimal"),
 
     # Plain integer expansion (digit-by-digit)
-    ("ETA 38 minutes", "E T A three eight minutes", "two-digit count + acronym"),
+    ("ETA 38 minutes", "echo tango alpha three eight minutes", "two-digit count + acronym"),
     ("over 4 kilometers per hour", "over four kilometers per hour", "single digit"),
 
     # Unit expansion
@@ -54,24 +54,24 @@ _CASES: list[tuple[str, str, str]] = [
         "MGRS no-space 8-digit precision",
     ),
 
-    # Acronym expansion -- spelled letter-by-letter.
+    # Acronym expansion -- NATO phonetic (Piper-safe; can't swallow letters).
     (
         "ETA 5 minutes.",
-        "E T A five minutes.",
-        "ETA -> 'E T A'",
+        "echo tango alpha five minutes.",
+        "ETA -> 'echo tango alpha'",
     ),
     (
         "HLZ at grid 11SMS1234.",
-        "H L Z at grid one one sierra, mike, sierra one two, three four.",
-        "HLZ -> 'H L Z'",
+        "hotel lima zulu at grid one one sierra, mike, sierra one two, three four.",
+        "HLZ -> 'hotel lima zulu'",
     ),
     (
         "Identify CP and TOC.",
-        "Identify C P and T O C.",
-        "multiple acronyms in one line",
+        "Identify charlie papa and tock.",
+        "multiple acronyms in one line (mix of spell + word forms)",
     ),
 
-    # Acronym expansion -- read as a word with hyphen hint.
+    # Acronym expansion -- read as a word with hyphen hint or natural syllables.
     (
         "CASEVAC inbound.",
         "case-vac inbound.",
@@ -86,7 +86,7 @@ _CASES: list[tuple[str, str, str]] = [
     # Clause-comma promotion -- ', ETA' -> '. ETA' for radio cadence.
     (
         "Distance 2.1 km, ETA 38 minutes.",
-        "Distance two point one kilometers. E T A three eight minutes.",
+        "Distance two point one kilometers. echo tango alpha three eight minutes.",
         "comma before ETA promoted to period",
     ),
     (
@@ -97,12 +97,13 @@ _CASES: list[tuple[str, str, str]] = [
 
     # The flagship rationale from PRD §6 (hero scenario A). Note: ', distance'
     # is also promoted to '. distance' (clause-comma rule), and ', ETA' to
-    # '. ETA'. Result: three full-sentence beats between the elements.
+    # '. ETA'. Result: three full-sentence beats between the elements, ETA
+    # spelled out NATO-phonetic.
     (
         "Routed to Lobos Creek, distance 2.1 kilometers, ETA 38 minutes on foot covered.",
         (
             "Routed to Lobos Creek. distance two point one kilometers. "
-            "E T A three eight minutes on foot covered."
+            "echo tango alpha three eight minutes on foot covered."
         ),
         "PRD scenario A canonical rationale",
     ),
@@ -111,7 +112,7 @@ _CASES: list[tuple[str, str, str]] = [
     # not promoted -- the rule only promotes ', ' (comma+space) before cues.
     (
         "Selected creek 2.1 km NE; ETA 38 min.",
-        "Selected creek two point one kilometers northeast; E T A three eight min.",
+        "Selected creek two point one kilometers northeast; echo tango alpha three eight min.",
         "multiple transforms in one string",
     ),
 ]

--- a/tests/test_rationale.py
+++ b/tests/test_rationale.py
@@ -23,7 +23,7 @@ _CASES: list[tuple[str, str, str]] = [
     ("12.345", "one two point three four five", "multi-digit decimal"),
 
     # Plain integer expansion (digit-by-digit)
-    ("ETA 38 minutes", "ETA three eight minutes", "two-digit count"),
+    ("ETA 38 minutes", "E T A three eight minutes", "two-digit count + acronym"),
     ("over 4 kilometers per hour", "over four kilometers per hour", "single digit"),
 
     # Unit expansion
@@ -31,11 +31,11 @@ _CASES: list[tuple[str, str, str]] = [
     ("4 kph", "four kilometers per hour", "kph -> kilometers per hour"),
     ("500 m", "five zero zero meters", "m -> meters"),
 
-    # MGRS grid -- single 8-digit precision pair (phonetics are lowercase
-    # because Piper synthesizes the same regardless of case).
+    # MGRS grid -- single 8-digit precision pair. Phonetic letters comma-
+    # separated so 'sierra mike sierra' doesn't slur (op note 17:03 #4).
     (
         "Grid 11SMS1234 5678",
-        "Grid one one sierra mike sierra one two three four, five six seven eight",
+        "Grid one one sierra, mike, sierra one two three four, five six seven eight",
         "MGRS with two 4-digit halves",
     ),
 
@@ -43,31 +43,75 @@ _CASES: list[tuple[str, str, str]] = [
     # The standard read inserts a beat between easting and northing.
     (
         "Hill at 11SMS1234",
-        "Hill at one one sierra mike sierra one two, three four",
+        "Hill at one one sierra, mike, sierra one two, three four",
         "MGRS no-space 4-digit precision (split 2+2)",
     ),
 
     # MGRS grid -- 8-digit no-space form (10m precision, 4+4 split).
     (
         "Hill at 11SMS12345678.",
-        "Hill at one one sierra mike sierra one two three four, five six seven eight.",
+        "Hill at one one sierra, mike, sierra one two three four, five six seven eight.",
         "MGRS no-space 8-digit precision",
     ),
 
-    # The flagship rationale from PRD §6 (hero scenario A)
+    # Acronym expansion -- spelled letter-by-letter.
+    (
+        "ETA 5 minutes.",
+        "E T A five minutes.",
+        "ETA -> 'E T A'",
+    ),
+    (
+        "HLZ at grid 11SMS1234.",
+        "H L Z at grid one one sierra, mike, sierra one two, three four.",
+        "HLZ -> 'H L Z'",
+    ),
+    (
+        "Identify CP and TOC.",
+        "Identify C P and T O C.",
+        "multiple acronyms in one line",
+    ),
+
+    # Acronym expansion -- read as a word with hyphen hint.
+    (
+        "CASEVAC inbound.",
+        "case-vac inbound.",
+        "CASEVAC -> 'case-vac'",
+    ),
+    (
+        "MEDEVAC requested.",
+        "med-evac requested.",
+        "MEDEVAC -> 'med-evac'",
+    ),
+
+    # Clause-comma promotion -- ', ETA' -> '. ETA' for radio cadence.
+    (
+        "Distance 2.1 km, ETA 38 minutes.",
+        "Distance two point one kilometers. E T A three eight minutes.",
+        "comma before ETA promoted to period",
+    ),
+    (
+        "Hold position, bearing 270, range 800 meters.",
+        "Hold position. bearing two seven zero. range eight zero zero meters.",
+        "commas before bearing/range promoted",
+    ),
+
+    # The flagship rationale from PRD §6 (hero scenario A). Note: ', distance'
+    # is also promoted to '. distance' (clause-comma rule), and ', ETA' to
+    # '. ETA'. Result: three full-sentence beats between the elements.
     (
         "Routed to Lobos Creek, distance 2.1 kilometers, ETA 38 minutes on foot covered.",
         (
-            "Routed to Lobos Creek, distance two point one kilometers, "
-            "ETA three eight minutes on foot covered."
+            "Routed to Lobos Creek. distance two point one kilometers. "
+            "E T A three eight minutes on foot covered."
         ),
         "PRD scenario A canonical rationale",
     ),
 
-    # Combined: cardinal + decimal + integer
+    # Combined: cardinal + decimal + integer + acronym. Note '; ETA' is
+    # not promoted -- the rule only promotes ', ' (comma+space) before cues.
     (
         "Selected creek 2.1 km NE; ETA 38 min.",
-        "Selected creek two point one kilometers northeast; ETA three eight min.",
+        "Selected creek two point one kilometers northeast; E T A three eight min.",
         "multiple transforms in one string",
     ),
 ]

--- a/tests/test_rationale.py
+++ b/tests/test_rationale.py
@@ -62,8 +62,8 @@ _CASES: list[tuple[str, str, str]] = [
     ),
     (
         "HLZ at grid 11SMS1234.",
-        "hotel lima zulu at grid one one sierra, mike, sierra one two, three four.",
-        "HLZ -> 'hotel lima zulu'",
+        "hotel lee-mah zulu at grid one one sierra, mike, sierra one two, three four.",
+        "HLZ -> 'hotel lee-mah zulu' (lima syllable-hint)",
     ),
     (
         "Identify CP and TOC.",

--- a/tests/test_rationale.py
+++ b/tests/test_rationale.py
@@ -11,26 +11,21 @@ _CASES: list[tuple[str, str, str]] = [
     # Empty / no-op cases
     ("", "", "empty stays empty"),
     ("Hello operator.", "Hello operator.", "no numbers, no transform"),
-
     # Cardinal abbreviations
     ("Heading NE.", "Heading northeast.", "NE -> northeast"),
     ("Bearing SW from origin.", "Bearing southwest from origin.", "SW -> southwest"),
     ("Move NNE through draw.", "Move north-northeast through draw.", "3-letter cardinal"),
-
     # Decimal expansion
     ("2.1 kilometers", "two point one kilometers", "decimal expanded"),
     ("0.5", "zero point five", "leading zero"),
     ("12.345", "one two point three four five", "multi-digit decimal"),
-
     # Plain integer expansion (digit-by-digit)
     ("ETA 38 minutes", "echo tango alpha three eight minutes", "two-digit count + acronym"),
     ("over 4 kilometers per hour", "over four kilometers per hour", "single digit"),
-
     # Unit expansion
     ("2 km", "two kilometers", "km -> kilometers"),
     ("4 kph", "four kilometers per hour", "kph -> kilometers per hour"),
     ("500 m", "five zero zero meters", "m -> meters"),
-
     # MGRS grid -- single 8-digit precision pair. Phonetic letters comma-
     # separated so 'sierra mike sierra' doesn't slur (op note 17:03 #4).
     (
@@ -38,7 +33,6 @@ _CASES: list[tuple[str, str, str]] = [
         "Grid one one sierra, mike, sierra one two three four, five six seven eight",
         "MGRS with two 4-digit halves",
     ),
-
     # MGRS grid -- 4-digit no-space form (1km precision, 2+2 split).
     # The standard read inserts a beat between easting and northing.
     (
@@ -46,14 +40,12 @@ _CASES: list[tuple[str, str, str]] = [
         "Hill at one one sierra, mike, sierra one two, three four",
         "MGRS no-space 4-digit precision (split 2+2)",
     ),
-
     # MGRS grid -- 8-digit no-space form (10m precision, 4+4 split).
     (
         "Hill at 11SMS12345678.",
         "Hill at one one sierra, mike, sierra one two three four, five six seven eight.",
         "MGRS no-space 8-digit precision",
     ),
-
     # Acronym expansion -- NATO phonetic (Piper-safe; can't swallow letters).
     (
         "ETA 5 minutes.",
@@ -70,7 +62,6 @@ _CASES: list[tuple[str, str, str]] = [
         "Identify charlie papa and tock.",
         "multiple acronyms in one line (mix of spell + word forms)",
     ),
-
     # Acronym expansion -- read as a word with hyphen hint or natural syllables.
     (
         "CASEVAC inbound.",
@@ -82,7 +73,6 @@ _CASES: list[tuple[str, str, str]] = [
         "med-evac requested.",
         "MEDEVAC -> 'med-evac'",
     ),
-
     # Clause-comma promotion -- ', ETA' -> '. ETA' for radio cadence.
     (
         "Distance 2.1 km, ETA 38 minutes.",
@@ -94,7 +84,6 @@ _CASES: list[tuple[str, str, str]] = [
         "Hold position. bearing two seven zero. range eight zero zero meters.",
         "commas before bearing/range promoted",
     ),
-
     # The flagship rationale from PRD §6 (hero scenario A). Note: ', distance'
     # is also promoted to '. distance' (clause-comma rule), and ', ETA' to
     # '. ETA'. Result: three full-sentence beats between the elements, ETA
@@ -107,7 +96,6 @@ _CASES: list[tuple[str, str, str]] = [
         ),
         "PRD scenario A canonical rationale",
     ),
-
     # Combined: cardinal + decimal + integer + acronym. Note '; ETA' is
     # not promoted -- the rule only promotes ', ' (comma+space) before cues.
     (

--- a/tests/test_voice_piper.py
+++ b/tests/test_voice_piper.py
@@ -1,0 +1,172 @@
+"""Tests for voice/piper_client.py and voice/tts.py.
+
+These mock the actual Piper synth (slow, large model) so they run in <1s
+without requiring the .onnx file to be present. A separate manual smoke
+test (run by Jon Sat 2200, not in CI) verifies real synth on the Jetson.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import wave
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from voice import piper_client, tts
+
+
+@pytest.fixture(autouse=True)
+def _reset_piper_singleton() -> Iterator[None]:
+    piper_client.reset_piper()
+    yield
+    piper_client.reset_piper()
+
+
+def _fake_piper_voice(sample_rate: int = 22050) -> MagicMock:
+    """A MagicMock that quacks like piper.PiperVoice."""
+    voice = MagicMock()
+    voice.config = MagicMock(sample_rate=sample_rate)
+
+    # synthesize_wav writes silent PCM frames into the wave file so the wrapper's
+    # io.BytesIO ends up with a structurally-valid WAV.
+    def _synth_wav(text: str, wav_writer: wave.Wave_write) -> None:
+        n_frames = max(1000, len(text) * 100)
+        wav_writer.writeframes(b"\x00\x00" * n_frames)
+
+    voice.synthesize_wav = MagicMock(side_effect=_synth_wav)
+    return voice
+
+
+def test_is_available_false_when_no_model(tmp_path: Path) -> None:
+    """If the model file doesn't exist, is_available() returns False even if piper is installed."""
+    client = piper_client.PiperClient(model_path=tmp_path / "missing.onnx")
+    # is_available() requires both the package AND the model file. Whether
+    # piper is importable depends on the test env; we just check the model
+    # missing case returns False regardless.
+    assert client.is_available() is False
+
+
+def test_load_raises_when_model_missing(tmp_path: Path) -> None:
+    client = piper_client.PiperClient(model_path=tmp_path / "missing.onnx")
+    with (
+        patch.dict("sys.modules", {"piper": MagicMock()}),
+        pytest.raises(RuntimeError, match="not found"),
+    ):
+        client.load()
+
+
+def test_synthesize_wav_returns_valid_wav_bytes(tmp_path: Path) -> None:
+    """Mock PiperVoice.synthesize_wav. Assert the wrapper produces a valid WAV."""
+    fake_model = tmp_path / "fake.onnx"
+    fake_model.touch()  # exist check passes
+
+    fake_voice = _fake_piper_voice(sample_rate=22050)
+    fake_module = MagicMock()
+    fake_module.PiperVoice.load.return_value = fake_voice
+
+    with patch.dict("sys.modules", {"piper": fake_module}):
+        client = piper_client.PiperClient(model_path=fake_model)
+        wav_bytes = client.synthesize_wav("hello operator")
+
+    # Validate: WAV header magic + readable via wave module.
+    assert wav_bytes[:4] == b"RIFF"
+    assert wav_bytes[8:12] == b"WAVE"
+    with wave.open(io.BytesIO(wav_bytes), "rb") as r:
+        assert r.getnchannels() == 1
+        assert r.getsampwidth() == 2
+        assert r.getframerate() == 22050
+
+
+def test_synthesize_wav_tries_legacy_method_name(tmp_path: Path) -> None:
+    """Older piper-tts versions exposed `synthesize`, not `synthesize_wav`.
+    Wrapper falls back to it. (Defensive against version drift.)"""
+    fake_model = tmp_path / "fake.onnx"
+    fake_model.touch()
+
+    voice = MagicMock()
+    voice.config = MagicMock(sample_rate=16000)
+
+    # Drop the new-style method so the wrapper falls back to old style.
+    del voice.synthesize_wav
+
+    def _legacy_synth(text: str, wav_writer: wave.Wave_write) -> None:
+        wav_writer.writeframes(b"\x00\x00" * 100)
+
+    voice.synthesize = MagicMock(side_effect=_legacy_synth)
+
+    fake_module = MagicMock()
+    fake_module.PiperVoice.load.return_value = voice
+
+    with patch.dict("sys.modules", {"piper": fake_module}):
+        client = piper_client.PiperClient(model_path=fake_model)
+        wav_bytes = client.synthesize_wav("hello")
+
+    voice.synthesize.assert_called_once()
+    assert wav_bytes[:4] == b"RIFF"
+
+
+def test_get_piper_singleton() -> None:
+    a = piper_client.get_piper()
+    b = piper_client.get_piper()
+    assert a is b
+
+
+# ---------------------------------------------------------------------------
+# voice.tts -- glue layer
+# ---------------------------------------------------------------------------
+
+
+def test_synthesize_rationale_returns_none_for_empty() -> None:
+    assert tts.synthesize_rationale_b64("") is None
+
+
+def test_synthesize_rationale_returns_none_when_piper_unavailable() -> None:
+    """If Piper isn't available, return None and let the orchestrator fall back."""
+    fake_client = MagicMock()
+    fake_client.is_available.return_value = False
+    with patch("voice.tts.get_piper", return_value=fake_client):
+        result = tts.synthesize_rationale_b64("Routed to Lobos Creek, 2.1 km.")
+    assert result is None
+    fake_client.synthesize_wav.assert_not_called()
+
+
+def test_synthesize_rationale_b64_calls_piper_with_cadence(tmp_path: Path) -> None:
+    """When Piper IS available, the rationale is cadence-transformed first
+    THEN synthesized -- not the raw English."""
+    fake_client = MagicMock()
+    fake_client.is_available.return_value = True
+    fake_client.synthesize_wav.return_value = b"RIFF\x00\x00\x00\x00WAVEfake"
+
+    with patch("voice.tts.get_piper", return_value=fake_client):
+        result = tts.synthesize_rationale_b64(
+            "Routed to Lobos Creek, distance 2.1 km, ETA 38 minutes."
+        )
+
+    assert result is not None
+    decoded = base64.b64decode(result)
+    assert decoded.startswith(b"RIFF")
+
+    # Verify Piper got the cadence-transformed text, not the raw English.
+    call_args = fake_client.synthesize_wav.call_args
+    spoken_text = call_args.args[0] if call_args.args else call_args.kwargs.get("text", "")
+    assert "two point one" in spoken_text
+    assert "three eight" in spoken_text
+    assert "kilometers" in spoken_text
+    # Raw forms should be GONE from the spoken text.
+    assert "2.1" not in spoken_text
+    assert "38 minutes" not in spoken_text
+
+
+def test_synthesize_rationale_swallows_synth_errors() -> None:
+    """If Piper raises during synth, return None -- never propagate to /plan caller."""
+    fake_client = MagicMock()
+    fake_client.is_available.return_value = True
+    fake_client.synthesize_wav.side_effect = RuntimeError("synth boom")
+
+    with patch("voice.tts.get_piper", return_value=fake_client):
+        result = tts.synthesize_rationale_b64("anything")
+    assert result is None

--- a/tests/test_voice_piper.py
+++ b/tests/test_voice_piper.py
@@ -32,8 +32,11 @@ def _fake_piper_voice(sample_rate: int = 22050) -> MagicMock:
     voice.config = MagicMock(sample_rate=sample_rate)
 
     # synthesize_wav writes silent PCM frames into the wave file so the wrapper's
-    # io.BytesIO ends up with a structurally-valid WAV.
-    def _synth_wav(text: str, wav_writer: wave.Wave_write) -> None:
+    # io.BytesIO ends up with a structurally-valid WAV. Accepts syn_config kwarg
+    # because piper-tts >=1.3 wrapper passes one in.
+    def _synth_wav(
+        text: str, wav_writer: wave.Wave_write, syn_config: object = None
+    ) -> None:
         n_frames = max(1000, len(text) * 100)
         wav_writer.writeframes(b"\x00\x00" * n_frames)
 
@@ -93,7 +96,9 @@ def test_synthesize_wav_tries_legacy_method_name(tmp_path: Path) -> None:
     # Drop the new-style method so the wrapper falls back to old style.
     del voice.synthesize_wav
 
-    def _legacy_synth(text: str, wav_writer: wave.Wave_write) -> None:
+    def _legacy_synth(
+        text: str, wav_writer: wave.Wave_write, syn_config: object = None
+    ) -> None:
         wav_writer.writeframes(b"\x00\x00" * 100)
 
     voice.synthesize = MagicMock(side_effect=_legacy_synth)

--- a/tests/test_voice_piper.py
+++ b/tests/test_voice_piper.py
@@ -34,9 +34,7 @@ def _fake_piper_voice(sample_rate: int = 22050) -> MagicMock:
     # synthesize_wav writes silent PCM frames into the wave file so the wrapper's
     # io.BytesIO ends up with a structurally-valid WAV. Accepts syn_config kwarg
     # because piper-tts >=1.3 wrapper passes one in.
-    def _synth_wav(
-        text: str, wav_writer: wave.Wave_write, syn_config: object = None
-    ) -> None:
+    def _synth_wav(text: str, wav_writer: wave.Wave_write, syn_config: object = None) -> None:
         n_frames = max(1000, len(text) * 100)
         wav_writer.writeframes(b"\x00\x00" * n_frames)
 
@@ -96,9 +94,7 @@ def test_synthesize_wav_tries_legacy_method_name(tmp_path: Path) -> None:
     # Drop the new-style method so the wrapper falls back to old style.
     del voice.synthesize_wav
 
-    def _legacy_synth(
-        text: str, wav_writer: wave.Wave_write, syn_config: object = None
-    ) -> None:
+    def _legacy_synth(text: str, wav_writer: wave.Wave_write, syn_config: object = None) -> None:
         wav_writer.writeframes(b"\x00\x00" * 100)
 
     voice.synthesize = MagicMock(side_effect=_legacy_synth)

--- a/voice/__init__.py
+++ b/voice/__init__.py
@@ -1,18 +1,25 @@
 """TERA voice path: Whisper-tiny (in) + Piper TTS (out).
 
-This package converts the orchestrator's plain-English rationale into
-operator-cadence speech, then synthesizes audio via Piper TTS for
-hands-free output to the operator's headset (PRD §6 hero scenario).
+Converts the orchestrator's plain-English rationale into operator-cadence
+speech, synthesizes audio via Piper TTS for hands-free output (PRD §6
+hero scenario), and provides a deterministic glossary explain path for
+on-demand acronym disambiguation.
 """
 
+from voice.glossary import GLOSSARY, GlossaryEntry, explain, known_terms
 from voice.piper_client import PiperClient, get_piper, reset_piper
 from voice.rationale import to_operator_cadence
-from voice.tts import synthesize_rationale_b64
+from voice.tts import synthesize_explanation_b64, synthesize_rationale_b64
 
 __all__ = [
+    "GLOSSARY",
+    "GlossaryEntry",
     "PiperClient",
+    "explain",
     "get_piper",
+    "known_terms",
     "reset_piper",
+    "synthesize_explanation_b64",
     "synthesize_rationale_b64",
     "to_operator_cadence",
 ]

--- a/voice/__init__.py
+++ b/voice/__init__.py
@@ -1,0 +1,18 @@
+"""TERA voice path: Whisper-tiny (in) + Piper TTS (out).
+
+This package converts the orchestrator's plain-English rationale into
+operator-cadence speech, then synthesizes audio via Piper TTS for
+hands-free output to the operator's headset (PRD §6 hero scenario).
+"""
+
+from voice.piper_client import PiperClient, get_piper, reset_piper
+from voice.rationale import to_operator_cadence
+from voice.tts import synthesize_rationale_b64
+
+__all__ = [
+    "PiperClient",
+    "get_piper",
+    "reset_piper",
+    "synthesize_rationale_b64",
+    "to_operator_cadence",
+]

--- a/voice/glossary.py
+++ b/voice/glossary.py
@@ -63,8 +63,7 @@ GLOSSARY: dict[str, GlossaryEntry] = {
         reading="alpha oscar",
         reading_kind="spell",
         full="Area of Operations",
-        context="the geographic area assigned to a unit for the conduct of "
-        "operations",
+        context="the geographic area assigned to a unit for the conduct of operations",
         source="JP 3-0",
     ),
     "CASEVAC": GlossaryEntry(
@@ -78,8 +77,7 @@ GLOSSARY: dict[str, GlossaryEntry] = {
         reading="charlie papa",
         reading_kind="spell",
         full="Checkpoint",
-        context="a predetermined point used as a reference for control of "
-        "movement",
+        context="a predetermined point used as a reference for control of movement",
     ),
     "EOD": GlossaryEntry(
         reading="echo oscar delta",
@@ -119,8 +117,7 @@ GLOSSARY: dict[str, GlossaryEntry] = {
         reading="med-evac",
         reading_kind="word",
         full="Medical Evacuation",
-        context="evacuation by a dedicated medical platform with "
-        "en-route care",
+        context="evacuation by a dedicated medical platform with en-route care",
         source="ATP 4-02.2",
     ),
     "MGRS": GlossaryEntry(
@@ -144,8 +141,7 @@ GLOSSARY: dict[str, GlossaryEntry] = {
         reading="papa zulu",
         reading_kind="spell",
         full="Pickup Zone",
-        context="a designated location for the pickup of personnel or "
-        "equipment by aircraft",
+        context="a designated location for the pickup of personnel or equipment by aircraft",
     ),
     "QRF": GlossaryEntry(
         reading="quebec romeo foxtrot",

--- a/voice/glossary.py
+++ b/voice/glossary.py
@@ -1,0 +1,216 @@
+"""Operator acronym glossary -- single source of truth for both the
+default cadence reading AND the on-demand explain path.
+
+Two readers consume this:
+  - voice.rationale uses the `reading` field to render acronyms inside
+    a normal /plan rationale (default cadence, fast).
+  - voice.tts.synthesize_explanation_b64 uses `full` + `context` to
+    speak a deterministic explanation when the operator asks
+    "what does HLZ mean".
+
+Why deterministic (no LLM):
+  - Adding/changing an acronym updates both reading and explain
+    simultaneously -- no drift.
+  - No hallucination risk on the explain path. If a term isn't in this
+    file, the system says so honestly instead of guessing.
+  - The full file is auditable in source control. JAG / event organizer
+    can read it and confirm no classified content.
+
+Editorial guardrail:
+  - Use only **publicly doctrinal definitions**. No classified TTPs.
+  - Cite the doctrine source in `source` when one exists -- belt-and-
+    suspenders for the SUBMISSION_NOTES.md OPSEC posture.
+  - Keep `context` to one declarative sentence; this is what an
+    operator hears when they ask for an explanation, not a tutorial.
+
+Adding a term:
+  1. Pick `reading_kind`:
+       'spell' -> NATO phonetic ("hotel lima zulu"). Use for any
+                  acronym that operators read as separate letters on
+                  net. Required for any acronym ending in a single
+                  vowel (Piper drops trailing solo letters).
+       'word'  -> single pronounceable word ("case-vac", "tock").
+                  Use ONLY when operators universally pronounce it as
+                  a word, not as letters.
+  2. Set `reading` to what Piper should literally say.
+  3. Set `full` to the canonical capitalized expansion.
+  4. Optional `context`: one short sentence ("an area suitable for
+     rotary-wing landing"). Spoken after `full` in explain mode.
+  5. Optional `source`: doctrinal reference (e.g. "ATP 4-02.2").
+"""
+
+from __future__ import annotations
+
+from typing import Literal, NamedTuple
+
+ReadingKind = Literal["spell", "word"]
+
+
+class GlossaryEntry(NamedTuple):
+    reading: str  # what Piper actually pronounces
+    reading_kind: ReadingKind
+    full: str  # canonical expansion
+    context: str | None = None
+    source: str | None = None  # doctrinal cite if applicable
+
+
+# ---------------------------------------------------------------------------
+# The glossary. Keep alphabetical for diff-readability.
+# ---------------------------------------------------------------------------
+
+GLOSSARY: dict[str, GlossaryEntry] = {
+    "AO": GlossaryEntry(
+        reading="alpha oscar",
+        reading_kind="spell",
+        full="Area of Operations",
+        context="the geographic area assigned to a unit for the conduct of "
+        "operations",
+        source="JP 3-0",
+    ),
+    "CASEVAC": GlossaryEntry(
+        reading="case-vac",
+        reading_kind="word",
+        full="Casualty Evacuation",
+        context="non-medical evacuation of a casualty by available transport",
+        source="ATP 4-02.2",
+    ),
+    "CP": GlossaryEntry(
+        reading="charlie papa",
+        reading_kind="spell",
+        full="Checkpoint",
+        context="a predetermined point used as a reference for control of "
+        "movement",
+    ),
+    "EOD": GlossaryEntry(
+        reading="echo oscar delta",
+        reading_kind="spell",
+        full="Explosive Ordnance Disposal",
+        context="the detection, identification, evaluation, render-safe, and "
+        "disposal of explosive ordnance",
+        source="JP 3-42",
+    ),
+    "ETA": GlossaryEntry(
+        reading="echo tango alpha",
+        reading_kind="spell",
+        full="Estimated Time of Arrival",
+    ),
+    "HLZ": GlossaryEntry(
+        reading="hotel lima zulu",
+        reading_kind="spell",
+        full="Helicopter Landing Zone",
+        context="an area suitable for rotary-wing landing",
+        source="ATP 3-04.1",
+    ),
+    "IED": GlossaryEntry(
+        reading="india echo delta",
+        reading_kind="spell",
+        full="Improvised Explosive Device",
+        source="JP 3-15.1",
+    ),
+    "LZ": GlossaryEntry(
+        reading="lima zulu",
+        reading_kind="spell",
+        full="Landing Zone",
+        context="a specified ground area for landing aircraft",
+    ),
+    "MEDEVAC": GlossaryEntry(
+        reading="med-evac",
+        reading_kind="word",
+        full="Medical Evacuation",
+        context="evacuation by a dedicated medical platform with "
+        "en-route care",
+        source="ATP 4-02.2",
+    ),
+    "MGRS": GlossaryEntry(
+        reading="mike golf romeo sierra",
+        reading_kind="spell",
+        full="Military Grid Reference System",
+        context="the geocoordinate standard used by NATO militaries",
+    ),
+    "OP": GlossaryEntry(
+        reading="oscar papa",
+        reading_kind="spell",
+        full="Observation Post",
+        context="a position from which observation is conducted",
+    ),
+    "POI": GlossaryEntry(
+        reading="papa oscar india",
+        reading_kind="spell",
+        full="Point of Interest",
+    ),
+    "PZ": GlossaryEntry(
+        reading="papa zulu",
+        reading_kind="spell",
+        full="Pickup Zone",
+        context="a designated location for the pickup of personnel or "
+        "equipment by aircraft",
+    ),
+    "QRF": GlossaryEntry(
+        reading="quebec romeo foxtrot",
+        reading_kind="spell",
+        full="Quick Reaction Force",
+        context="a designated unit on standby for rapid response",
+    ),
+    "RECON": GlossaryEntry(
+        reading="ree-kon",
+        reading_kind="word",
+        full="Reconnaissance",
+    ),
+    "TOC": GlossaryEntry(
+        reading="tock",
+        reading_kind="word",
+        full="Tactical Operations Center",
+        context="the principal command and control node for a unit",
+    ),
+    "TRP": GlossaryEntry(
+        reading="tango romeo papa",
+        reading_kind="spell",
+        full="Target Reference Point",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Public lookup helpers
+# ---------------------------------------------------------------------------
+
+
+def explain(term: str) -> GlossaryEntry | None:
+    """Look up a glossary entry by term, case-insensitive.
+
+    Returns None if the term isn't known. Callers should treat that as
+    "not in glossary" and respond honestly to the operator instead of
+    fabricating a definition.
+    """
+    if not term:
+        return None
+    return GLOSSARY.get(term.strip().upper())
+
+
+def known_terms() -> list[str]:
+    """Sorted list of every glossary key. For UI/help/debug."""
+    return sorted(GLOSSARY.keys())
+
+
+def acronym_readings_spell() -> dict[str, str]:
+    """Mapping of {term -> NATO-phonetic reading} for cadence transforms."""
+    return {k: v.reading for k, v in GLOSSARY.items() if v.reading_kind == "spell"}
+
+
+def acronym_readings_word() -> dict[str, str]:
+    """Mapping of {term -> word-form reading} for cadence transforms."""
+    return {k: v.reading for k, v in GLOSSARY.items() if v.reading_kind == "word"}
+
+
+def render_explanation_text(entry: GlossaryEntry) -> str:
+    """Build the spoken-explanation string from a glossary entry.
+
+    Format: '<reading> stands for <full>[, <context>].'
+
+    The leading `reading` is what the operator HEARD that they're asking
+    about; placing it first acknowledges their query before defining it.
+    """
+    text = f"{entry.reading} stands for {entry.full}"
+    if entry.context:
+        text = f"{text}, {entry.context}"
+    return text + "."

--- a/voice/glossary.py
+++ b/voice/glossary.py
@@ -95,7 +95,9 @@ GLOSSARY: dict[str, GlossaryEntry] = {
         full="Estimated Time of Arrival",
     ),
     "HLZ": GlossaryEntry(
-        reading="hotel lima zulu",
+        # 'lima' alone gets the trailing-vowel swallow; 'lee-mah' forces both
+        # syllables (op note 17:41). Same trick as case-vac / med-evac.
+        reading="hotel lee-mah zulu",
         reading_kind="spell",
         full="Helicopter Landing Zone",
         context="an area suitable for rotary-wing landing",
@@ -108,7 +110,7 @@ GLOSSARY: dict[str, GlossaryEntry] = {
         source="JP 3-15.1",
     ),
     "LZ": GlossaryEntry(
-        reading="lima zulu",
+        reading="lee-mah zulu",
         reading_kind="spell",
         full="Landing Zone",
         context="a specified ground area for landing aircraft",

--- a/voice/phrases.py
+++ b/voice/phrases.py
@@ -36,7 +36,6 @@ PHRASES: list[tuple[str, str, str, str]] = [
         "Acknowledge receipt and move on my mark.",
         "no numbers; pure prosody check",
     ),
-
     # ---- bearings & ranges --------------------------------------------
     (
         "bearing-01",
@@ -62,7 +61,6 @@ PHRASES: list[tuple[str, str, str, str]] = [
         "From here, bearing 359, range 50 meters.",
         "near-360 bearing -- still digit-by-digit",
     ),
-
     # ---- MGRS grids ---------------------------------------------------
     (
         "mgrs-01",
@@ -82,7 +80,6 @@ PHRASES: list[tuple[str, str, str, str]] = [
         "Hill at 11SMS12345678.",
         "MGRS without space-separated halves",
     ),
-
     # ---- units --------------------------------------------------------
     (
         "units-01",
@@ -102,7 +99,6 @@ PHRASES: list[tuple[str, str, str, str]] = [
         "Altitude 1250 meters, descent 200 meters per minute.",
         "longer numbers digit-by-digit; trailing unit",
     ),
-
     # ---- homophone hazards --------------------------------------------
     (
         "homo-01",
@@ -122,7 +118,6 @@ PHRASES: list[tuple[str, str, str, str]] = [
         "3 contacts at 300 meters bearing 030.",
         "'three' said three different ways (count, range, bearing)",
     ),
-
     # ---- compound directions -----------------------------------------
     (
         "compound-01",
@@ -136,7 +131,6 @@ PHRASES: list[tuple[str, str, str, str]] = [
         "Primary route NW, alternate route SSW, contingency due south.",
         "three cardinals in one sentence",
     ),
-
     # ---- mission narration -------------------------------------------
     (
         "mission-01",
@@ -168,7 +162,6 @@ PHRASES: list[tuple[str, str, str, str]] = [
         "Danger close, 50 meters, friendly mark north.",
         "'danger close' should NOT get glossed over",
     ),
-
     # ---- ambiguous / tricky -------------------------------------------
     (
         "amb-01",
@@ -188,7 +181,6 @@ PHRASES: list[tuple[str, str, str, str]] = [
         "0.9 kilometers to checkpoint, 9 minutes.",
         "leading-zero decimal next to plain integer",
     ),
-
     # ---- the canonical PRD scenarios ---------------------------------
     (
         "prd-A",

--- a/voice/phrases.py
+++ b/voice/phrases.py
@@ -1,0 +1,235 @@
+"""Voice-out test phrase corpus.
+
+Categorized phrases for listen-testing the rationale -> cadence -> Piper
+chain. Each phrase exercises one or more failure modes that operators
+care about. Keep these short and realistic -- they should sound like
+something an operator would actually hear on net.
+
+Categories
+----------
+clean        -- baseline, no traps. Should always sound natural.
+bearings     -- 3-digit headings, bearing/range pairs.
+mgrs         -- grid references at varying precision.
+units        -- distances, speeds, altitudes.
+homophones   -- numbers/words that confuse on radio (5/9, 3/free, 2/to).
+compound     -- compound cardinals, multi-clause sentences.
+mission      -- realistic mission narration (CASEVAC, contact, status).
+ambiguous    -- intentionally tricky phrasing that could be misread.
+prd          -- the canonical PRD scenario rationales.
+
+Each entry is (id, category, text, what_to_listen_for).
+"""
+
+from __future__ import annotations
+
+PHRASES: list[tuple[str, str, str, str]] = [
+    # ---- baseline ------------------------------------------------------
+    (
+        "clean-01",
+        "clean",
+        "Operator, route plan ready. Standby for confirmation.",
+        "natural pacing, clean stop at end",
+    ),
+    (
+        "clean-02",
+        "clean",
+        "Acknowledge receipt and move on my mark.",
+        "no numbers; pure prosody check",
+    ),
+
+    # ---- bearings & ranges --------------------------------------------
+    (
+        "bearing-01",
+        "bearings",
+        "Heading 030 for 2.5 kilometers.",
+        "'zero three zero' digit-by-digit; decimal smooth",
+    ),
+    (
+        "bearing-02",
+        "bearings",
+        "Bearing 270, range 800 meters.",
+        "'two seven zero'; range read clean",
+    ),
+    (
+        "bearing-03",
+        "bearings",
+        "Turn NE then maintain 045 for 1.2 kilometers.",
+        "cardinal expansion + bearing + decimal",
+    ),
+    (
+        "bearing-04",
+        "bearings",
+        "From here, bearing 359, range 50 meters.",
+        "near-360 bearing -- still digit-by-digit",
+    ),
+
+    # ---- MGRS grids ---------------------------------------------------
+    (
+        "mgrs-01",
+        "mgrs",
+        "Grid 11SMS1234 5678.",
+        "phonetic letters; comma pause between halves",
+    ),
+    (
+        "mgrs-02",
+        "mgrs",
+        "Target at 18TWL8412 9023, friendlies at 18TWL8395 9011.",
+        "two MGRS in one sentence; mid-sentence comma flow",
+    ),
+    (
+        "mgrs-03",
+        "mgrs",
+        "Hill at 11SMS12345678.",
+        "MGRS without space-separated halves",
+    ),
+
+    # ---- units --------------------------------------------------------
+    (
+        "units-01",
+        "units",
+        "Distance 4.2 km, ETA 38 minutes on foot.",
+        "decimal, integer, units all in one line",
+    ),
+    (
+        "units-02",
+        "units",
+        "Wind from 220 at 15 kph, gusting 25.",
+        "kph -> 'kilometers per hour'; sequential numbers",
+    ),
+    (
+        "units-03",
+        "units",
+        "Altitude 1250 meters, descent 200 meters per minute.",
+        "longer numbers digit-by-digit; trailing unit",
+    ),
+
+    # ---- homophone hazards --------------------------------------------
+    (
+        "homo-01",
+        "homophones",
+        "5 friendlies at 9 o'clock.",
+        "'five' vs 'nine' -- can you tell them apart cleanly?",
+    ),
+    (
+        "homo-02",
+        "homophones",
+        "2 vehicles for 4 personnel.",
+        "two/to and four/for collisions",
+    ),
+    (
+        "homo-03",
+        "homophones",
+        "3 contacts at 300 meters bearing 030.",
+        "'three' said three different ways (count, range, bearing)",
+    ),
+
+    # ---- compound directions -----------------------------------------
+    (
+        "compound-01",
+        "compound",
+        "Move NNE through draw, then SE around the ridge.",
+        "compound cardinals -- 'north-northeast' smooth?",
+    ),
+    (
+        "compound-02",
+        "compound",
+        "Primary route NW, alternate route SSW, contingency due south.",
+        "three cardinals in one sentence",
+    ),
+
+    # ---- mission narration -------------------------------------------
+    (
+        "mission-01",
+        "mission",
+        "Routed to Lobos Creek. Distance 2.1 kilometers. ETA 38 minutes on foot covered.",
+        "the PRD scenario A read; should sound briefing-grade",
+    ),
+    (
+        "mission-02",
+        "mission",
+        "CASEVAC requested. Routing to open field at grid 11SMS1234 5678. Suitable HLZ.",
+        "Kyle's situational-context prototype (issue #45)",
+    ),
+    (
+        "mission-03",
+        "mission",
+        "Contact front, 200 meters, dismounts. Break.",
+        "short urgent burst; 'break' should land hard",
+    ),
+    (
+        "mission-04",
+        "mission",
+        "Be advised: route blocked at waypoint 3. Rerouting through alternate.",
+        "'be advised' cadence; mid-sentence colon",
+    ),
+    (
+        "mission-05",
+        "mission",
+        "Danger close, 50 meters, friendly mark north.",
+        "'danger close' should NOT get glossed over",
+    ),
+
+    # ---- ambiguous / tricky -------------------------------------------
+    (
+        "amb-01",
+        "ambiguous",
+        "Move to 11SMS1234, then 11SMS5678, then halt.",
+        "two grids back to back; do you confuse them?",
+    ),
+    (
+        "amb-02",
+        "ambiguous",
+        "ETA 11, distance 11, bearing 110.",
+        "'eleven' three ways; can you tell quantity from grid?",
+    ),
+    (
+        "amb-03",
+        "ambiguous",
+        "0.9 kilometers to checkpoint, 9 minutes.",
+        "leading-zero decimal next to plain integer",
+    ),
+
+    # ---- the canonical PRD scenarios ---------------------------------
+    (
+        "prd-A",
+        "prd",
+        "Routed to Lobos Creek, distance 2.1 kilometers, ETA 38 minutes on foot covered.",
+        "PRD scenario A: urban freshwater route",
+    ),
+    (
+        "prd-B",
+        "prd",
+        "Routed via covered ridge to objective. Avoiding open ground at 11SMS1234 5678.",
+        "PRD scenario B: austere covered route with grid",
+    ),
+    (
+        "prd-C",
+        "prd",
+        "Highest threat priority grid identified. Routing dismount team via NW draw.",
+        "PRD scenario C: priority-grid dispatch",
+    ),
+]
+
+
+def by_category(category: str) -> list[tuple[str, str, str, str]]:
+    """Filter phrases by category. Returns empty list if category unknown."""
+    return [p for p in PHRASES if p[1] == category]
+
+
+def by_id(phrase_id: str) -> tuple[str, str, str, str] | None:
+    """Find a single phrase by id. Returns None if not found."""
+    for p in PHRASES:
+        if p[0] == phrase_id:
+            return p
+    return None
+
+
+def categories() -> list[str]:
+    """Distinct category names, in PHRASES order."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for _, cat, _, _ in PHRASES:
+        if cat not in seen:
+            seen.add(cat)
+            out.append(cat)
+    return out

--- a/voice/piper_client.py
+++ b/voice/piper_client.py
@@ -1,0 +1,145 @@
+"""Wrapper around `piper-tts` for offline text -> WAV synthesis.
+
+Why a wrapper:
+- Lazy load. The Piper voice model takes ~500ms to load. We do it once at
+  process startup, not per request.
+- Defensive imports. The `piper-tts` package is in the [voice] optional
+  extra. Machines without it (e.g., CI on a path that doesn't run voice
+  tests) shouldn't crash on import.
+- Graceful degradation. If Piper or the voice model isn't available,
+  return None from synth calls; the orchestrator falls back to text-only.
+
+Usage::
+
+    client = get_piper()  # lazy singleton
+    if client.is_available():
+        wav_bytes = client.synthesize_wav("Hello operator")
+
+This module never exits the process or raises on missing voice -- a degraded
+TTS path is better than no /plan response. The orchestrator decides whether
+to require audio (which it does NOT in MVP).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import wave
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+
+# Default voice model. Override via PIPER_MODEL_PATH env var.
+_DEFAULT_VOICE = "en_US-libritts_r-medium"
+_DEFAULT_DIR = Path(__file__).resolve().parent.parent / "models" / "piper"
+
+
+def _resolve_model_path() -> Path:
+    """Locate the voice .onnx file, prefer env override."""
+    explicit = os.environ.get("PIPER_MODEL_PATH")
+    if explicit:
+        return Path(explicit)
+    voice = os.environ.get("PIPER_VOICE", _DEFAULT_VOICE)
+    return _DEFAULT_DIR / f"{voice}.onnx"
+
+
+class PiperClient:
+    """Thin wrapper around piper-tts. Holds a single loaded voice."""
+
+    def __init__(self, model_path: str | Path | None = None) -> None:
+        self.model_path = Path(model_path) if model_path else _resolve_model_path()
+        self._voice: Any | None = None
+        self._sample_rate: int = 22050  # default; overridden when voice loads
+
+    def is_available(self) -> bool:
+        """True if piper-tts is installed AND the voice model exists. Fast check."""
+        try:
+            import piper  # noqa: F401
+        except ImportError:
+            return False
+        return self.model_path.exists()
+
+    def load(self) -> None:
+        """Load the voice model. Idempotent. Raises if piper or model missing."""
+        if self._voice is not None:
+            return
+        try:
+            from piper import PiperVoice
+        except ImportError as e:
+            raise RuntimeError(
+                "piper-tts not installed; run: make install-voice"
+            ) from e
+        if not self.model_path.exists():
+            raise RuntimeError(
+                f"Piper voice model not found at {self.model_path}. "
+                "Run the voice-model download in setup."
+            )
+        self._voice = PiperVoice.load(str(self.model_path))
+        # Pull sample rate from the voice's config -- different voices use
+        # different rates (16k for low-quality, 22050 for medium).
+        cfg = getattr(self._voice, "config", None)
+        if cfg is not None and hasattr(cfg, "sample_rate"):
+            self._sample_rate = int(cfg.sample_rate)
+        log.info(
+            "piper_voice_loaded",
+            model_path=str(self.model_path),
+            sample_rate=self._sample_rate,
+        )
+
+    @property
+    def sample_rate(self) -> int:
+        return self._sample_rate
+
+    def synthesize_wav(self, text: str) -> bytes:
+        """Synthesize the given text and return WAV bytes.
+
+        Raises RuntimeError if Piper isn't available or model isn't loaded
+        (call .is_available() first to gate).
+        """
+        self.load()
+        assert self._voice is not None  # post-condition of self.load()
+
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as wav:
+            wav.setnchannels(1)
+            wav.setsampwidth(2)  # 16-bit PCM
+            wav.setframerate(self._sample_rate)
+            # Piper API note: synthesize_wav writes raw PCM frames into the
+            # wave file in chunks. The piper-tts package version >=1.4 exposes
+            # `synthesize_wav(text, wav_writer)` directly. Older versions used
+            # `synthesize(text, wav_writer)`. Try both; fall back gracefully.
+            if hasattr(self._voice, "synthesize_wav"):
+                self._voice.synthesize_wav(text, wav)
+            elif hasattr(self._voice, "synthesize"):
+                self._voice.synthesize(text, wav)
+            else:
+                raise RuntimeError(
+                    "PiperVoice has neither synthesize_wav nor synthesize -- "
+                    "unsupported piper-tts version"
+                )
+        return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_client: PiperClient | None = None
+
+
+def get_piper() -> PiperClient:
+    """Lazy singleton. Most callers want this."""
+    global _client
+    if _client is None:
+        _client = PiperClient()
+    return _client
+
+
+def reset_piper() -> None:
+    """For tests."""
+    global _client
+    _client = None

--- a/voice/piper_client.py
+++ b/voice/piper_client.py
@@ -97,9 +97,7 @@ class PiperClient:
         try:
             from piper import PiperVoice
         except ImportError as e:
-            raise RuntimeError(
-                "piper-tts not installed; run: make install-voice"
-            ) from e
+            raise RuntimeError("piper-tts not installed; run: make install-voice") from e
         if not self.model_path.exists():
             raise RuntimeError(
                 f"Piper voice model not found at {self.model_path}. "

--- a/voice/piper_client.py
+++ b/voice/piper_client.py
@@ -8,6 +8,9 @@ Why a wrapper:
   tests) shouldn't crash on import.
 - Graceful degradation. If Piper or the voice model isn't available,
   return None from synth calls; the orchestrator falls back to text-only.
+- Synthesis params. Operator cadence wants slower speech, normalized
+  volume, and a small inter-sentence pause -- this module owns those
+  defaults so downstream callers don't think about them.
 
 Usage::
 
@@ -37,6 +40,17 @@ log = structlog.get_logger(__name__)
 _DEFAULT_VOICE = "en_US-libritts_r-medium"
 _DEFAULT_DIR = Path(__file__).resolve().parent.parent / "models" / "piper"
 
+# Synthesis defaults tuned for operator cadence:
+#   length_scale > 1.0 -> slower speech (1.15 = ~15% slower than default).
+#   sentence_silence_s -> pause inserted between sentences (Piper inserts
+#     this when it sees sentence-ending punctuation).
+#   volume = 1.0 -> no attenuation. Normalize handles peak limiting.
+_DEFAULT_LENGTH_SCALE = 1.15  # slow down ~15% for operator pacing
+_DEFAULT_NOISE_SCALE = 0.667  # piper default; controls vocal variation
+_DEFAULT_NOISE_W_SCALE = 0.8  # piper default; controls phoneme duration jitter
+_DEFAULT_SENTENCE_SILENCE_S = 0.35
+_DEFAULT_VOLUME = 1.0
+
 
 def _resolve_model_path() -> Path:
     """Locate the voice .onnx file, prefer env override."""
@@ -50,8 +64,21 @@ def _resolve_model_path() -> Path:
 class PiperClient:
     """Thin wrapper around piper-tts. Holds a single loaded voice."""
 
-    def __init__(self, model_path: str | Path | None = None) -> None:
+    def __init__(
+        self,
+        model_path: str | Path | None = None,
+        length_scale: float = _DEFAULT_LENGTH_SCALE,
+        noise_scale: float = _DEFAULT_NOISE_SCALE,
+        noise_w_scale: float = _DEFAULT_NOISE_W_SCALE,
+        sentence_silence_s: float = _DEFAULT_SENTENCE_SILENCE_S,
+        volume: float = _DEFAULT_VOLUME,
+    ) -> None:
         self.model_path = Path(model_path) if model_path else _resolve_model_path()
+        self.length_scale = length_scale
+        self.noise_scale = noise_scale
+        self.noise_w_scale = noise_w_scale
+        self.sentence_silence_s = sentence_silence_s
+        self.volume = volume
         self._voice: Any | None = None
         self._sample_rate: int = 22050  # default; overridden when voice loads
 
@@ -94,14 +121,41 @@ class PiperClient:
     def sample_rate(self) -> int:
         return self._sample_rate
 
-    def synthesize_wav(self, text: str) -> bytes:
+    def _build_syn_config(self, length_scale: float | None = None) -> Any | None:
+        """Build a piper.SynthesisConfig if available, else None.
+
+        piper-tts >=1.3 exposes SynthesisConfig with length_scale, volume,
+        noise params, and sentence_silence. Older versions don't have it,
+        so we return None and let the synth use library defaults.
+        """
+        try:
+            from piper import SynthesisConfig
+        except ImportError:
+            return None
+        return SynthesisConfig(
+            length_scale=length_scale if length_scale is not None else self.length_scale,
+            noise_scale=self.noise_scale,
+            noise_w_scale=self.noise_w_scale,
+            volume=self.volume,
+        )
+
+    def synthesize_wav(self, text: str, length_scale: float | None = None) -> bytes:
         """Synthesize the given text and return WAV bytes.
+
+        Args:
+            text: input text. Sentence-ending punctuation triggers Piper's
+                  inter-sentence silence pause.
+            length_scale: optional override of the configured pace. Higher
+                  values mean slower speech (1.0 = default Piper, 1.15 =
+                  operator cadence, 1.3 = very slow).
 
         Raises RuntimeError if Piper isn't available or model isn't loaded
         (call .is_available() first to gate).
         """
         self.load()
         assert self._voice is not None  # post-condition of self.load()
+
+        syn_config = self._build_syn_config(length_scale)
 
         buf = io.BytesIO()
         with wave.open(buf, "wb") as wav:
@@ -112,10 +166,17 @@ class PiperClient:
             # wave file in chunks. The piper-tts package version >=1.4 exposes
             # `synthesize_wav(text, wav_writer)` directly. Older versions used
             # `synthesize(text, wav_writer)`. Try both; fall back gracefully.
+            # syn_config is passed when available; older versions ignore it.
             if hasattr(self._voice, "synthesize_wav"):
-                self._voice.synthesize_wav(text, wav)
+                if syn_config is not None:
+                    self._voice.synthesize_wav(text, wav, syn_config=syn_config)
+                else:
+                    self._voice.synthesize_wav(text, wav)
             elif hasattr(self._voice, "synthesize"):
-                self._voice.synthesize(text, wav)
+                if syn_config is not None:
+                    self._voice.synthesize(text, wav, syn_config=syn_config)
+                else:
+                    self._voice.synthesize(text, wav)
             else:
                 raise RuntimeError(
                     "PiperVoice has neither synthesize_wav nor synthesize -- "

--- a/voice/rationale.py
+++ b/voice/rationale.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 
 import re
 
+from voice.glossary import acronym_readings_spell, acronym_readings_word
+
 # ---------------------------------------------------------------------------
 # Single-digit phonetics. Each digit gets its own word, no contractions
 # (so "0" is "zero" not "oh").
@@ -121,43 +123,21 @@ _UNIT_FULL = {
 
 
 # ---------------------------------------------------------------------------
-# Acronyms. Two flavors:
-#   _ACRONYM_SPELL  -- expand to NATO phonetic words ("ETA" -> "echo tango
-#                      alpha"). Operator note 17:24 #1: Piper drops the
-#                      trailing "A" in space-separated forms ("E T A" reads
-#                      as "E tay"). NATO phonetics are mil-correct AND
-#                      physically impossible for Piper to swallow because
-#                      every letter becomes a multi-syllable word.
-#   _ACRONYM_WORD   -- read as a word, with hyphens hinting syllable splits
-#                      ("CASEVAC" -> "case-vac"). Operators say these as
-#                      words on net, not as letters.
-# Order: _WORD first (so e.g. "MEDEVAC" doesn't get partially-matched by an
-# acronym in _SPELL), then _SPELL. Word-boundary anchored.
+# Acronym readings -- source of truth is voice.glossary. Two flavors:
+#   _ACRONYM_SPELL  -- NATO phonetic ("ETA" -> "echo tango alpha"). Operator
+#                      note 17:24: Piper drops trailing solo letters in
+#                      space-separated forms ("E T A" reads as "E tay").
+#                      NATO multi-syllable words are physically impossible
+#                      for Piper to swallow.
+#   _ACRONYM_WORD   -- single pronounceable word ("case-vac", "tock") that
+#                      operators universally read as a word, not letters.
+#
+# Application order in the cadence transform: _WORD first, then _SPELL --
+# avoids partial matches (e.g. 'MEDEVAC' before any 'EVAC' rule).
 # ---------------------------------------------------------------------------
 
-_ACRONYM_SPELL = {
-    "ETA": "echo tango alpha",
-    "HLZ": "hotel lima zulu",
-    "LZ": "lima zulu",
-    "PZ": "papa zulu",
-    "IED": "india echo delta",
-    "EOD": "echo oscar delta",
-    "AO": "alpha oscar",
-    "CP": "charlie papa",
-    "OP": "oscar papa",
-    "POI": "papa oscar india",
-    "MGRS": "mike golf romeo sierra",
-    "QRF": "quebec romeo foxtrot",
-    "TRP": "tango romeo papa",
-}
-
-_ACRONYM_WORD = {
-    "CASEVAC": "case-vac",
-    "MEDEVAC": "med-evac",
-    "RECON": "ree-kon",
-    # TOC is universally pronounced 'tock' on net, not letters.
-    "TOC": "tock",
-}
+_ACRONYM_SPELL = acronym_readings_spell()
+_ACRONYM_WORD = acronym_readings_word()
 
 
 # ---------------------------------------------------------------------------

--- a/voice/rationale.py
+++ b/voice/rationale.py
@@ -122,34 +122,41 @@ _UNIT_FULL = {
 
 # ---------------------------------------------------------------------------
 # Acronyms. Two flavors:
-#   _ACRONYM_SPELL  -- read letter-by-letter ("ETA" -> "E T A").
+#   _ACRONYM_SPELL  -- expand to NATO phonetic words ("ETA" -> "echo tango
+#                      alpha"). Operator note 17:24 #1: Piper drops the
+#                      trailing "A" in space-separated forms ("E T A" reads
+#                      as "E tay"). NATO phonetics are mil-correct AND
+#                      physically impossible for Piper to swallow because
+#                      every letter becomes a multi-syllable word.
 #   _ACRONYM_WORD   -- read as a word, with hyphens hinting syllable splits
-#                      ("CASEVAC" -> "case-vac"). Operators say these as words.
-# Order: _SPELL first (longer abbreviations take precedence), then _WORD.
-# Word-boundary anchored so we don't touch sub-words.
+#                      ("CASEVAC" -> "case-vac"). Operators say these as
+#                      words on net, not as letters.
+# Order: _WORD first (so e.g. "MEDEVAC" doesn't get partially-matched by an
+# acronym in _SPELL), then _SPELL. Word-boundary anchored.
 # ---------------------------------------------------------------------------
 
 _ACRONYM_SPELL = {
-    "ETA": "E T A",
-    "HLZ": "H L Z",
-    "LZ": "L Z",
-    "PZ": "P Z",
-    "IED": "I E D",
-    "EOD": "E O D",
-    "AO": "A O",
-    "CP": "C P",
-    "OP": "O P",
-    "TOC": "T O C",
-    "POI": "P O I",
-    "MGRS": "M G R S",
-    "QRF": "Q R F",
-    "TRP": "T R P",
+    "ETA": "echo tango alpha",
+    "HLZ": "hotel lima zulu",
+    "LZ": "lima zulu",
+    "PZ": "papa zulu",
+    "IED": "india echo delta",
+    "EOD": "echo oscar delta",
+    "AO": "alpha oscar",
+    "CP": "charlie papa",
+    "OP": "oscar papa",
+    "POI": "papa oscar india",
+    "MGRS": "mike golf romeo sierra",
+    "QRF": "quebec romeo foxtrot",
+    "TRP": "tango romeo papa",
 }
 
 _ACRONYM_WORD = {
     "CASEVAC": "case-vac",
     "MEDEVAC": "med-evac",
     "RECON": "ree-kon",
+    # TOC is universally pronounced 'tock' on net, not letters.
+    "TOC": "tock",
 }
 
 

--- a/voice/rationale.py
+++ b/voice/rationale.py
@@ -87,7 +87,9 @@ _MGRS_PHONETIC = {
     "H": "hotel",
     "J": "juliet",
     "K": "kilo",
-    "L": "lima",
+    # 'lee-mah' (not 'lima') -- Piper slurs the trailing 'a' otherwise.
+    # Op note 17:41: 'lima still sounds weird ... anything with a soft a'.
+    "L": "lee-mah",
     "M": "mike",
     "N": "november",
     "P": "papa",

--- a/voice/rationale.py
+++ b/voice/rationale.py
@@ -121,8 +121,78 @@ _UNIT_FULL = {
 
 
 # ---------------------------------------------------------------------------
+# Acronyms. Two flavors:
+#   _ACRONYM_SPELL  -- read letter-by-letter ("ETA" -> "E T A").
+#   _ACRONYM_WORD   -- read as a word, with hyphens hinting syllable splits
+#                      ("CASEVAC" -> "case-vac"). Operators say these as words.
+# Order: _SPELL first (longer abbreviations take precedence), then _WORD.
+# Word-boundary anchored so we don't touch sub-words.
+# ---------------------------------------------------------------------------
+
+_ACRONYM_SPELL = {
+    "ETA": "E T A",
+    "HLZ": "H L Z",
+    "LZ": "L Z",
+    "PZ": "P Z",
+    "IED": "I E D",
+    "EOD": "E O D",
+    "AO": "A O",
+    "CP": "C P",
+    "OP": "O P",
+    "TOC": "T O C",
+    "POI": "P O I",
+    "MGRS": "M G R S",
+    "QRF": "Q R F",
+    "TRP": "T R P",
+}
+
+_ACRONYM_WORD = {
+    "CASEVAC": "case-vac",
+    "MEDEVAC": "med-evac",
+    "RECON": "ree-kon",
+}
+
+
+# ---------------------------------------------------------------------------
+# Clause-boundary punctuation. Commas give Piper ~120ms; periods give the
+# full sentence_silence (350ms). For radio cadence we want full pause between
+# count/range/bearing/ETA elements, so promote "," before these cue words to
+# a period. Operator notes (Sat 17:03): without this the elements blur.
+# ---------------------------------------------------------------------------
+
+_CLAUSE_CUES = ("ETA", "bearing", "range", "altitude", "distance")
+
+
+# ---------------------------------------------------------------------------
 # Transformation passes
 # ---------------------------------------------------------------------------
+
+
+def _promote_clause_commas(text: str) -> str:
+    """Replace ', <cue>' with '. <cue>' so Piper takes a full sentence pause.
+
+    Before: "Distance 2.1 km, ETA 38 minutes, on foot covered."
+    After:  "Distance 2.1 km. ETA 38 minutes. on foot covered."
+
+    The lowercase second clause start ('on') stays lowercase -- Piper's
+    prosody handles it fine. Promoting cuts ETA-blurring complaints
+    (operator notes 17:03 #5/6/14/17/18).
+    """
+    pattern = "|".join(re.escape(c) for c in _CLAUSE_CUES)
+    return re.sub(rf",\s+(?=({pattern})\b)", ". ", text, flags=re.IGNORECASE)
+
+
+def _expand_acronyms(text: str) -> str:
+    """Spell out known acronyms.
+
+    Run AFTER _expand_mgrs_grids so MGRS letter groups (which become lowercase
+    phonetic words) don't accidentally re-match an uppercase acronym pattern.
+    """
+    for word, spelled in _ACRONYM_WORD.items():
+        text = re.sub(rf"\b{word}\b", spelled, text)
+    for acronym, spelled in _ACRONYM_SPELL.items():
+        text = re.sub(rf"\b{acronym}\b", spelled, text)
+    return text
 
 
 def _expand_mgrs_grids(text: str) -> str:
@@ -153,7 +223,10 @@ def _expand_mgrs_grids(text: str) -> str:
             digits1, digits2 = digits1[:half], digits1[half:]
 
         zone_words = _digits_spoken(zone)
-        letter_words = " ".join(_MGRS_PHONETIC.get(c, c) for c in letters.upper())
+        # Comma-separate phonetic letters so each lands as its own beat in
+        # Piper. Without this, runs like 'sierra mike sierra' or 'whiskey
+        # lima' slur into each other (operator notes 17:03 #4/5/6/16).
+        letter_words = ", ".join(_MGRS_PHONETIC.get(c, c) for c in letters.upper())
         d1_words = _digits_spoken(digits1)
         d2_words = _digits_spoken(digits2)
 
@@ -233,19 +306,25 @@ def to_operator_cadence(text: str) -> str:
     """Convert plain-English rationale into operator-cadence speech.
 
     The order of passes matters:
-      1. MGRS grids first (their digits + letters need to win before generic
-         passes touch them).
-      2. Cardinal abbreviations (NE etc.) -> full words.
-      3. Units (km, kph) -> spelled-out (so number+unit reads naturally).
-      4. Decimals (2.1) -> 'two point one'.
-      5. Plain integers (38) -> 'three eight' digit-by-digit.
+      1. _promote_clause_commas: ', ETA'/'bearing'/'range' -> '. <cue>' so
+         Piper takes a full sentence pause between elements (radio tradition).
+      2. _expand_mgrs_grids: their digits + letters need to win before generic
+         passes touch them. Now comma-separates phonetic letters too.
+      3. _expand_acronyms: spell out ETA/HLZ/etc. Must run AFTER MGRS so
+         MGRS-internal letters (now lowercase phonetic words) don't re-match.
+      4. _expand_cardinals: NE -> northeast.
+      5. _expand_units: km -> kilometers (number+unit reads naturally).
+      6. _expand_decimals: 2.1 -> 'two point one'.
+      7. _expand_counted_numbers: 38 -> 'three eight' digit-by-digit.
 
     The result is fed straight to Piper. No further normalization required.
     """
     if not text:
         return text
 
+    text = _promote_clause_commas(text)
     text = _expand_mgrs_grids(text)
+    text = _expand_acronyms(text)
     text = _expand_cardinals(text)
     text = _expand_units(text)
     text = _expand_decimals(text)

--- a/voice/rationale.py
+++ b/voice/rationale.py
@@ -129,9 +129,15 @@ def _expand_mgrs_grids(text: str) -> str:
     """Match MGRS grids like '11SMS1234 5678' or '11SMS12345678'.
 
     Pattern: 1-2 digits (zone), 1-3 letters (band+square), then digits in
-    pairs of 2/4/6/8/10 (precision). Example: '11SMS1234 5678'.
+    pairs of 2/4/6/8/10 (precision). Examples:
+      '11SMS1234 5678'   -- 8-digit precision, halves separated by space
+      '11SMS12345678'    -- 8-digit precision, no space
+      '11SMS1234'        -- 4-digit precision
+      '18TWL8412 9023'   -- different zone/letters, same shape
 
-    Speak as: 'one one Sierra Mike Sierra one two three four, five six seven eight'.
+    Speak as: 'one one sierra mike sierra one two three four, five six seven eight'.
+    For the no-space form, split the digit run in half so the comma still
+    falls between the easting and northing.
     """
 
     def repl(m: re.Match[str]) -> str:
@@ -139,6 +145,12 @@ def _expand_mgrs_grids(text: str) -> str:
         letters = m.group("letters")
         digits1 = m.group("digits1")
         digits2 = m.group("digits2") or ""
+
+        # No-space form ('11SMS12345678'): digits1 is the full run. Split in
+        # half so easting/northing each get their own beat.
+        if not digits2 and len(digits1) >= 4 and len(digits1) % 2 == 0:
+            half = len(digits1) // 2
+            digits1, digits2 = digits1[:half], digits1[half:]
 
         zone_words = _digits_spoken(zone)
         letter_words = " ".join(_MGRS_PHONETIC.get(c, c) for c in letters.upper())
@@ -151,8 +163,9 @@ def _expand_mgrs_grids(text: str) -> str:
             parts.append(d2_words)
         return " ".join(p for p in parts if p)
 
+    # digits1 allows up to 10 digits (5+5 max precision in a single run).
     pattern = re.compile(
-        r"\b(?P<zone>\d{1,2})(?P<letters>[A-Z]{1,3})(?P<digits1>\d{2,5})(?:\s+(?P<digits2>\d{2,5}))?\b",
+        r"\b(?P<zone>\d{1,2})(?P<letters>[A-Z]{1,3})(?P<digits1>\d{2,10})(?:\s+(?P<digits2>\d{2,5}))?\b",
     )
     return pattern.sub(repl, text)
 

--- a/voice/rationale.py
+++ b/voice/rationale.py
@@ -1,0 +1,243 @@
+"""Operator-cadence transformer.
+
+Converts plain-English rationale strings (as produced by the orchestrator)
+into the cadence operators expect when listening hands-free:
+
+  - bearings (3-digit) -> "zero three zero"
+  - counted numbers > 9 -> digit-by-digit ("three eight" not "thirty-eight")
+  - decimals -> "two point one"
+  - units -> spelled out ("kilometers" not "km")
+  - MGRS grids -> phonetic letters + digit-by-digit
+  - cardinal abbreviations -> full word ("northeast" not "NE")
+
+Pure string transformation. No LLM in the loop. Deterministic, table-driven,
+testable. The grammar is intentionally narrow: this code does NOT try to
+turn arbitrary English into mil-cadence -- it only rewrites the patterns
+the orchestrator's rationale templates actually emit.
+
+Refining cadence rules is a paired task between Jon (impl) and Ben (operator
+SME). When in doubt, prefer fewer transformations over more -- it's better
+to leave a phrase plain-English than to mangle it.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Single-digit phonetics. Each digit gets its own word, no contractions
+# (so "0" is "zero" not "oh").
+# ---------------------------------------------------------------------------
+
+_DIGIT_WORD = {
+    "0": "zero",
+    "1": "one",
+    "2": "two",
+    "3": "three",
+    "4": "four",
+    "5": "five",
+    "6": "six",
+    "7": "seven",
+    "8": "eight",
+    "9": "nine",
+}
+
+
+def _digits_spoken(digits: str) -> str:
+    """'1234' -> 'one two three four'."""
+    return " ".join(_DIGIT_WORD[c] for c in digits if c in _DIGIT_WORD)
+
+
+# ---------------------------------------------------------------------------
+# Cardinal abbreviations -> full words.
+# Order matters: longer matches first (NE before N) to avoid partial replace.
+# ---------------------------------------------------------------------------
+
+_CARDINAL_FULL = [
+    ("NNW", "north-northwest"),
+    ("NNE", "north-northeast"),
+    ("ENE", "east-northeast"),
+    ("ESE", "east-southeast"),
+    ("SSE", "south-southeast"),
+    ("SSW", "south-southwest"),
+    ("WSW", "west-southwest"),
+    ("WNW", "west-northwest"),
+    ("NW", "northwest"),
+    ("NE", "northeast"),
+    ("SW", "southwest"),
+    ("SE", "southeast"),
+]
+
+
+# ---------------------------------------------------------------------------
+# MGRS phonetic alphabet (NATO). Used when reading grids letter-by-letter.
+# Only the letters that actually appear in MGRS are required.
+# ---------------------------------------------------------------------------
+
+_MGRS_PHONETIC = {
+    "A": "alpha",
+    "B": "bravo",
+    "C": "charlie",
+    "D": "delta",
+    "E": "echo",
+    "F": "foxtrot",
+    "G": "golf",
+    "H": "hotel",
+    "J": "juliet",
+    "K": "kilo",
+    "L": "lima",
+    "M": "mike",
+    "N": "november",
+    "P": "papa",
+    "Q": "quebec",
+    "R": "romeo",
+    "S": "sierra",
+    "T": "tango",
+    "U": "uniform",
+    "V": "victor",
+    "W": "whiskey",
+    "X": "x-ray",
+    "Y": "yankee",
+    "Z": "zulu",
+}
+
+
+# ---------------------------------------------------------------------------
+# Unit suffix expansion. Spoken-as is what Piper actually says; the synthesis
+# is more natural when the unit is spelled out.
+# ---------------------------------------------------------------------------
+
+_UNIT_FULL = {
+    "km": "kilometers",
+    "kph": "kilometers per hour",
+    "kmh": "kilometers per hour",
+    "kts": "knots",
+    "mph": "miles per hour",
+    "mi": "miles",
+    "nm": "nautical miles",
+    "ft": "feet",
+    "m": "meters",
+}
+
+
+# ---------------------------------------------------------------------------
+# Transformation passes
+# ---------------------------------------------------------------------------
+
+
+def _expand_mgrs_grids(text: str) -> str:
+    """Match MGRS grids like '11SMS1234 5678' or '11SMS12345678'.
+
+    Pattern: 1-2 digits (zone), 1-3 letters (band+square), then digits in
+    pairs of 2/4/6/8/10 (precision). Example: '11SMS1234 5678'.
+
+    Speak as: 'one one Sierra Mike Sierra one two three four, five six seven eight'.
+    """
+
+    def repl(m: re.Match[str]) -> str:
+        zone = m.group("zone")
+        letters = m.group("letters")
+        digits1 = m.group("digits1")
+        digits2 = m.group("digits2") or ""
+
+        zone_words = _digits_spoken(zone)
+        letter_words = " ".join(_MGRS_PHONETIC.get(c, c) for c in letters.upper())
+        d1_words = _digits_spoken(digits1)
+        d2_words = _digits_spoken(digits2)
+
+        parts = [zone_words, letter_words, d1_words]
+        if d2_words:
+            parts[-1] = d1_words + ","
+            parts.append(d2_words)
+        return " ".join(p for p in parts if p)
+
+    pattern = re.compile(
+        r"\b(?P<zone>\d{1,2})(?P<letters>[A-Z]{1,3})(?P<digits1>\d{2,5})(?:\s+(?P<digits2>\d{2,5}))?\b",
+    )
+    return pattern.sub(repl, text)
+
+
+def _expand_cardinals(text: str) -> str:
+    """NE -> northeast etc. Word-boundary anchored to avoid replacing inside identifiers."""
+    for abbr, full in _CARDINAL_FULL:
+        text = re.sub(rf"\b{abbr}\b", full, text)
+    return text
+
+
+def _expand_units(text: str) -> str:
+    """Replace numeric+unit pairs ('2.1 km') with numeric + spelled-unit
+    ('2.1 kilometers'). Handles numbers like 2, 2.1, 38, 0.5 with optional
+    space before the unit."""
+    for short, full in _UNIT_FULL.items():
+        # Match number (int or decimal) followed by optional space + unit + word boundary.
+        text = re.sub(rf"(\d+(?:\.\d+)?)\s*{short}\b", rf"\1 {full}", text)
+    return text
+
+
+def _expand_decimals(text: str) -> str:
+    """'2.1' -> 'two point one' (always digit-by-digit on either side of '.')."""
+
+    def repl(m: re.Match[str]) -> str:
+        whole, frac = m.group(1), m.group(2)
+        return f"{_digits_spoken(whole)} point {_digits_spoken(frac)}"
+
+    return re.sub(r"\b(\d+)\.(\d+)\b", repl, text)
+
+
+def _expand_counted_numbers(text: str) -> str:
+    """Plain integers >= 10 spoken digit-by-digit ('38' -> 'three eight').
+    Single-digit numbers (0-9) are usually fine as-is in Piper but spelled
+    out anyway for consistency. Numbers in MGRS grids are already handled."""
+
+    def repl(m: re.Match[str]) -> str:
+        return _digits_spoken(m.group(0))
+
+    # Match 1+ digits not preceded by a letter (avoids touching things mid-word).
+    return re.sub(r"(?<![A-Za-z])\b\d+\b", repl, text)
+
+
+def _expand_three_digit_bearings(text: str) -> str:
+    """3-digit bearings (000-359) preceded by 'bearing' or 'heading' get
+    digit-by-digit. We do this BEFORE _expand_counted_numbers so the cue word
+    is still present when we match. The narrower pass is preserved through
+    a placeholder substitution -- low risk since this matches only a couple
+    of patterns in our rationale templates.
+
+    NOTE: in practice _expand_counted_numbers will already speak '030' as
+    'zero three zero' so this function is currently a no-op marker. Kept
+    here for future cadence rules that need bearing-specific phrasing
+    (e.g. future templates that emit just '030' without a cue word).
+    """
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def to_operator_cadence(text: str) -> str:
+    """Convert plain-English rationale into operator-cadence speech.
+
+    The order of passes matters:
+      1. MGRS grids first (their digits + letters need to win before generic
+         passes touch them).
+      2. Cardinal abbreviations (NE etc.) -> full words.
+      3. Units (km, kph) -> spelled-out (so number+unit reads naturally).
+      4. Decimals (2.1) -> 'two point one'.
+      5. Plain integers (38) -> 'three eight' digit-by-digit.
+
+    The result is fed straight to Piper. No further normalization required.
+    """
+    if not text:
+        return text
+
+    text = _expand_mgrs_grids(text)
+    text = _expand_cardinals(text)
+    text = _expand_units(text)
+    text = _expand_decimals(text)
+    text = _expand_three_digit_bearings(text)
+    text = _expand_counted_numbers(text)
+
+    # Collapse any double spaces that came from substitutions.
+    return re.sub(r"\s{2,}", " ", text).strip()

--- a/voice/tts.py
+++ b/voice/tts.py
@@ -1,8 +1,15 @@
 """Glue between the orchestrator's plain-English rationale and Piper TTS.
 
-The orchestrator calls `synthesize_rationale_b64(rationale)` to get a
-base64-encoded WAV ready to embed in PlanResponse. Returns None if Piper
-is unavailable -- caller treats that as a degraded but valid response.
+Two synthesis paths:
+
+  synthesize_rationale_b64(text) -- the /plan default. Cadence-transforms
+    a plain-English rationale and synthesizes it. Used in every plan
+    response when ?tts=true.
+
+  synthesize_explanation_b64(term) -- the on-demand explain path. Looks up
+    `term` in voice.glossary (deterministic, no LLM) and synthesizes
+    "<reading> stands for <full meaning>, <context>." Returns None for
+    unknown terms so the operator never hears a fabricated definition.
 
 Pure I/O wiring. Cadence transformation lives in voice.rationale; the
 synth lives in voice.piper_client. This module just composes them.
@@ -14,6 +21,7 @@ import base64
 
 import structlog
 
+from voice.glossary import explain, render_explanation_text
 from voice.piper_client import get_piper
 from voice.rationale import to_operator_cadence
 
@@ -55,3 +63,55 @@ def synthesize_rationale_b64(
         return None
 
     return base64.b64encode(wav_bytes).decode("ascii")
+
+
+def synthesize_explanation_b64(
+    term: str, length_scale: float | None = None
+) -> dict[str, str] | None:
+    """Synthesize a deterministic spoken explanation of an acronym.
+
+    Looks up `term` in voice.glossary (case-insensitive). If known, returns
+    `{"term": <canonical key>, "text": <spoken text>, "audio_b64": <wav>}`.
+    If unknown, returns None and logs `glossary_term_unknown` -- caller can
+    play a 'term not recognized' clip or surface that to the operator.
+
+    Why this is safer than asking the LLM to define the acronym:
+      - Deterministic: same input always yields same output.
+      - Auditable: the definition lives in a versioned source file.
+      - No fabrication risk: unknown terms don't get plausibly-wrong defs.
+
+    Args:
+        term: the acronym the operator wants explained (e.g. "HLZ").
+        length_scale: optional pacing override (None = client default).
+    """
+    entry = explain(term)
+    if entry is None:
+        log.info("glossary_term_unknown", term=term)
+        return None
+
+    spoken_text = render_explanation_text(entry)
+
+    client = get_piper()
+    if not client.is_available():
+        log.info("piper_unavailable", note="explain returns text without audio")
+        return {
+            "term": term.strip().upper(),
+            "text": spoken_text,
+            "audio_b64": "",
+        }
+
+    try:
+        wav_bytes = client.synthesize_wav(spoken_text, length_scale=length_scale)
+    except Exception as e:  # noqa: BLE001 -- never fail the explain path
+        log.warning("piper_explain_synth_failed", error=str(e))
+        return {
+            "term": term.strip().upper(),
+            "text": spoken_text,
+            "audio_b64": "",
+        }
+
+    return {
+        "term": term.strip().upper(),
+        "text": spoken_text,
+        "audio_b64": base64.b64encode(wav_bytes).decode("ascii"),
+    }

--- a/voice/tts.py
+++ b/voice/tts.py
@@ -28,9 +28,7 @@ from voice.rationale import to_operator_cadence
 log = structlog.get_logger(__name__)
 
 
-def synthesize_rationale_b64(
-    rationale: str, length_scale: float | None = None
-) -> str | None:
+def synthesize_rationale_b64(rationale: str, length_scale: float | None = None) -> str | None:
     """Take an English rationale, return base64-encoded WAV (or None).
 
     Steps:

--- a/voice/tts.py
+++ b/voice/tts.py
@@ -1,0 +1,50 @@
+"""Glue between the orchestrator's plain-English rationale and Piper TTS.
+
+The orchestrator calls `synthesize_rationale_b64(rationale)` to get a
+base64-encoded WAV ready to embed in PlanResponse. Returns None if Piper
+is unavailable -- caller treats that as a degraded but valid response.
+
+Pure I/O wiring. Cadence transformation lives in voice.rationale; the
+synth lives in voice.piper_client. This module just composes them.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import structlog
+
+from voice.piper_client import get_piper
+from voice.rationale import to_operator_cadence
+
+log = structlog.get_logger(__name__)
+
+
+def synthesize_rationale_b64(rationale: str) -> str | None:
+    """Take an English rationale, return base64-encoded WAV (or None).
+
+    Steps:
+      1. Convert to operator cadence.
+      2. Synthesize via Piper.
+      3. Base64-encode for JSON transport.
+
+    Returns None if Piper isn't available (no model, package missing) so
+    the caller can degrade gracefully. Never raises -- TTS is auxiliary
+    to the route response.
+    """
+    if not rationale:
+        return None
+
+    client = get_piper()
+    if not client.is_available():
+        log.info("piper_unavailable", note="returning None; rationale will be text-only")
+        return None
+
+    spoken = to_operator_cadence(rationale)
+    try:
+        wav_bytes = client.synthesize_wav(spoken)
+    except Exception as e:  # noqa: BLE001 -- TTS failure must not fail /plan
+        log.warning("piper_synth_failed", error=str(e))
+        return None
+
+    return base64.b64encode(wav_bytes).decode("ascii")

--- a/voice/tts.py
+++ b/voice/tts.py
@@ -20,13 +20,20 @@ from voice.rationale import to_operator_cadence
 log = structlog.get_logger(__name__)
 
 
-def synthesize_rationale_b64(rationale: str) -> str | None:
+def synthesize_rationale_b64(
+    rationale: str, length_scale: float | None = None
+) -> str | None:
     """Take an English rationale, return base64-encoded WAV (or None).
 
     Steps:
       1. Convert to operator cadence.
       2. Synthesize via Piper.
       3. Base64-encode for JSON transport.
+
+    Args:
+        rationale: plain English. Empty string returns None.
+        length_scale: optional pacing override (1.0 = default, 1.15 = ops
+                      cadence, 1.3 = slow). None uses the client default.
 
     Returns None if Piper isn't available (no model, package missing) so
     the caller can degrade gracefully. Never raises -- TTS is auxiliary
@@ -42,7 +49,7 @@ def synthesize_rationale_b64(rationale: str) -> str | None:
 
     spoken = to_operator_cadence(rationale)
     try:
-        wav_bytes = client.synthesize_wav(spoken)
+        wav_bytes = client.synthesize_wav(spoken, length_scale=length_scale)
     except Exception as e:  # noqa: BLE001 -- TTS failure must not fail /plan
         log.warning("piper_synth_failed", error=str(e))
         return None


### PR DESCRIPTION
Closes #21, closes #26.

## Summary

Multimodal output: `POST /plan?tts=true` returns `audio_b64` (base64 WAV) of the rationale spoken in operator cadence. Plus a deterministic glossary explain path for on-demand acronym disambiguation.

## What's new

- **voice/rationale.py** — pure-string operator cadence transformer (NATO phonetics, MGRS phonetic letters, clause-boundary pauses, syllable-hint rules from listen-test feedback)
- **voice/piper_client.py** — lazy Piper wrapper, configurable length_scale (1.15 ops cadence default), graceful degradation if model missing
- **voice/tts.py** — \`synthesize_rationale_b64\` + \`synthesize_explanation_b64\`
- **voice/glossary.py** — single source of truth for acronym readings + canonical expansions + doctrinal cites (17 terms)
- **voice/phrases.py** — 27-phrase listen-test corpus (9 categories)
- **scripts/demo_voice.py** — interactive listen-test harness with note capture, \`--explain TERM\`, \`--explain-list\`
- **agent/orchestrator.py** + **agent/app.py** + **agent/schemas.py** — wired \`?tts=true\` query param + \`audio_b64\` field on PlanResponse
- **docs/SUBMISSION_NOTES.md** — eligibility & ethics posture (NPS Foundation, OPSEC posture)

## Real synth verified

0.83s for canonical PRD scenario A rationale → 190KB WAV @ 22050Hz mono. Listen-tested through 27-phrase corpus across 4 cadence iterations.

## Tests

- 56 new tests (rationale: 27, glossary: 12, voice piper: 5, tts: 4, e2e: 2 + 6 misc)
- **177/177 green**
- Ruff + mypy + bandit clean
- Includes \`chore(lint)\` commit fixing 6 inherited lint regressions on main (crypto/sign_bench.py, security/cot_inject_demo.py, tests/test_prompt_tak_context.py)

## Test plan

- [ ] CI green
- [ ] \`afplay /tmp/tera_demo.wav\` post-merge sanity
- [ ] Future PR: trigger UX for explain (voice command via Whisper, or ATAK button)