### PR TITLE
chore(infra): harden Windows security tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,30 @@
 .PHONY: help onboard catchup install install-crypto install-voice fmt lint test security ci run tcpdump-demo audit-log demo-proofs inject-demo sign-bench demo eval clean protect-branch
 .DEFAULT_GOAL := help
 
-PY := python3.11
+ifeq ($(OS),Windows_NT)
+SHELL := C:/PROGRA~1/Git/bin/bash.exe
+else
+SHELL := /bin/bash
+endif
+.SHELLFLAGS := -eu -o pipefail -c
+
 VENV := .venv
-PIP := $(VENV)/bin/pip
-PYTHON := $(VENV)/bin/python
-RUFF := $(VENV)/bin/ruff
-MYPY := $(VENV)/bin/mypy
-PYTEST := $(VENV)/bin/pytest
-BANDIT := $(VENV)/bin/bandit
-PIPAUDIT := $(VENV)/bin/pip-audit
+ifeq ($(OS),Windows_NT)
+PY := py.exe -3.11
+VENV_BIN := $(VENV)/Scripts
+EXE := .exe
+else
+PY := python3.11
+VENV_BIN := $(VENV)/bin
+EXE :=
+endif
+PIP := $(VENV_BIN)/pip$(EXE)
+PYTHON := $(VENV_BIN)/python$(EXE)
+RUFF := $(VENV_BIN)/ruff$(EXE)
+MYPY := $(VENV_BIN)/mypy$(EXE)
+PYTEST := $(VENV_BIN)/pytest$(EXE)
+BANDIT := $(VENV_BIN)/bandit$(EXE)
+PIPAUDIT := $(VENV_BIN)/pip-audit$(EXE)
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
@@ -20,13 +35,13 @@ onboard: ## "I am Ben, get me ready to party." (interactive). Pass NAME=ben to s
 catchup: ## Resume work after a sync break: pull main, refresh deps, summarize what changed
 	@bash scripts/catchup.sh
 
-$(VENV)/bin/activate: pyproject.toml requirements-ci.txt ## Create venv if missing
+$(VENV_BIN)/activate: pyproject.toml requirements-ci.txt ## Create venv if missing
 	$(PY) -m venv $(VENV)
-	$(PIP) install --upgrade pip
-	$(PIP) install -r requirements-ci.txt
-	$(PIP) install -e ".[dev]"
+	$(PYTHON) -m pip install --upgrade pip
+	$(PYTHON) -m pip install -r requirements-ci.txt
+	$(PYTHON) -m pip install -e ".[dev]"
 
-install: $(VENV)/bin/activate ## Install core deps into venv (everyone runs this first)
+install: $(VENV_BIN)/activate ## Install core deps into venv (everyone runs this first)
 
 install-crypto: install ## Install ML-DSA / liboqs deps. ONLY for Satriyo (P2). Requires `liboqs` system lib first.
 	@if ! pkg-config --exists liboqs 2>/dev/null && [ ! -f /usr/local/lib/liboqs.dylib ] && [ ! -f /usr/local/lib/liboqs.so ] && [ ! -f /opt/homebrew/lib/liboqs.dylib ]; then \
@@ -39,11 +54,11 @@ install-crypto: install ## Install ML-DSA / liboqs deps. ONLY for Satriyo (P2). 
 		echo "After installing liboqs, run 'make install-crypto' again."; \
 		exit 1; \
 	fi
-	$(PIP) install -e ".[crypto]"
+	$(PYTHON) -m pip install -e ".[crypto]"
 	@echo "[OK] crypto deps installed. You can now: make sign-bench"
 
 install-voice: install ## Install Whisper + Piper deps. ONLY for Jon (P1).
-	$(PIP) install -e ".[voice]"
+	$(PYTHON) -m pip install -e ".[voice]"
 	@echo "[OK] voice deps installed."
 
 fmt: install ## Format code with ruff
@@ -81,7 +96,7 @@ ci: lint test security ## Full CI gate (must pass before push)
 	@echo "[OK] make ci passed"
 
 run: install ## Start the agent service locally (stub)
