### PR TITLE
fix(infra): repair LF normalization typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ ci: lint test security ## Full CI gate (must pass before push)
 	@echo "[OK] make ci passed"
 
 run: install ## Start the agent service locally (stub)
-	$(VENV_BIN)/uvicon$(EXE) agent.app:app --host 0.0.0.0 --port 8000 --reload
+	$(VENV_BIN)/uvicorn$(EXE) agent.app:app --host 0.0.0.0 --port 8000 --reload
 
 tcpdump-demo: ## Open tcpdump no-outbound monitor + audit log scroll for the security proof
 	@bash infra/security_demo_monitors.sh

--- a/infra/audit_log_scroll.sh
+++ b/infra/audit_log_scroll.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 AUDIT_LOG="${WAYFINDER_AUDIT_LOG:-logs/security_audit.jsonl}"
 TAIL_LINES="${TAIL_LINES:-30}"
 
-mkdir -p "$(diname "$AUDIT_LOG")"
+mkdir -p "$(dirname "$AUDIT_LOG")"
 touch "$AUDIT_LOG"
 
 echo "======================================================"

--- a/infra/cot_signed_scroll.sh
+++ b/infra/cot_signed_scroll.sh
@@ -14,7 +14,7 @@ OK_COLOR="\033[32m"
 WARN_COLOR="\033[33m"
 RESET="\033[0m"
 
-mkdir -p "$(diname "$AUDIT_LOG")"
+mkdir -p "$(dirname "$AUDIT_LOG")"
 touch "$AUDIT_LOG"
 
 echo "======================================================"

--- a/infra/tcpdump_demo.sh
+++ b/infra/tcpdump_demo.sh
@@ -31,7 +31,7 @@ touch "$TEXT_LOG" "$SUMMARY_LOG"
 
 # The firewall already blocks egress in the hero demo. The capture filter is a
 # second proof surface: it ignores loopback and TAK multicast so local runtime
-# traffic does not obscure extenal outbound attempts.
+# traffic does not obscure external outbound attempts.
 BPF_FILTER="${WAYFINDER_TCPDUMP_FILTER:-not (host 127.0.0.1 or host ::1 or dst net 224.0.0.0/4 or dst host 239.2.3.1)}"
 DIRECTION_ARGS=()
 if tcpdump -h 2>&1 | grep -q -- "-Q "; then

--- a/scripts/onboard.sh
+++ b/scripts/onboard.sh
@@ -19,7 +19,7 @@ YELLOW=$'\033[33m'; RED=$'\033[31m'; RESET=$'\033[0m'
 say()   { printf "%s\n" "$*"; }
 title() { printf "\n${BOLD}${CYAN}== %s ==${RESET}\n" "$*"; }
 ok()    { printf "  ${GREEN}[ok]${RESET}   %s\n" "$*"; }
-wan()  { printf "  ${YELLOW}[!!]${RESET}   %s\n" "$*"; }
+warn() { printf "  ${YELLOW}[!!]${RESET}   %s\n" "$*"; }
 err()   { printf "  ${RED}[xx]${RESET}   %s\n" "$*" >&2; }
 ask()   { printf "${BOLD}%s${RESET} " "$*"; }
 
@@ -113,35 +113,35 @@ for cand in python3.11 python3 python; do
         PY_CMD="$cand"; break
     fi
 done
-if [[ -n "$PY_CMD" ]]; then ok "Python 3.11 found ($PY_CMD)"; else wan "Python 3.11 not found (try: brew install python@3.11)"; PYOK=0; fi
+if [[ -n "$PY_CMD" ]]; then ok "Python 3.11 found ($PY_CMD)"; else warn "Python 3.11 not found (try: brew install python@3.11)"; PYOK=0; fi
 
 if command -v gh >/dev/null; then
     if gh auth status >/dev/null 2>&1; then ok "gh authed"
-    else wan "gh installed but not authed (run: gh auth login)"; GHOK=0
+    else warn "gh installed but not authed (run: gh auth login)"; GHOK=0
     fi
 else
-    wan "gh not installed (brew install gh, then: gh auth login)"; GHOK=0
+    warn "gh not installed (brew install gh, then: gh auth login)"; GHOK=0
 fi
 
 if command -v lefthook >/dev/null; then
     if [[ -f .git/hooks/pre-push ]]; then ok "lefthook installed (pre-push hook present)"
-    else wan "lefthook found but hooks not installed in this repo (run: lefthook install)"; HOOKOK=0
+    else warn "lefthook found but hooks not installed in this repo (run: lefthook install)"; HOOKOK=0
     fi
 else
