### PR TITLE
feat(voice): per-request voice profile toggle on /plan (closes #54)

### DIFF
--- a/agent/app.py
+++ b/agent/app.py
@@ -10,7 +10,7 @@ module is just the FastAPI wrapper.
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, Literal
 
 import structlog
 from fastapi import FastAPI, HTTPException
@@ -48,14 +48,36 @@ def health() -> dict[str, Any]:
 
 
 @app.post("/plan", response_model=PlanResponse, responses={403: {"model": PlanBlocked}})
-async def plan_endpoint(req: PlanRequest, tts: bool = False) -> PlanResponse:
+async def plan_endpoint(
+    req: PlanRequest,
+    tts: bool = False,
+    profile: Literal["calm", "comms", "critical"] | None = None,
+) -> PlanResponse:
     """POST /plan with optional TTS.
 
-    `?tts=true` makes the orchestrator synthesize the rationale via Piper
-    and return it base64-encoded in `audio_b64`. Defaults to False so the
-    web frontend can keep doing what it does without surprise audio payloads.
-    The hero demo (PRD §6) sets `?tts=true`.
+    Query / body params:
+        ?tts=true            -- synthesize the rationale via Piper, return
+                                base64 WAV in `audio_b64`.
+        ?profile=<mode>      -- pin the voice profile for this request:
+                                'calm' (briefer voice, no FX), 'comms'
+                                (default ops cadence + radio FX), 'critical'
+                                (degraded radio FX for urgent contexts).
+                                Equivalent to setting `voice_profile` in
+                                the request body. The query-param form is
+                                here for curl ergonomics. If both forms are
+                                set, the body wins (explicit > implicit).
+                                None = read TERA_VOICE_PROFILE env var or
+                                fall back to 'comms'.
+
+    Defaults preserve old behavior: ?tts=false means audio_b64 is null.
+    The hero demo (PRD §6) sets `?tts=true`. Severity cues in the
+    rationale auto-elevate the chosen mode upward but never demote.
     """
+    if profile is not None and req.voice_profile is None:
+        # Promote query-param profile into the request body so the
+        # orchestrator sees a single source of truth. If req.voice_profile
+        # is already set in the body, keep that.
+        req = req.model_copy(update={"voice_profile": profile})
     try:
         return await orchestrate_plan(req, with_tts=tts)
     except PlanBlockedError as e:

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -424,7 +424,10 @@ async def plan(req: PlanRequest, mode: ModeOrAuto = "auto", with_tts: bool = Fal
         try:
             from voice.tts import synthesize_rationale_b64
 
-            audio_b64 = synthesize_rationale_b64(dispatch["rationale"])
+            audio_b64 = synthesize_rationale_b64(
+                dispatch["rationale"],
+                operator_mode=req.voice_profile,
+            )
         except Exception as e:  # noqa: BLE001 -- TTS failure must not fail /plan
             logger.warning("tts_synth_failed", error=str(e))
 

--- a/agent/schemas.py
+++ b/agent/schemas.py
@@ -57,12 +57,21 @@ class Coord(BaseModel):
 
 
 class PlanRequest(BaseModel):
-    """The operator's natural-language request + their current position."""
+    """The operator's natural-language request + their current position.
+
+    `voice_profile` lets the caller pin which voice the orchestrator uses
+    for the spoken rationale (PRD §6, issue #54). 'calm' = briefer voice,
+    'comms' = default ops cadence, 'critical' = degraded radio FX. None
+    means: read TERA_VOICE_PROFILE env var, falling back to 'comms'.
+    Severity cues in the rationale (CASEVAC, DANGER CLOSE, etc.) will
+    auto-elevate the chosen mode upward but never demote.
+    """
 
     prompt: str = Field(..., min_length=1, max_length=2000)
     current: Coord
     request_id: str | None = None
     source: Literal["operator_voice", "operator_text", "test"] = "operator_text"
+    voice_profile: Literal["calm", "comms", "critical"] | None = None
 
 
 class Waypoint(BaseModel):

--- a/tests/test_orchestrator_tts.py
+++ b/tests/test_orchestrator_tts.py
@@ -67,3 +67,81 @@ def test_plan_with_tts_query_returns_audio(client: TestClient) -> None:
     assert body["audio_b64"] is not None
     decoded = base64.b64decode(body["audio_b64"])
     assert decoded.startswith(b"RIFF")
+
+
+# ---------------------------------------------------------------------------
+# Voice profile toggle (#54)
+# ---------------------------------------------------------------------------
+
+
+def _capture_orchestrate_call(captured: dict) -> Any:
+    """Side-effect factory that records the PlanRequest the handler passed
+    to orchestrate_plan. Lets us assert the plumbing without running the
+    full pipeline."""
+
+    def _impl(req: Any, *args: Any, **kwargs: Any) -> Any:
+        captured["req"] = req
+        captured["kwargs"] = kwargs
+        return _fake_orchestrate_response(req, *args, **kwargs)
+
+    return _impl
+
+
+def test_voice_profile_query_param_promoted_to_body(client: TestClient) -> None:
+    """?profile=critical without a body field becomes req.voice_profile=critical."""
+    captured: dict[str, Any] = {}
+    with patch("agent.app.orchestrate_plan", side_effect=_capture_orchestrate_call(captured)):
+        r = client.post(
+            "/plan?tts=true&profile=critical",
+            json={
+                "prompt": "CASEVAC, plot route",
+                "current": {"lat": 37.78, "lon": -122.46},
+            },
+        )
+    assert r.status_code == 200, r.text
+    assert captured["req"].voice_profile == "critical"
+
+
+def test_voice_profile_body_field_wins_over_query_param(client: TestClient) -> None:
+    """If both forms are set, the body wins (explicit > implicit)."""
+    captured: dict[str, Any] = {}
+    with patch("agent.app.orchestrate_plan", side_effect=_capture_orchestrate_call(captured)):
+        r = client.post(
+            "/plan?tts=true&profile=calm",
+            json={
+                "prompt": "route to creek",
+                "current": {"lat": 37.78, "lon": -122.46},
+                "voice_profile": "critical",
+            },
+        )
+    assert r.status_code == 200, r.text
+    assert captured["req"].voice_profile == "critical"
+
+
+def test_voice_profile_unknown_value_rejected(client: TestClient) -> None:
+    """FastAPI / Pydantic should 422 on an unknown profile string."""
+    r = client.post(
+        "/plan",
+        json={
+            "prompt": "route to creek",
+            "current": {"lat": 37.78, "lon": -122.46},
+            "voice_profile": "tactical",  # not in the Literal
+        },
+    )
+    assert r.status_code == 422, r.text
+
+
+def test_voice_profile_default_is_none(client: TestClient) -> None:
+    """No profile in body or query -> req.voice_profile is None (orchestrator
+    falls back to env var or 'comms')."""
+    captured: dict[str, Any] = {}
+    with patch("agent.app.orchestrate_plan", side_effect=_capture_orchestrate_call(captured)):
+        r = client.post(
+            "/plan",
+            json={
+                "prompt": "route to creek",
+                "current": {"lat": 37.78, "lon": -122.46},
+            },
+        )
+    assert r.status_code == 200, r.text
+    assert captured["req"].voice_profile is None


### PR DESCRIPTION
Closes #54. Adds `PlanRequest.voice_profile` field + `?profile=` query param to POST /plan with body-wins-over-query precedence and a clean fallback to `TERA_VOICE_PROFILE` env var. Severity auto-elevation from #63 preserved (one-way: calm→comms→critical, never demotes). 238/238 tests green. ruff + format + mypy clean.