### PR TITLE
chore: gitignore demo videos / audio recordings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,19 @@ local.properties
 **/.takdev/
 *.apk
 *.aab
+
+# ---------------------------------------------------------------------------
+# Demo / video / audio recordings should NEVER live in the repo.
+# Save to ~/Desktop/tera-demo-clips/ (gitignored at home dir level)
+# or share via the team Drive folder. See docs/demo-recording-plan.md.
+# ---------------------------------------------------------------------------
+*.mov
+*.mp4
+*.webm
+*.mkv
+*.m4a
+*.mp3
+*.flac
+*.wav
+!tests/**/*.wav
+!models/piper/*.onnx.json


### PR DESCRIPTION
Defensive guard. Ben's atak-plugin-mvp-demo.mov (88MB) showed up at the repo root tonight; one `git add -A` from anyone and we ship binaries to public origin.

Adds:
- `*.mov`, `*.mp4`, `*.webm`, `*.mkv` — video
- `*.m4a`, `*.mp3`, `*.flac` — audio
- `*.wav` — audio (preserves `tests/**/*.wav` and `models/piper/*.onnx.json` via negation rules)

Ben's clip moved to `~/Desktop/tera-demo-clips/`.