### PR TITLE
docs: NPS Foundation Entrepreneurship Club affiliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TERA — Tactical Edge Route Agent
 
-> **By Team TruePoint** · National Security Hackathon 2026 (Cerebral Valley × US Army xTech)
+> **By Team TruePoint** — competing as members of the **[Naval Postgraduate School Foundation](https://npsfoundation.org/) Entrepreneurship Club** · National Security Hackathon 2026 (Cerebral Valley × US Army xTech)
 >
 > A pocket-sized, fully-offline AI agent that turns natural language into trustworthy tactical routes inside ATAK, on a Jetson Orin Nano, with no cloud and no outbound packets. Voice in, voice and visual out — operators can navigate hands-free while climbing, fast-roping, or running another task.
 

--- a/team.yml
+++ b/team.yml
@@ -4,6 +4,18 @@
 # Update github_username for each member at kickoff (Jon owns this).
 # Then run: bash scripts/sync-team.sh   (rewrites CODEOWNERS with the real handles)
 
+# All team members compete as members of the NPS Foundation Entrepreneurship
+# Club -- not in any representative US Army / Navy / DoD capacity. The NPS
+# Foundation (501(c)(3)) funded the team's travel to the event in support of
+# the Entrepreneurship Club program. See docs/SUBMISSION_NOTES.md for the
+# full eligibility / ethics posture.
+affiliation:
+  organization: "Naval Postgraduate School Foundation"
+  program: "Entrepreneurship Club"
+  legal_status: "501(c)(3) non-profit"
+  representing: "NPS Foundation"
+  not_representing: ["US Army", "US Navy", "DoD"]
+
 team:
   - id: jon
     name: Jon
@@ -50,7 +62,7 @@ team:
     email: TODO_kyle_email
     resources_owned:
       - { name: "Cesium Ion token", scope: "NPS SF Hackathon, khicks1724", consumers: [jon, ben], stored_in: ".env -> CESIUM_ION_TOKEN" }
-      - { name: "Prior reference material", url: "", note: "Kyle's prior planning reference. Public + openly accessible per hackathon Tool Usage rule. Use as a REFERENCE for design patterns or as a dependency if licensed permissively. Do NOT copy-paste source into our repo (project must be 'new work only'). Most relevant to: mesh stretch (#23), parsing-verification on RF anomalies (#22)." }
+      - { name: "RFSim repo (reference, not copy-paste)", url: "https://github.com/khicks1724/RFSim", note: "Kyle's prior RF simulator. Public + openly accessible per hackathon Tool Usage rule. Use as a REFERENCE for design patterns or as a dependency if licensed permissively. Do NOT copy-paste source into our repo (project must be 'new work only'). Most relevant to: mesh stretch (#23), parsing-verification on RF anomalies (#22)." }
 
   - id: ben
     name: Ben


### PR DESCRIPTION
Codifies the team's affiliation per call at Sat 18:30 — we compete as members of the **NPS Foundation Entrepreneurship Club**, not in any representative US Army / Navy / DoD capacity.

## Changes

- **\`README.md\`** — header now reads \"competing as members of the Naval Postgraduate School Foundation Entrepreneurship Club\" so xTech / Cerebral Valley judges and any auditor see this immediately on first contact with the repo.
- **\`team.yml\`** — new top-level \`affiliation\` block (organization, program, legal status, who we represent, who we don't). Single source of truth for any derived deck / correspondence content.
- **\`.gitignore\`** — ignores \`models/piper/*.onnx\` and \`*.onnx.json\` so any branch off main doesn't accidentally commit the 78MB voice model. PR #49's branch already has these; landing here unblocks future branches.

## Out of scope

The full eligibility / ethics / prize-handling posture (resources, OPSEC, NPS Foundation as 501(c)(3) prize recipient) lives in \`docs/SUBMISSION_NOTES.md\`, which lands with PR #49 (voice).

## Test plan

- [x] \`ruff format --check\` clean
- [x] 119/119 tests still green
- [x] \`gitignore\` change verified by attempting \`git add models/piper/\` (now correctly ignored)