### PR TITLE
Fix ATAK plugin host input and naming

### DIFF
--- a/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
+++ b/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
@@ -10,8 +10,10 @@ import android.os.Looper;
 import android.speech.RecognitionListener;
 import android.speech.RecognizerIntent;
 import android.speech.SpeechRecognizer;
+import android.text.InputType;
 import android.view.View;
 import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
@@ -208,12 +210,15 @@ public class TERAPlugin implements IPlugin {
 
         EditText hostEdit = new EditText(hostButton.getContext());
         hostEdit.setSingleLine(true);
+        hostEdit.setInputType(InputType.TYPE_CLASS_TEXT
+                | InputType.TYPE_TEXT_VARIATION_URI
+                | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
         hostEdit.setHint(R.string.host_input_hint);
         hostEdit.setText(hostState.toString());
         hostEdit.setTextSize(13);
-        hostEdit.setTextColor(Color.WHITE);
-        hostEdit.setHintTextColor(pluginContext.getResources().getColor(R.color.muted_gray));
-        hostEdit.setBackgroundResource(R.drawable.chat_icon_button_bg);
+        hostEdit.setTextColor(Color.BLACK);
+        hostEdit.setHintTextColor(Color.GRAY);
+        hostEdit.setBackgroundResource(R.drawable.host_input_bg);
         hostEdit.setPadding(dp(10), 0, dp(10), 0);
         hostEdit.setSelectAllOnFocus(false);
 
@@ -237,14 +242,15 @@ public class TERAPlugin implements IPlugin {
         content.addView(title);
         content.addView(hostEdit, new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
-                LinearLayout.LayoutParams.WRAP_CONTENT));
+                dp(38)));
         content.addView(actions);
 
         PopupWindow popup = new PopupWindow(content, dp(280),
                 LinearLayout.LayoutParams.WRAP_CONTENT, true);
         popup.setOutsideTouchable(true);
         popup.setInputMethodMode(PopupWindow.INPUT_METHOD_NEEDED);
-        popup.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+        popup.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
+                | WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
         popup.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(Color.TRANSPARENT));
 
         apply.setOnClickListener(v -> {
@@ -267,6 +273,14 @@ public class TERAPlugin implements IPlugin {
         });
 
         popup.showAsDropDown(hostButton, -dp(160), dp(6));
+        hostEdit.requestFocus();
+        mainHandler.postDelayed(() -> {
+            InputMethodManager imm = (InputMethodManager) pluginContext.getSystemService(
+                    Context.INPUT_METHOD_SERVICE);
+            if (imm != null) {
+                imm.showSoftInput(hostEdit, InputMethodManager.SHOW_IMPLICIT);
+            }
+        }, 100);
     }
 
     private void toggleVoiceInput(View voiceButton, EditText chatInput, TextView status,

--- a/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
+++ b/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
@@ -11,6 +11,7 @@ import android.speech.RecognitionListener;
 import android.speech.RecognizerIntent;
 import android.speech.SpeechRecognizer;
 import android.text.InputType;
+import android.view.Gravity;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
@@ -245,9 +246,10 @@ public class TERAPlugin implements IPlugin {
                 dp(38)));
         content.addView(actions);
 
-        PopupWindow popup = new PopupWindow(content, dp(280),
+        PopupWindow popup = new PopupWindow(content, dp(300),
                 LinearLayout.LayoutParams.WRAP_CONTENT, true);
         popup.setOutsideTouchable(true);
+        popup.setClippingEnabled(false);
         popup.setInputMethodMode(PopupWindow.INPUT_METHOD_NEEDED);
         popup.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
                 | WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
@@ -272,7 +274,8 @@ public class TERAPlugin implements IPlugin {
             popup.dismiss();
         });
 
-        popup.showAsDropDown(hostButton, -dp(160), dp(6));
+        popup.showAtLocation(hostButton.getRootView(),
+                Gravity.TOP | Gravity.CENTER_HORIZONTAL, 0, dp(18));
         hostEdit.requestFocus();
         mainHandler.postDelayed(() -> {
             InputMethodManager imm = (InputMethodManager) pluginContext.getSystemService(

--- a/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
+++ b/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
@@ -11,6 +11,7 @@ import android.speech.RecognitionListener;
 import android.speech.RecognizerIntent;
 import android.speech.SpeechRecognizer;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
@@ -211,7 +212,10 @@ public class TERAPlugin implements IPlugin {
         hostEdit.setText(hostState.toString());
         hostEdit.setTextSize(13);
         hostEdit.setTextColor(Color.WHITE);
-        hostEdit.setHintTextColor(Color.GRAY);
+        hostEdit.setHintTextColor(pluginContext.getResources().getColor(R.color.muted_gray));
+        hostEdit.setBackgroundResource(R.drawable.chat_icon_button_bg);
+        hostEdit.setPadding(dp(10), 0, dp(10), 0);
+        hostEdit.setSelectAllOnFocus(false);
 
         LinearLayout actions = new LinearLayout(hostButton.getContext());
         actions.setOrientation(LinearLayout.HORIZONTAL);
@@ -239,6 +243,8 @@ public class TERAPlugin implements IPlugin {
         PopupWindow popup = new PopupWindow(content, dp(280),
                 LinearLayout.LayoutParams.WRAP_CONTENT, true);
         popup.setOutsideTouchable(true);
+        popup.setInputMethodMode(PopupWindow.INPUT_METHOD_NEEDED);
+        popup.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         popup.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(Color.TRANSPARENT));
 
         apply.setOnClickListener(v -> {

--- a/atak/plugin/app/src/main/res/drawable/host_input_bg.xml
+++ b/atak/plugin/app/src/main/res/drawable/host_input_bg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="7dp" />
+    <solid android:color="#F2F2F2" />
+    <stroke android:width="1dp" android:color="#8A8A8A" />
+</shape>

--- a/atak/plugin/app/src/main/res/values/strings.xml
+++ b/atak/plugin/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App -->
-    <string name="app_name">TERA.ai</string>
+    <string name="app_name">TERA</string>
     <!-- description -->
     <string name="app_desc">Tactical Edge Route Agent</string>
     <string name="endpoint_hint">http://127.0.0.1:8000/plan</string>
@@ -29,8 +29,8 @@
     <string name="mic_button">VOICE</string>
     <string name="tts_button">TEXT TO SPEECH</string>
     <string name="info_button">INFO</string>
-    <string name="tera_info_title">About TERA.ai</string>
-    <string name="tera_info_message">TERA.ai is a tactical edge assistant for chat-driven route planning and field decision support. Enter a host, send a message, and review agent responses in the chat transcript.</string>
+    <string name="tera_info_title">About TERA</string>
+    <string name="tera_info_message">TERA is a tactical edge assistant for chat-driven route planning and field decision support. Enter a host, send a message, and review agent responses in the chat transcript.</string>
     <string name="status_sending">Sending message...</string>
     <string name="status_listening">Listening...</string>
 


### PR DESCRIPTION
## Summary\n- restore the visible ATAK plugin name to TERA\n- make the host entry field readable while typing\n- move the host popup to the top of the ATAK window so the keyboard does not cover it\n\n## Verification\n- ./gradlew assembleCivRelease