### PR TITLE
Infra/firewall dev protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ deploy/secrets/
 
 valhalla_tiles/
 *.gph
+certs/
 
 # ---------------------------------------------------------------------------
 # ATAK SDK is a developer prerequisite, NOT source.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help onboard catchup install install-crypto install-voice fmt lint test security shellcheck-syntax ci run tcpdump-demo audit-log demo-proofs inject-demo sign-bench demo eval clean protect-branch firewall firewall-remove firewall-status
+.PHONY: help onboard catchup install install-crypto install-voice fmt lint test security shellcheck-syntax ci run run-https gen-cert tcpdump-demo audit-log demo-proofs inject-demo sign-bench demo eval clean protect-branch firewall firewall-remove firewall-status
 .DEFAULT_GOAL := help
 
 ifeq ($(OS),Windows_NT)
@@ -100,8 +100,18 @@ shellcheck-syntax: ## bash -n parse-check on every committed shell script (catch
 	@echo "[shellcheck-syntax] parsing every *.sh under repo root..."
 	@status=0; 	while IFS= read -r f; do 	  if bash -n "$$f" 2>&1; then 	    echo "  [ok] $$f"; 	  else 	    echo "  [FAIL] $$f"; status=1; 	  fi; 	done < <(find . -name '*.sh' -not -path './.venv/*' -not -path './node_modules/*' -not -path './.git/*'); 	if [ $$status -eq 0 ]; then echo "[OK] all shell scripts parse cleanly"; else exit $$status; fi
 
-run: install ## Start the agent service locally (stub)
-	$(VENV_BIN)/uvicorn$(EXE) agent.app:app --host 0.0.0.0 --port 8000 --reload
+run: install ## Start the agent service on localhost only (HTTP, port 8000)
+	PYTHONIOENCODING=utf-8 $(VENV_BIN)/uvicorn$(EXE) agent.app:app --host 127.0.0.1 --port 8000 --reload
+
+gen-cert: ## Generate self-signed TLS cert for local HTTPS (run once, output to certs/)
+	@bash infra/gen_dev_cert.sh
+
+run-https: install gen-cert ## Start agent with HTTPS on localhost (port 8443)
+	PYTHONIOENCODING=utf-8 $(VENV_BIN)/uvicorn$(EXE) agent.app:app \
+		--host 127.0.0.1 --port 8443 \
+		--ssl-keyfile certs/key.pem \
+		--ssl-certfile certs/cert.pem \
+		--reload
 
 firewall: ## Block port 8000 from WiFi (Windows only). Run before `make run` on shared networks.
 	@powershell -ExecutionPolicy Bypass -File infra/firewall_dev.ps1 add

--- a/infra/gen_dev_cert.sh
+++ b/infra/gen_dev_cert.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Generate a self-signed TLS cert for local HTTPS development.
+# Run once before `make run-https`. Cert is gitignored (certs/).
+#
+# Usage:
+#   bash infra/gen_dev_cert.sh
+#   make gen-cert
+
+set -euo pipefail
+
+CERT_DIR="$(git rev-parse --show-toplevel)/certs"
+KEY="$CERT_DIR/key.pem"
+CERT="$CERT_DIR/cert.pem"
+
+mkdir -p "$CERT_DIR"
+
+if [[ -f "$KEY" && -f "$CERT" ]]; then
+    echo "[cert] Already exists: $CERT"
+    echo "[cert] Delete certs/ and re-run to regenerate."
+    exit 0
+fi
+
+openssl req -x509 -newkey rsa:2048 \
+    -keyout "$KEY" -out "$CERT" \
+    -days 365 -nodes \
+    -subj "/CN=localhost" \
+    -addext "subjectAltName=IP:127.0.0.1,DNS:localhost" 2>/dev/null
+
+echo ""
+echo "[cert] Generated: $CERT"
+echo "[cert] Key:       $KEY"
+echo "[cert] Valid for: 365 days (localhost + 127.0.0.1)"
+echo ""
+echo "[cert] Run server: make run-https"
+echo "[cert] NOTE: Browser will show 'Not secure' warning -- click Advanced -> Proceed."
+echo "[cert]       This is expected for self-signed certs on localhost."
+echo ""


### PR DESCRIPTION
## Summary

Harden local dev server: fix `make run` binding from `0.0.0.0` to
`127.0.0.1`, add `make run-https` (TLS on port 8443), and add
`make gen-cert` to generate a self-signed cert per-machine.

## Issue

Closes #N/A — security hardening follow-up to #71 (firewall script).
No dedicated issue; flagged during local WiFi hotspot testing.

## Test plan

- `make gen-cert` → cert generated at `certs/cert.pem` (gitignored)
- `make run-https` → server starts at `https://127.0.0.1:8443`
- `curl -sk https://127.0.0.1:8443/health` → `{"status":"ok",...}`
- `curl -s http://127.0.0.1:8443/health` → connection refused (HTTP rejected)
- `Test-NetConnection 10.1.62.209 -Port 8443` → TcpTestSucceeded: False
  (not accessible from WiFi — confirmed on shared hotspot)
- `make run` now uses `--host 127.0.0.1` instead of `0.0.0.0`

## Lane(s)

- [ ] agent / ontology / voice / eval (P1)
- [ ] atak / routing / data / figma (P4)
- [ ] hardware / deploy / models / mesh (P3)
- [x] security / crypto / infra / CI (P2)
- [ ] docs / cross-cutting

## Pre-merge checklist

- [ ] `make ci` passes locally
- [x] Conventional commit message
- [x] No secrets, no `.env`, no model weights committed
      (`certs/` is gitignored — private keys never enter repo)
- [x] AGENTS.md / lane file consulted before generating code
- [ ] AI PR review completed; HIGH findings addressed or waived
- [ ] Cross-lane: paired reviewer tagged
