### PR TITLE
chore(infra): enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+.gitattributes text eol=lf
+*.sh text eol=lf
+Makefile text eol=lf
+lefthook.yml text eol=lf
+.github/workflows/*.yml text eol=lf


### PR DESCRIPTION
## Summary

- Adds `.gitattributes` covering shell scripts, Makefile, lefthook config, and GitHub workflows
- Prevents the WSL Bash parse failure (`syntax error near unexpected token $'{\r''`) that Satriyo hit on Windows checkouts
- Minimal scope — file-only, no content rewrites. Git normalizes line endings on next checkout for any file matching the patterns

## Why this PR replaces #55

PR #55 had the same intent but its Codex-generated patch contained character-deletion regressions across 6 files that would have broken `make run`, `make demo-proofs`, `make tcpdump-demo`, and `make onboard` at runtime:

- Makefile: `uvicorn` → `uvicon`
- infra/audit_log_scroll.sh: `dirname` → `diname`
- infra/cot_signed_scroll.sh: `dirname` → `diname`
- infra/security_demo_monitors.sh: `dirname` → `diname`
- infra/tcpdump_demo.sh: `external` → `extenal` (comment)
- scripts/onboard.sh: `warn` → `wan` (function + every callsite)

`make ci` doesn't invoke these scripts, so the test suite missed all six. They would only have surfaced at demo time.

This PR adds *only* the `.gitattributes` policy file. Existing files are left untouched. Anyone who needs an explicit re-normalize can run `git add --renormalize .` in a follow-up scoped commit (uses git's built-in normalizer, not an LLM rewrite).

## Test plan

- File contents: 5 lines, 126 bytes, all LF line endings (verified with \`xxd\`)
- Existing test suite still passes: \`make ci\` → 148 tests passing on main as of #53
- WSL verification (Satriyo): after merge, run \`git rm --cached -r . && git reset --hard HEAD\` to force re-checkout with normalization applied

Refs #15.