-	$(VENV)/bin/uvicorn agent.app:app --host 0.0.0.0 --port 8000 --reload
+	$(VENV_BIN)/uvicorn$(EXE) agent.app:app --host 0.0.0.0 --port 8000 --reload
 
 tcpdump-demo: ## Open tcpdump no-outbound monitor + audit log scroll for the security proof
 	@bash infra/security_demo_monitors.sh
@@ -98,7 +113,7 @@ inject-demo: install ## Demo pitch beat: unsigned CoT rejected, signed CoT accep
 sign-bench: install ## Sign + verify 1000 CoT round-trips, assert < 5 ms avg (issue #12)
 	$(PYTHON) crypto/sign_bench.py
 
-protect-branch: ## Lock main branch protection via GitHub API (needs GITHUB_TOKEN env var)
+protect-branch: ## Lock main branch protection via GitHub API (GITHUB_TOKEN or gh auth)
 	@bash infra/protect_branch.sh
 
 demo: install ## Run the hero scenario end-to-end (lands by Sun 0500)

--- a/crypto/sign_bench.py
+++ b/crypto/sign_bench.py
@@ -11,7 +11,6 @@ On a dev laptop this is usually < 1 ms (Ed25519 fallback) or < 2 ms (ML-DSA-65).
 
 from __future__ import annotations
 
-import json
 import sys
 import time
 from pathlib import Path

--- a/infra/protect_branch.sh
+++ b/infra/protect_branch.sh
@@ -1,35 +1,47 @@
 #!/usr/bin/env bash
 # Set branch protection on main. Issue #2.
 #
-# Requires a GitHub personal access token with repo scope.
-# Set GITHUB_TOKEN env var before running:
+# Requires either:
+#   1. GITHUB_TOKEN env var with repo administration permission, or
+#   2. an authenticated gh CLI session (`gh auth login`).
 #
-#   export GITHUB_TOKEN="ghp_..."
+# Env-var path:
+#
+#   export GITHUB_TOKEN="<token-with-repo-admin-permission>"
 #   bash infra/protect_branch.sh
 #
-# Or use gh CLI (preferred when installed):
-#   gh api -X PUT "repos/jdev-02/tera/branches/main/protection" \
-#     -f required_status_checks='{"strict":true,"contexts":["ci"]}' \
-#     -f enforce_admins=true \
-#     -f required_pull_request_reviews='{"required_approving_review_count":0}' \
-#     -f restrictions=null
+# gh path:
+#
+#   gh auth login
+#   bash infra/protect_branch.sh
 #
 # Web UI fallback (Settings -> Branches -> Add rule for "main"):
-#   ☑ Require pull request before merging
-#   ☑ Require status checks to pass  -> select "ci"
-#   ☑ Do not allow bypassing above settings
-#   ☑ Include administrators
+#   - Require pull request before merging
+#   - Require status checks to pass -> select "ci"
+#   - Do not allow bypassing above settings
+#   - Include administrators
 
 set -euo pipefail
 
 REPO="jdev-02/tera"
 BRANCH="main"
 
-if [ -z "${GITHUB_TOKEN:-}" ]; then
-    echo "ERROR: GITHUB_TOKEN is not set."
+TOKEN="${GITHUB_TOKEN:-}"
+
+if [ -z "$TOKEN" ] && command -v gh >/dev/null 2>&1; then
+    echo "[protect_branch] GITHUB_TOKEN not set; trying gh auth token..."
+    TOKEN="$(gh auth token 2>/dev/null || true)"
+fi
+
+if [ -z "$TOKEN" ]; then
+    echo "ERROR: No GitHub token available."
     echo ""
-    echo "Set it with:"
-    echo "  export GITHUB_TOKEN=ghp_..."
+    echo "Option 1:"
+    echo "  export GITHUB_TOKEN=<token-with-repo-admin-permission>"
+    echo "  bash infra/protect_branch.sh"
+    echo ""
+    echo "Option 2:"
+    echo "  gh auth login"
     echo "  bash infra/protect_branch.sh"
     exit 1
 fi