-    wan "lefthook not installed (brew install lefthook && lefthook install)"; HOOKOK=0
+    warn "lefthook not installed (brew install lefthook && lefthook install)"; HOOKOK=0
 fi
 
 VENV_OK=1
 if [[ -d .venv ]]; then
-    if [[ -f .venv/bin/uvicon ]]; then ok ".venv exists and looks healthy"
-    else wan ".venv exists but seems incomplete (run: make install)"; VENV_OK=0
+    if [[ -f .venv/bin/uvicorn ]]; then ok ".venv exists and looks healthy"
+    else warn ".venv exists but seems incomplete (run: make install)"; VENV_OK=0
     fi
 else
-    wan ".venv missing. RUN THIS NOW: make install"
+    warn ".venv missing. RUN THIS NOW: make install"
     VENV_OK=0
 fi
 
-if [[ -f .env ]]; then ok ".env exists"; else wan ".env missing. RUN THIS NOW: cp .env.example .env"; fi
+if [[ -f .env ]]; then ok ".env exists"; else warn ".env missing. RUN THIS NOW: cp .env.example .env"; fi
 
 # Lane-specific install hint
 case "$NAME" in
@@ -149,17 +149,17 @@ case "$NAME" in
         if [[ -f .venv/bin/python ]] && .venv/bin/python -c "import oqs" 2>/dev/null; then
             ok "liboqs-python installed (you can run sign-bench)"
         else
-            wan "liboqs-python NOT installed yet. When you start issue #12 (signer), RUN THESE:"
-            wan "    1) brew install liboqs    (macOS)   OR   bash infra/install_liboqs.sh   (Linux)"
-            wan "    2) make install-crypto"
-            wan "(You do NOT need this for issues #2 or #3. Start with those.)"
+            warn "liboqs-python NOT installed yet. When you start issue #12 (signer), RUN THESE:"
+            warn "    1) brew install liboqs    (macOS)   OR   bash infra/install_liboqs.sh   (Linux)"
+            warn "    2) make install-crypto"
+            warn "(You do NOT need this for issues #2 or #3. Start with those.)"
         fi
         ;;
     jon)
         if [[ -f .venv/bin/python ]] && .venv/bin/python -c "import faster_whisper" 2>/dev/null; then
             ok "voice deps installed"
         else
-            wan "voice deps NOT installed yet. When you start voice work (issues #18, #26), RUN: make install-voice"
+            warn "voice deps NOT installed yet. When you start voice work (issues #18, #26), RUN: make install-voice"
         fi
         ;;
 esac
@@ -179,11 +179,11 @@ for i in data:
     if [[ -n "$ISSUES" ]]; then
         echo "$ISSUES"
     else
-        wan "no issues found with labels for your lane"
-        wan "run 'bash scripts/seed-issues.sh' first (Jon / Satriyo do this once at kickoff)"
+        warn "no issues found with labels for your lane"
+        warn "run 'bash scripts/seed-issues.sh' first (Jon / Satriyo do this once at kickoff)"
     fi
 else
-    wan "skipping issue pull (gh not authed)"
+    warn "skipping issue pull (gh not authed)"
 fi
 
 # --- Generate Codex prompt --------------------------------------------------


### PR DESCRIPTION
## Summary
- repair LF-normalization typo regressions called out by Jon
- restore `uvicorn`, `dirname`, `external`, and `warn` callsites
- leave `.gitattributes` in place; this PR does not re-run manual line-ending rewrites

## Test Plan
- typo grep: `uvicon|diname|extenal|\bwan\b` returned no matches in Makefile/infra/scripts
- `bash -n infra/audit_log_scroll.sh infra/cot_signed_scroll.sh infra/security_demo_monitors.sh infra/tcpdump_demo.sh scripts/onboard.sh scripts/catchup.sh scripts/seed-issues.sh`
- WSL: `/usr/bin/bash -n ...` on the same shell scripts
- `WAYFINDER_DEMO_DRY_RUN=1 make demo-proofs`
- `WAYFINDER_DEMO_DRY_RUN=1 make tcpdump-demo`
- WSL: `WAYFINDER_DEMO_DRY_RUN=1 make demo-proofs && WAYFINDER_DEMO_DRY_RUN=1 make tcpdump-demo && make -n run`
- `make onboard NAME=satriyo`
- WSL: `make onboard NAME=satriyo`
- WSL: `make catchup`
- `make ci` (206 passed)
- pre-push hook ran `make ci` successfully (206 passed)

Follow-up for #15 and supersedes the broken #55/#59 LF rewrite fallout.