@@ -38,21 +50,23 @@ PAYLOAD='{"required_status_checks":{"strict":true,"contexts":["ci"]},"enforce_ad
 
 echo "[protect_branch] Setting protection on ${REPO}:${BRANCH}..."
 
-STATUS=$(curl -s -o /tmp/protect_branch_response.json -w "%{http_code}" \
+RESPONSE_FILE="${TMPDIR:-/tmp}/protect_branch_response.json"
+
+STATUS=$(curl -s -o "$RESPONSE_FILE" -w "%{http_code}" \
     -X PUT \
-    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "Authorization: Bearer ${TOKEN}" \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "https://api.github.com/repos/${REPO}/branches/${BRANCH}/protection" \
     -d "$PAYLOAD")
 
 if [ "$STATUS" -eq 200 ] || [ "$STATUS" -eq 201 ]; then
-    echo "[protect_branch] OK — branch protection enabled on ${REPO}:${BRANCH}"
+    echo "[protect_branch] OK - branch protection enabled on ${REPO}:${BRANCH}"
     echo "[protect_branch] Required checks: ci"
     echo "[protect_branch] Enforce admins: true"
     echo "[protect_branch] Direct push to main: BLOCKED"
 else
-    echo "[protect_branch] ERROR — HTTP $STATUS"
-    cat /tmp/protect_branch_response.json 2>/dev/null || true
+    echo "[protect_branch] ERROR - HTTP $STATUS"
+    cat "$RESPONSE_FILE" 2>/dev/null || true
     exit 1
 fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,10 +3,26 @@ pre-commit:
   commands:
     fmt:
       glob: "*.{py}"
-      run: .venv/bin/ruff format --check {staged_files} || (.venv/bin/ruff format {staged_files} && echo "Files reformatted; please re-stage and re-commit." && exit 1)
+      run: |
+        if [ -x .venv/Scripts/ruff.exe ]; then
+          ruff=.venv/Scripts/ruff.exe
+        else
+          ruff=.venv/bin/ruff
+        fi
+        "$ruff" format --check {staged_files} || {
+          "$ruff" format {staged_files}
+          echo 'Files reformatted; please re-stage and re-commit.'
+          exit 1
+        }
     lint:
       glob: "*.{py}"
-      run: .venv/bin/ruff check {staged_files}
+      run: |
+        if [ -x .venv/Scripts/ruff.exe ]; then
+          ruff=.venv/Scripts/ruff.exe
+        else
+          ruff=.venv/bin/ruff
+        fi
+        "$ruff" check {staged_files}
     gitleaks:
       run: which gitleaks > /dev/null && gitleaks protect --staged --redact --no-banner || true
 
@@ -14,7 +30,7 @@ commit-msg:
   commands:
     conventional:
       run: |
-        msg=$(head -1 "$1")
+        msg=$(head -1 "{1}")
         if echo "$msg" | grep -Eq '^(feat|fix|chore|refactor|test|docs|ci|perf|style)(\([a-z0-9-]+\))?: .{3,}'; then
           exit 0
         fi

--- a/security/cot_inject_demo.py
+++ b/security/cot_inject_demo.py
@@ -17,10 +17,10 @@ Usage:
 
 from __future__ import annotations
 
-import json
 import sys
-import xml.etree.ElementTree as ET
 from pathlib import Path
+
+import defusedxml.ElementTree
 
 # Allow running from repo root or from security/ directory.
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -58,6 +58,7 @@ SAMPLE_ROUTE = CotRoute(
 # Output helpers (ASCII-safe for Windows cp1252 + Linux UTF-8)
 # ---------------------------------------------------------------------------
 
+
 def _line(char: str = "-", width: int = 60) -> str:
     return char * width
 
@@ -76,6 +77,7 @@ def _print_result(label: str, r: VerificationResult, expect_valid: bool) -> bool
 # ---------------------------------------------------------------------------
 # Demo
 # ---------------------------------------------------------------------------
+
 
 def demo() -> None:
     print()
@@ -103,7 +105,9 @@ def demo() -> None:
     print("This is what every legacy device on the mesh already sends.")
     print()
     r = verify_cot(SAMPLE_COT)
-    all_passed &= _print_result("unsigned CoT from legacy device / adversary", r, expect_valid=False)
+    all_passed &= _print_result(
+        "unsigned CoT from legacy device / adversary", r, expect_valid=False
+    )
 
     # ------------------------------------------------------------------
     # Scenario 2: Tampered CoT -- valid signature, wrong lat/lon
@@ -118,13 +122,15 @@ def demo() -> None:
     signed_dict = sign_cot(SAMPLE_ROUTE)
     signed_xml = _embed(SAMPLE_COT, signed_dict)
     # Tamper: change point lat in the outer CoT envelope after signing
-    root = ET.fromstring(signed_xml)  # safe -- we just built it
+    root = defusedxml.ElementTree.fromstring(signed_xml)  # safe -- we just built it
     point = root.find("point")
     assert point is not None
     point.set("lat", "99.999")  # attacker moves the destination
-    tampered_xml = ET.tostring(root, encoding="unicode")
+    tampered_xml = defusedxml.ElementTree.tostring(root, encoding="unicode")
     r = verify_cot(tampered_xml)
-    all_passed &= _print_result("tampered CoT (destination moved by attacker)", r, expect_valid=False)
+    all_passed &= _print_result(
+        "tampered CoT (destination moved by attacker)", r, expect_valid=False
+    )
 
     # ------------------------------------------------------------------
     # Scenario 3: Properly signed route from Jetson
@@ -141,7 +147,7 @@ def demo() -> None:
     r = verify_cot(valid_xml)
     print(f"  Algorithm : {signed_dict2['algorithm']}")
     print(f"  Key ID    : {signed_dict2['key_id']}")
-    short_sig = signed_dict2['signature'][:32] + "..."
+    short_sig = signed_dict2["signature"][:32] + "..."
     print(f"  Sig (hex) : {short_sig}")
     print()
     all_passed &= _print_result("signed CoT from Jetson", r, expect_valid=True)

--- a/tests/test_prompt_tak_context.py
+++ b/tests/test_prompt_tak_context.py
@@ -4,20 +4,15 @@ from pathlib import Path
 
 from ontology.loader import build_system_prompt
 
-
 PROMPT_DIR = Path("prompts/local_model_prompts")
 
 
 def test_tera_prompts_include_tak_output_context() -> None:
-    full_prompt = (PROMPT_DIR / "tera_full_system_prompt.md").read_text(
+    full_prompt = (PROMPT_DIR / "tera_full_system_prompt.md").read_text(encoding="utf-8")
+    local_prompt = (PROMPT_DIR / "tera_local_model_system_prompt.md").read_text(encoding="utf-8")
+    sourcing_prompt = (PROMPT_DIR / "imagery_sourcing_local_model_system_prompt.md").read_text(
         encoding="utf-8"
     )
-    local_prompt = (PROMPT_DIR / "tera_local_model_system_prompt.md").read_text(
-        encoding="utf-8"
-    )
-    sourcing_prompt = (
-        PROMPT_DIR / "imagery_sourcing_local_model_system_prompt.md"
-    ).read_text(encoding="utf-8")
 
     assert "## TAK Output Intent" in full_prompt
     assert "signed TAK CoT" in full_prompt


### PR DESCRIPTION
## Summary
- let `infra/protect_branch.sh` use `GITHUB_TOKEN` or fall back to `gh auth token`
- make `make ci` and lefthook work on Windows with Git Bash + Python 3.11 venv paths
- clean existing lint blockers in sign-bench / inject-demo proof files

## Test Plan
- `lefthook run pre-commit --force`
- `make ci` (148 passed)
- `git push` pre-push hook ran `make ci` successfully

Notes: `gitleaks` is not installed locally, so the local security target reported the existing fallback message; GitHub Actions still runs the gitleaks gate. The existing `pyproject.toml` mypy warning for `security.*` still appears and is tracked by #35.

Follow-up for #2 and #3.