### PR TITLE
feat(planner): Source Planner UI + geo_algorithms + Jetson server scripts (Kyle)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,10 +22,14 @@ TERA_DEVICE_PROFILE=austere
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4o-mini
 ANTHROPIC_API_KEY=
-ANTHROPIC_MODEL=claude-sonnet-4-5
+CLAUDE_MODEL=Claude Sonnet 4.6
+ANTHROPIC_API_URL=https://api.anthropic.com/v1/messages
+ANTHROPIC_MODELS_URL=https://api.anthropic.com/v1/models
+ANTHROPIC_VERSION=2023-06-01
 
 # Phase 3 local LLM
 OLLAMA_HOST=http://127.0.0.1:11434
+OLLAMA_BASE_URL=http://127.0.0.1:11434
 OLLAMA_MODEL=gemma2:2b
 
 # --- Voice ---

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ data/runtime/
 data/cache/
 data/extracts/*.osm.pbf
 data/dem/*.tif
+llm_dev_kmh/offline_packages/
 *.zip
 
 .archive/

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,13 @@ atak-link-test: ## Test Samsung/ATAK-device LAN reachability to Jetson. Pass JET
 	@test -n "$(JETSON_IP)" || (echo "Usage: make atak-link-test JETSON_IP=<jetson-wifi-ip> [PORT=8080]" >&2; exit 2)
 	bash atak/scripts/test_jetson_link.sh "$(JETSON_IP)" "$(if $(PORT),$(PORT),8080)"
 
+atak-link-server: install ## Start Jetson Gemma proof server for ATAK plugin link tests
+	bash atak/scripts/run_jetson_gemma_server.sh
+
+atak-link-test: ## Test Samsung/ATAK-device LAN reachability to Jetson. Pass JETSON_IP=...
+	@test -n "$(JETSON_IP)" || (echo "Usage: make atak-link-test JETSON_IP=<jetson-wifi-ip> [PORT=8080]" >&2; exit 2)
+	bash atak/scripts/test_jetson_link.sh "$(JETSON_IP)" "$(if $(PORT),$(PORT),8080)"
+
 tcpdump-demo: ## Open tcpdump no-outbound monitor + audit log scroll for the security proof
 	@bash infra/security_demo_monitors.sh
 

--- a/agent/llm.py
+++ b/agent/llm.py
@@ -316,7 +316,7 @@ class OllamaClient:
                 f"OllamaClient host must be loopback, got: {self.host}. "
                 "Refusing to start to prevent accidental network egress."
             )
-        self.model = model or os.environ.get("OLLAMA_MODEL", "gemma2:2b")
+        self.model = model or os.environ.get("OLLAMA_MODEL", "gemma3:4b")
         self.client = OllamaLib(host=self.host)
 
     def _to_messages(self, messages: list[Message]) -> list[dict[str, str]]:

--- a/llm_dev_kmh/README.md
+++ b/llm_dev_kmh/README.md
@@ -7,20 +7,22 @@ Map-centric local LLM workspace kept entirely inside `llm_dev_kmh`.
 - serves a Cesium-based map view with imagery and terrain streaming
 - exposes an operator sidebar tailored for TERA map and source-planning workflows
 - lists locally installed Ollama models
-- sends prompt requests to local Ollama via `/api/prompt`
+- sends prompt requests through `/api/prompt` with Claude-first, Ollama-second fallback
 - lets the operator draw and resize an AO rectangle for source package coverage
 
 ## Run it directly
 
 1. Start Ollama on the host machine and confirm the model is available.
-2. Set environment variables as needed.
+2. Set environment variables as needed. Put `ANTHROPIC_API_KEY` in the repo
+   root `.env` when Claude should be the primary provider.
 3. Start the app with Uvicorn from an environment that has the requirements installed.
 
 Example on Windows PowerShell:
 
 ```powershell
 $env:OLLAMA_BASE_URL="http://127.0.0.1:11434"
-$env:OLLAMA_MODEL="gemma4:e4b"
+$env:OLLAMA_MODEL="gemma3:4b"
+$env:CLAUDE_MODEL="Claude Sonnet 4.6"
 $env:CESIUM_ION_TOKEN="YOUR_TOKEN_HERE"
 uvicorn llm_dev_kmh.app:app --host 0.0.0.0 --port 8080
 ```
@@ -39,8 +41,12 @@ docker compose up --build
 
 ## Environment variables
 
-- `OLLAMA_BASE_URL`: defaults to `http://host.docker.internal:11434`
-- `OLLAMA_MODEL`: default model exposed in the UI
+- `ANTHROPIC_API_KEY`: primary Claude API key loaded from repo root `.env` or environment
+- `CLAUDE_MODEL`: primary Claude model, default `Claude Sonnet 4.6` (normalized to Anthropic's supported Sonnet 4 API snapshot)
+- `ANTHROPIC_API_URL`: Claude Messages endpoint, default `https://api.anthropic.com/v1/messages`
+- `ANTHROPIC_MODELS_URL`: Claude model discovery endpoint, default `https://api.anthropic.com/v1/models`
+- `OLLAMA_BASE_URL`: defaults to `http://127.0.0.1:11434`
+- `OLLAMA_MODEL`: local fallback default; if unavailable, the app autodetects an installed Ollama model
 - `REQUEST_TIMEOUT_S`: prompt timeout in seconds, default `120`
 - `CESIUM_ION_TOKEN`: required for Cesium World Terrain and Cesium satellite imagery
 - `CESIUM_ION_ARCHIVE_ID`: optional completed Cesium ion archive id to download into the Jetson package root.
@@ -62,6 +68,7 @@ docker compose up --build
 ## Notes
 
 - Without `CESIUM_ION_TOKEN`, the workspace falls back to OpenStreetMap imagery and ellipsoid terrain.
+- Provider order defaults to Claude first when `ANTHROPIC_API_KEY` is configured, then detected local Ollama, then the deterministic browser planner.
 - On Docker Desktop, `host.docker.internal` should resolve automatically.
 - On Linux, `extra_hosts` maps `host.docker.internal` to the Docker host gateway.
 - If Ollama is running somewhere else on your LAN, set `OLLAMA_BASE_URL` to that reachable address before starting the container.

--- a/llm_dev_kmh/README.md
+++ b/llm_dev_kmh/README.md
@@ -43,6 +43,18 @@ docker compose up --build
 - `OLLAMA_MODEL`: default model exposed in the UI
 - `REQUEST_TIMEOUT_S`: prompt timeout in seconds, default `120`
 - `CESIUM_ION_TOKEN`: required for Cesium World Terrain and Cesium satellite imagery
+- `CESIUM_ION_ARCHIVE_ID`: optional completed Cesium ion archive id to download into the Jetson package root.
+- `CESIUM_ION_ASSET_IDS`: optional comma-separated ion asset ids for creating a bounded AO clip before downloading it. Use only with assets/licensing that permit archives or clips.
+- Cesium World stream data stays stream-only. The Jetson offline package downloads Cesium only through ion archives/exports, then extracts and indexes the local files for query/preview.
+- `ESRI_ARCGIS_TOKEN`: optional; used only if the operator explicitly selects Esri export jobs. The default U.S. imagery path uses NAIP, with Sentinel-2 as the global fallback.
+- `NAIP_AWS_STATE`, `NAIP_AWS_YEAR`, `NAIP_AWS_RESOLUTION`, `NAIP_AWS_BANDSET`: controls public NAIP AWS prefix downloads; defaults are inferred U.S. state, `2022`, `60cm`, and `rgbir`.
+- `NAIP_AWS_BUCKET`: defaults to `naip-analytic`; set to `naip-visualization` for RGB COGs when desired.
+- `NAIP_MAX_FILES`: safety cap for NAIP prefix downloads; defaults to `50`.
+- `NAIP_EARTHEXPLORER_DIR`: optional folder of EarthExplorer NAIP GeoTIFFs to import instead of relying only on AWS prefix downloads.
+- `GEOFABRIK_PBF_URL` or `GEOFABRIK_REGION_SLUG`: optional OSM override; otherwise the app infers a U.S. state extract such as `north-america/us/nevada-latest.osm.pbf`.
+- `DTED_SOURCE_DIR`: optional folder of EarthExplorer `.dt0/.dt1/.dt2` files; imported and converted with `gdal_translate` if GDAL is installed.
+- `OFFLINE_PACKAGE_ROOT`: Jetson directory where source packages, status files, terrain rasters, route artifacts, and CoT XML are written; defaults to `llm_dev_kmh/offline_packages`
+- `PACKAGE_MIN_FREE_GB`: disk space reserve enforced before downloads start; defaults to `10`
 - `DEFAULT_LAT`: initial camera latitude, default `37.7749`
 - `DEFAULT_LON`: initial camera longitude, default `-122.4194`
 - `DEFAULT_HEIGHT_M`: initial camera height in meters, default `14000`

--- a/llm_dev_kmh/README.md
+++ b/llm_dev_kmh/README.md
@@ -8,6 +8,7 @@ Map-centric local LLM workspace kept entirely inside `llm_dev_kmh`.
 - exposes an operator sidebar tailored for TERA map and source-planning workflows
 - lists locally installed Ollama models
 - sends prompt requests through `/api/prompt` with Claude-first, Ollama-second fallback
+- switches into Jetson ATAK local-agent mode with Ollama `gemma3:4b` and a browser mirror of ATAK-profile prompt traffic
 - lets the operator draw and resize an AO rectangle for source package coverage
 
 ## Run it directly
@@ -22,7 +23,7 @@ Example on Windows PowerShell:
 ```powershell
 $env:OLLAMA_BASE_URL="http://127.0.0.1:11434"
 $env:OLLAMA_MODEL="gemma3:4b"
-$env:CLAUDE_MODEL="Claude Sonnet 4.6"
+$env:CLAUDE_MODEL="claude-sonnet-4-6"
 $env:CESIUM_ION_TOKEN="YOUR_TOKEN_HERE"
 uvicorn llm_dev_kmh.app:app --host 0.0.0.0 --port 8080
 ```
@@ -42,11 +43,15 @@ docker compose up --build
 ## Environment variables
 
 - `ANTHROPIC_API_KEY`: primary Claude API key loaded from repo root `.env` or environment
-- `CLAUDE_MODEL`: primary Claude model, default `Claude Sonnet 4.6` (normalized to Anthropic's supported Sonnet 4 API snapshot)
+- `CLAUDE_MODEL`: primary Claude model, default `claude-sonnet-4-6`
 - `ANTHROPIC_API_URL`: Claude Messages endpoint, default `https://api.anthropic.com/v1/messages`
 - `ANTHROPIC_MODELS_URL`: Claude model discovery endpoint, default `https://api.anthropic.com/v1/models`
 - `OLLAMA_BASE_URL`: defaults to `http://127.0.0.1:11434`
-- `OLLAMA_MODEL`: local fallback default; if unavailable, the app autodetects an installed Ollama model
+- `OLLAMA_MODEL`: local fallback default, `gemma3:4b`; if unavailable, the app autodetects an installed Ollama model
+- `TERA_ATAK_MODEL`: model used by the ATAK Local button, default `gemma3:4b`
+- `TERA_ATAK_AGENT_COMMAND`: optional command launched by the ATAK Local button, for example a tmux/systemd wrapper on the Jetson
+- `TERA_ATAK_DEVICE_URL`: optional ATAK plugin/device target shown in activation status
+- `TERA_ATAK_MIRROR_LOG`: optional JSONL mirror path; defaults under `OFFLINE_PACKAGE_ROOT/runtime/`
 - `REQUEST_TIMEOUT_S`: prompt timeout in seconds, default `120`
 - `CESIUM_ION_TOKEN`: required for Cesium World Terrain and Cesium satellite imagery
 - `CESIUM_ION_ARCHIVE_ID`: optional completed Cesium ion archive id to download into the Jetson package root.
@@ -69,6 +74,7 @@ docker compose up --build
 
 - Without `CESIUM_ION_TOKEN`, the workspace falls back to OpenStreetMap imagery and ellipsoid terrain.
 - Provider order defaults to Claude first when `ANTHROPIC_API_KEY` is configured, then detected local Ollama, then the deterministic browser planner.
+- Pressing `ATAK Local` forces auto prompt traffic to local Ollama `gemma3:4b`, sets the UI provider/profile for the TERA ATAK link, and opens a mirror panel for ATAK plugin conversations.
 - On Docker Desktop, `host.docker.internal` should resolve automatically.
 - On Linux, `extra_hosts` maps `host.docker.internal` to the Docker host gateway.
 - If Ollama is running somewhere else on your LAN, set `OLLAMA_BASE_URL` to that reachable address before starting the container.

--- a/llm_dev_kmh/app.py
+++ b/llm_dev_kmh/app.py
@@ -32,16 +32,51 @@ ANTHROPIC_API_URL = os.getenv(
     "ANTHROPIC_API_URL", "https://api.anthropic.com/v1/messages"
 )
 ANTHROPIC_VERSION = os.getenv("ANTHROPIC_VERSION", "2023-06-01")
-CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
+CLAUDE_MODEL_ALIASES = {
+    "claude-sonnet-4-6": "claude-sonnet-4-6",
+    "claude-sonnet-4.6": "claude-sonnet-4-6",
+    "claude sonnet 4.6": "claude-sonnet-4-6",
+    "sonnet 4.6": "claude-sonnet-4-6",
+    "claude-sonnet-4": "claude-sonnet-4-6",
+    "claude sonnet 4": "claude-sonnet-4-6",
+    "claude-sonnet-4-20250514": "claude-sonnet-4-6",
+    "claude-opus-4-7": "claude-opus-4-7",
+    "claude opus 4.7": "claude-opus-4-7",
+    "opus 4.7": "claude-opus-4-7",
+    "claude-opus-4-1-20250805": "claude-opus-4-1-20250805",
+    "claude-haiku-4-5": "claude-haiku-4-5",
+    "claude-haiku-4-5-20251001": "claude-haiku-4-5-20251001",
+    "claude-3-7-sonnet-20250219": "claude-3-7-sonnet-20250219",
+    "claude-3-5-haiku-20241022": "claude-3-5-haiku-20241022",
+}
 REQUEST_TIMEOUT_S = float(os.getenv("REQUEST_TIMEOUT_S", "120"))
 LOCATION_SEARCH_TIMEOUT_S = float(os.getenv("LOCATION_SEARCH_TIMEOUT_S", "4"))
 LOCATION_SEARCH_URL = os.getenv(
     "LOCATION_SEARCH_URL", "https://nominatim.openstreetmap.org/search"
 )
+GOOGLE_MAPS_API_KEY = os.getenv("GOOGLE_MAPS_API_KEY", "").strip()
+GOOGLE_PLACES_AUTOCOMPLETE_URL = os.getenv(
+    "GOOGLE_PLACES_AUTOCOMPLETE_URL",
+    "https://places.googleapis.com/v1/places:autocomplete",
+)
+GOOGLE_PLACE_DETAILS_URL_BASE = os.getenv(
+    "GOOGLE_PLACE_DETAILS_URL_BASE",
+    "https://places.googleapis.com/v1",
+)
+GOOGLE_PLACES_TEXT_SEARCH_URL = os.getenv(
+    "GOOGLE_PLACES_TEXT_SEARCH_URL",
+    "https://places.googleapis.com/v1/places:searchText",
+)
 LOCATION_INTENT_PREFIX_RE = re.compile(
     r"^(?:go to|goto|navigate to|take me to|move map to|move to|search for|"
     r"find|show me|zoom to|center on|focus on|look up|open)\s+",
     re.IGNORECASE,
+)
+GOOGLE_MAPS_COORD_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"!3d(?P<lat>[+-]?\d+(?:\.\d+)?)!4d(?P<lon>[+-]?\d+(?:\.\d+)?)", re.IGNORECASE),
+    re.compile(r"@(?P<lat>[+-]?\d+(?:\.\d+)?),(?P<lon>[+-]?\d+(?:\.\d+)?)", re.IGNORECASE),
+    re.compile(r"[?&](?:q|ll|center)=(?P<lat>[+-]?\d+(?:\.\d+)?),(?P<lon>[+-]?\d+(?:\.\d+)?)", re.IGNORECASE),
 )
 CESIUM_ION_TOKEN = os.getenv("CESIUM_ION_TOKEN", "")
 DEFAULT_LAT = float(os.getenv("DEFAULT_LAT", "37.7749"))
@@ -94,6 +129,7 @@ class RuntimeConfigResponse(BaseModel):
     cesium_ion_token: str
     default_model: str
     claude_default_model: str
+    anthropic_api_key_configured: bool
     default_lat: float
     default_lon: float
     default_height_m: float
@@ -1804,8 +1840,18 @@ def _request_llm_provider(request: PromptRequest) -> str:
     return "ollama"
 
 
+def _normalize_claude_model(model: str | None) -> str:
+    candidate = (model or CLAUDE_MODEL).strip()
+    if not candidate:
+        return CLAUDE_MODEL
+    compact = re.sub(r"[\s_]+", "-", candidate.lower())
+    compact = compact.replace("sonnet-4.6", "sonnet-4-6")
+    compact = compact.replace("opus-4.7", "opus-4-7")
+    return CLAUDE_MODEL_ALIASES.get(compact, CLAUDE_MODEL_ALIASES.get(candidate.lower(), candidate))
+
+
 def _build_claude_payload(request: PromptRequest) -> tuple[str, dict[str, object]]:
-    model = request.cloud_model or request.model or CLAUDE_MODEL
+    model = _normalize_claude_model(request.cloud_model or request.model or CLAUDE_MODEL)
     payload: dict[str, object] = {
         "model": model,
         "max_tokens": 900,
@@ -1872,7 +1918,15 @@ async def _post_claude_message(request: PromptRequest) -> PromptResponse:
             model=model,
         )
         if exc.response.status_code in {401, 403}:
-            detail = "Claude API rejected the key or account access for this model."
+            detail = (
+                f"Claude API rejected the key or account access for {model}. "
+                "Check the key in Model Provider or set ANTHROPIC_API_KEY on the server."
+            )
+        elif exc.response.status_code == 400 and "model" in body.lower():
+            detail = (
+                f"Claude API rejected model {model}. Select Claude Sonnet 4.6 "
+                "or another listed model in Model Provider."
+            )
         else:
             detail = f"Claude API returned {exc.response.status_code}: {body}"
         raise HTTPException(status_code=502, detail=detail) from exc
@@ -1880,7 +1934,10 @@ async def _post_claude_message(request: PromptRequest) -> PromptResponse:
         log.error("claude_connection_error", error=str(exc), model=model)
         raise HTTPException(
             status_code=502,
-            detail=f"Could not reach Claude API. {exc}",
+            detail=(
+                "Could not reach Claude API. Check internet connectivity, proxy/firewall "
+                "settings, and the Anthropic API endpoint."
+            ),
         ) from exc
 
     text = _extract_claude_response_text(response.json())
@@ -1963,6 +2020,53 @@ def _clean_location_query(query: str) -> str:
         previous = cleaned
         cleaned = LOCATION_INTENT_PREFIX_RE.sub("", cleaned).strip()
     return cleaned
+
+
+def _coordinate_location_suggestion(query: str) -> LocationSuggestion | None:
+    for pattern in GOOGLE_MAPS_COORD_PATTERNS:
+        match = pattern.search(query)
+        if not match:
+            continue
+        lat = _safe_float(match.group("lat"), default=float("nan"))
+        lon = _safe_float(match.group("lon"), default=float("nan"))
+        if -90 <= lat <= 90 and -180 <= lon <= 180:
+            return LocationSuggestion(
+                name=f"Coordinates {lat:.5f}, {lon:.5f}",
+                detail="Parsed from Google Maps link or coordinate query.",
+                lat=lat,
+                lon=lon,
+                height_m=12000,
+                source="coordinate-query",
+                score=1000,
+            )
+
+    numbers = re.findall(r"[+-]?\d+(?:\.\d+)?", query)
+    if len(numbers) < 2 or "http" in query.lower():
+        return None
+    lat = _safe_float(numbers[0], default=float("nan"))
+    lon = _safe_float(numbers[1], default=float("nan"))
+    if abs(lat) > 90 and abs(lon) <= 90:
+        lat, lon = lon, lat
+    upper = query.upper()
+    if re.search(r"\d(?:\.\d+)?\s*S\b", upper):
+        lat = -abs(lat)
+    elif re.search(r"\d(?:\.\d+)?\s*N\b", upper):
+        lat = abs(lat)
+    if re.search(r"\d(?:\.\d+)?\s*W\b", upper) or " W" in upper:
+        lon = -abs(lon)
+    elif re.search(r"\d(?:\.\d+)?\s*E\b", upper) or " E" in upper:
+        lon = abs(lon)
+    if -90 <= lat <= 90 and -180 <= lon <= 180:
+        return LocationSuggestion(
+            name=f"Coordinates {lat:.5f}, {lon:.5f}",
+            detail="Parsed decimal latitude/longitude.",
+            lat=lat,
+            lon=lon,
+            height_m=12000,
+            source="coordinate-query",
+            score=1000,
+        )
+    return None
 
 
 def _distance_km(lat_a: float, lon_a: float, lat_b: float, lon_b: float) -> float:
@@ -2053,9 +2157,372 @@ def _score_online_location(
 
     if center_lat is not None and center_lon is not None:
         distance = _distance_km(center_lat, center_lon, suggestion.lat, suggestion.lon)
-        score += max(0, 35 - min(distance / 125, 35))
+        score += max(0, 10 - min(distance / 500, 10))
 
     return round(score, 3)
+
+
+def _google_location_bias(
+    *,
+    center_lat: float | None = None,
+    center_lon: float | None = None,
+    west: float | None = None,
+    south: float | None = None,
+    east: float | None = None,
+    north: float | None = None,
+) -> dict[str, object] | None:
+    if None not in (west, south, east, north):
+        return {
+            "rectangle": {
+                "low": {
+                    "latitude": min(float(south), float(north)),
+                    "longitude": min(float(west), float(east)),
+                },
+                "high": {
+                    "latitude": max(float(south), float(north)),
+                    "longitude": max(float(west), float(east)),
+                },
+            }
+        }
+    if center_lat is not None and center_lon is not None:
+        return {
+            "circle": {
+                "center": {
+                    "latitude": center_lat,
+                    "longitude": center_lon,
+                },
+                "radius": 50000.0,
+            }
+        }
+    return None
+
+
+def _google_text_value(value: object) -> str:
+    if isinstance(value, dict):
+        return str(value.get("text") or "").strip()
+    return str(value or "").strip()
+
+
+def _google_prediction_text(prediction: dict[str, object]) -> str:
+    direct_text = _google_text_value(prediction.get("text"))
+    if direct_text:
+        return direct_text
+    structured = prediction.get("structuredFormat")
+    if not isinstance(structured, dict):
+        return ""
+    main_text = _google_text_value(structured.get("mainText"))
+    secondary_text = _google_text_value(structured.get("secondaryText"))
+    return ", ".join(part for part in (main_text, secondary_text) if part)
+
+
+def _google_place_details_url(place_name: str) -> str:
+    place_path = place_name.strip().strip("/")
+    if not place_path:
+        return ""
+    base_url = GOOGLE_PLACE_DETAILS_URL_BASE.rstrip("/")
+    if place_path.startswith("places/"):
+        return f"{base_url}/{place_path}"
+    return f"{base_url}/places/{place_path}"
+
+
+async def _google_place_details_suggestion(
+    query: str,
+    place_name: str,
+    *,
+    client: httpx.AsyncClient,
+    prediction_text: str = "",
+    rank: int = 0,
+    center_lat: float | None = None,
+    center_lon: float | None = None,
+) -> tuple[LocationSuggestion | None, str | None]:
+    url = _google_place_details_url(place_name)
+    if not url:
+        return None, None
+
+    try:
+        response = await client.get(
+            url,
+            headers={
+                "X-Goog-Api-Key": GOOGLE_MAPS_API_KEY,
+                "X-Goog-FieldMask": (
+                    "id,displayName,formattedAddress,location,"
+                    "googleMapsUri,primaryType,types"
+                ),
+            },
+        )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        body = exc.response.text[:300]
+        return None, (
+            f"Google Maps Place Details returned {exc.response.status_code}: {body}"
+        )
+    except httpx.HTTPError as exc:
+        return None, f"Google Maps Place Details unavailable: {exc}"
+
+    place = response.json()
+    if not isinstance(place, dict):
+        return None, "Google Maps Place Details returned an unexpected payload."
+    location = place.get("location")
+    if not isinstance(location, dict):
+        return None, None
+    place_lat = _safe_float(location.get("latitude"), default=float("nan"))
+    place_lon = _safe_float(location.get("longitude"), default=float("nan"))
+    if not (-90 <= place_lat <= 90 and -180 <= place_lon <= 180):
+        return None, None
+
+    display_name = place.get("displayName")
+    name = _google_text_value(display_name) or prediction_text or query
+    formatted_address = str(place.get("formattedAddress") or "").strip()
+    google_maps_uri = str(place.get("googleMapsUri") or "").strip()
+    primary_type = str(place.get("primaryType") or "place").strip()
+    detail_parts = [
+        part for part in [primary_type, formatted_address, google_maps_uri] if part
+    ]
+    suggestion = LocationSuggestion(
+        name=name,
+        detail="Google Maps - " + " | ".join(detail_parts),
+        lat=place_lat,
+        lon=place_lon,
+        height_m=12000,
+        source="google-places",
+        score=900 - (rank * 12),
+    )
+    suggestion.score += _score_online_location(
+        query,
+        suggestion,
+        center_lat=center_lat,
+        center_lon=center_lon,
+        category="google",
+        place_type=primary_type,
+    )
+    return suggestion, None
+
+
+async def _google_places_location_suggestions(
+    query: str,
+    *,
+    center_lat: float | None = None,
+    center_lon: float | None = None,
+    west: float | None = None,
+    south: float | None = None,
+    east: float | None = None,
+    north: float | None = None,
+    limit: int = 8,
+    client: httpx.AsyncClient | None = None,
+) -> tuple[list[LocationSuggestion], str | None]:
+    if not GOOGLE_MAPS_API_KEY:
+        return [], "Google Maps Places search disabled; set GOOGLE_MAPS_API_KEY."
+
+    payload: dict[str, object] = {
+        "textQuery": query,
+        "pageSize": max(1, min(limit, 20)),
+        "languageCode": "en",
+    }
+    location_bias = _google_location_bias(
+        center_lat=center_lat,
+        center_lon=center_lon,
+        west=west,
+        south=south,
+        east=east,
+        north=north,
+    )
+    if location_bias:
+        payload["locationBias"] = location_bias
+
+    try:
+        headers = {
+            "Content-Type": "application/json",
+            "X-Goog-Api-Key": GOOGLE_MAPS_API_KEY,
+            "X-Goog-FieldMask": (
+                "places.id,places.displayName,places.formattedAddress,"
+                "places.location,places.googleMapsUri,places.primaryType"
+            ),
+        }
+        if client is None:
+            timeout = httpx.Timeout(LOCATION_SEARCH_TIMEOUT_S, connect=2.0)
+            async with httpx.AsyncClient(timeout=timeout) as owned_client:
+                response = await owned_client.post(
+                    GOOGLE_PLACES_TEXT_SEARCH_URL,
+                    json=payload,
+                    headers=headers,
+                )
+                response.raise_for_status()
+        else:
+            response = await client.post(
+                GOOGLE_PLACES_TEXT_SEARCH_URL,
+                json=payload,
+                headers=headers,
+            )
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        body = exc.response.text[:300]
+        return [], f"Google Maps Places search returned {exc.response.status_code}: {body}"
+    except httpx.HTTPError as exc:
+        return [], f"Google Maps Places search unavailable: {exc}"
+
+    suggestions: list[LocationSuggestion] = []
+    for index, place in enumerate(response.json().get("places", [])):
+        if not isinstance(place, dict):
+            continue
+        location = place.get("location")
+        if not isinstance(location, dict):
+            continue
+        place_lat = _safe_float(location.get("latitude"), default=float("nan"))
+        place_lon = _safe_float(location.get("longitude"), default=float("nan"))
+        if not (-90 <= place_lat <= 90 and -180 <= place_lon <= 180):
+            continue
+        display_name = place.get("displayName")
+        if isinstance(display_name, dict):
+            name = str(display_name.get("text") or "").strip()
+        else:
+            name = ""
+        formatted_address = str(place.get("formattedAddress") or "").strip()
+        google_maps_uri = str(place.get("googleMapsUri") or "").strip()
+        primary_type = str(place.get("primaryType") or "place").strip()
+        detail_parts = [
+            part for part in [primary_type, formatted_address, google_maps_uri] if part
+        ]
+        suggestion = LocationSuggestion(
+            name=name or formatted_address or query,
+            detail="Google Maps - " + " | ".join(detail_parts),
+            lat=place_lat,
+            lon=place_lon,
+            height_m=12000,
+            source="google-places",
+            score=650 - (index * 10),
+        )
+        suggestion.score += _score_online_location(
+            query,
+            suggestion,
+            center_lat=center_lat,
+            center_lon=center_lon,
+            category="google",
+            place_type=primary_type,
+        )
+        suggestions.append(suggestion)
+
+    return suggestions, None
+
+
+async def _google_places_autocomplete_suggestions(
+    query: str,
+    *,
+    center_lat: float | None = None,
+    center_lon: float | None = None,
+    west: float | None = None,
+    south: float | None = None,
+    east: float | None = None,
+    north: float | None = None,
+) -> tuple[list[LocationSuggestion], str | None]:
+    if not GOOGLE_MAPS_API_KEY:
+        return [], "Google Maps Places autocomplete disabled; set GOOGLE_MAPS_API_KEY."
+
+    payload: dict[str, object] = {
+        "input": query,
+        "includeQueryPredictions": True,
+        "languageCode": "en",
+    }
+    location_bias = _google_location_bias(
+        center_lat=center_lat,
+        center_lon=center_lon,
+        west=west,
+        south=south,
+        east=east,
+        north=north,
+    )
+    if location_bias:
+        payload["locationBias"] = location_bias
+
+    suggestions: list[LocationSuggestion] = []
+    detail_parts: list[str] = []
+    prediction_texts: list[str] = []
+    timeout = httpx.Timeout(LOCATION_SEARCH_TIMEOUT_S, connect=2.0)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(
+                GOOGLE_PLACES_AUTOCOMPLETE_URL,
+                json=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Goog-Api-Key": GOOGLE_MAPS_API_KEY,
+                    "X-Goog-FieldMask": (
+                        "suggestions.placePrediction.place,"
+                        "suggestions.placePrediction.placeId,"
+                        "suggestions.placePrediction.text.text,"
+                        "suggestions.placePrediction.structuredFormat.mainText.text,"
+                        "suggestions.placePrediction.structuredFormat.secondaryText.text,"
+                        "suggestions.queryPrediction.text.text"
+                    ),
+                },
+            )
+            response.raise_for_status()
+            for index, raw_suggestion in enumerate(
+                response.json().get("suggestions", [])
+            ):
+                if not isinstance(raw_suggestion, dict):
+                    continue
+                place_prediction = raw_suggestion.get("placePrediction")
+                if isinstance(place_prediction, dict):
+                    prediction_text = _google_prediction_text(place_prediction)
+                    place_name = str(
+                        place_prediction.get("place")
+                        or place_prediction.get("placeId")
+                        or ""
+                    ).strip()
+                    if place_name:
+                        place_suggestion, detail = await _google_place_details_suggestion(
+                            query,
+                            place_name,
+                            client=client,
+                            prediction_text=prediction_text,
+                            rank=index,
+                            center_lat=center_lat,
+                            center_lon=center_lon,
+                        )
+                        if place_suggestion:
+                            suggestions.append(place_suggestion)
+                            continue
+                        if detail:
+                            detail_parts.append(detail)
+                    if prediction_text:
+                        prediction_texts.append(prediction_text)
+                    continue
+
+                query_prediction = raw_suggestion.get("queryPrediction")
+                if isinstance(query_prediction, dict):
+                    query_text = _google_prediction_text(query_prediction)
+                    if query_text:
+                        prediction_texts.append(query_text)
+
+            for prediction_text in prediction_texts[:3]:
+                if len(suggestions) >= 8:
+                    break
+                text_suggestions, text_detail = (
+                    await _google_places_location_suggestions(
+                        prediction_text,
+                        center_lat=center_lat,
+                        center_lon=center_lon,
+                        west=west,
+                        south=south,
+                        east=east,
+                        north=north,
+                        limit=2,
+                        client=client,
+                    )
+                )
+                if text_suggestions:
+                    suggestions.extend(text_suggestions)
+                elif text_detail:
+                    detail_parts.append(text_detail)
+    except httpx.HTTPStatusError as exc:
+        body = exc.response.text[:300]
+        return [], (
+            f"Google Maps Places autocomplete returned {exc.response.status_code}: {body}"
+        )
+    except httpx.HTTPError as exc:
+        return [], f"Google Maps Places autocomplete unavailable: {exc}"
+
+    return suggestions, " | ".join(detail_parts[:3]) if detail_parts else None
 
 
 def _local_location_suggestions(query: str) -> list[LocationSuggestion]:
@@ -2096,7 +2563,8 @@ async def runtime_config() -> RuntimeConfigResponse:
     return RuntimeConfigResponse(
         cesium_ion_token=CESIUM_ION_TOKEN,
         default_model=OLLAMA_MODEL,
-        claude_default_model=CLAUDE_MODEL,
+        claude_default_model=_normalize_claude_model(CLAUDE_MODEL),
+        anthropic_api_key_configured=bool(os.getenv("ANTHROPIC_API_KEY", "").strip()),
         default_lat=DEFAULT_LAT,
         default_lon=DEFAULT_LON,
         default_height_m=DEFAULT_HEIGHT_M,
@@ -2143,77 +2611,127 @@ async def list_ollama_models() -> ModelsResponse:
 
 @app.get("/api/location-search", response_model=LocationSearchResponse)
 async def search_locations(
-    q: str = Query(min_length=2, max_length=200),
-    lat: float | None = Query(default=None, ge=-90, le=90),
-    lon: float | None = Query(default=None, ge=-180, le=180),
-    west: float | None = Query(default=None, ge=-180, le=180),
-    south: float | None = Query(default=None, ge=-90, le=90),
-    east: float | None = Query(default=None, ge=-180, le=180),
-    north: float | None = Query(default=None, ge=-90, le=90),
+    q: str = Query(min_length=1, max_length=200),
+    lat: float | None = None,
+    lon: float | None = None,
+    west: float | None = None,
+    south: float | None = None,
+    east: float | None = None,
+    north: float | None = None,
 ) -> LocationSearchResponse:
     query = _clean_location_query(q)
-    if len(query) < 2:
-        raise HTTPException(status_code=422, detail="Location query is too short.")
+    if not query:
+        return LocationSearchResponse(
+            query=query,
+            suggestions=[],
+            online=False,
+            detail="Enter a mission location, coordinates, or a Google Maps link.",
+        )
 
     suggestions = _local_location_suggestions(query)
+    coordinate_suggestion = _coordinate_location_suggestion(query)
+    if coordinate_suggestion:
+        suggestions.insert(0, coordinate_suggestion)
     online = False
-    detail: str | None = None
+    detail_parts: list[str] = []
 
-    try:
-        params: dict[str, object] = {
-            "q": query,
-            "format": "jsonv2",
-            "limit": 10,
-            "addressdetails": 1,
-            "extratags": 1,
-            "namedetails": 1,
-            "dedupe": 1,
-        }
-        if None not in (west, south, east, north):
-            params["viewbox"] = f"{west},{north},{east},{south}"
-
-        timeout = httpx.Timeout(LOCATION_SEARCH_TIMEOUT_S, connect=2.0)
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.get(
-                LOCATION_SEARCH_URL,
-                params=params,
-                headers={
-                    "Accept-Language": "en",
-                    "User-Agent": "TERA Source Planner local web app; optional online geocode",
-                },
-            )
-            response.raise_for_status()
-        online = True
-        for item in response.json():
-            item_lat = item.get("lat")
-            item_lon = item.get("lon")
-            if item_lat is None or item_lon is None:
-                continue
-            display_name = str(item.get("display_name") or item.get("name") or query)
-            category = str(item.get("category") or "online geocoder")
-            place_type = str(item.get("type") or "place")
-            suggestion = LocationSuggestion(
-                name=display_name.split(",")[0],
-                detail=f"{category}/{place_type} - {display_name}",
-                lat=float(item_lat),
-                lon=float(item_lon),
-                height_m=12000,
-                source="online-geocoder",
-            )
-            suggestion.score = _score_online_location(
+    if GOOGLE_MAPS_API_KEY:
+        autocomplete_suggestions, autocomplete_detail = (
+            await _google_places_autocomplete_suggestions(
                 query,
-                suggestion,
-                center_lat=lat if lat is not None else None,
-                center_lon=lon if lon is not None else None,
-                importance=_safe_float(item.get("importance")),
-                category=category,
-                place_type=place_type,
+                center_lat=lat,
+                center_lon=lon,
+                west=west,
+                south=south,
+                east=east,
+                north=north,
             )
-            suggestions.append(
-                suggestion
-            )
-    except (httpx.HTTPError, ValueError) as exc:
-        detail = f"Online location lookup unavailable: {exc}"
+        )
+        if autocomplete_suggestions:
+            online = True
+            suggestions.extend(autocomplete_suggestions)
+        elif autocomplete_detail:
+            detail_parts.append(autocomplete_detail)
+
+        text_search_suggestions, text_search_detail = await _google_places_location_suggestions(
+            query,
+            center_lat=lat,
+            center_lon=lon,
+            west=west,
+            south=south,
+            east=east,
+            north=north,
+            limit=8,
+        )
+        if text_search_suggestions:
+            online = True
+            suggestions.extend(text_search_suggestions)
+        elif text_search_detail:
+            detail_parts.append(text_search_detail)
+    else:
+        detail_parts.append(
+            "Google Maps Places disabled; set GOOGLE_MAPS_API_KEY for Google-grade autocomplete."
+        )
+
+    should_query_nominatim = len(query) >= 2 or not query.isdigit()
+    if should_query_nominatim:
+        try:
+            params: dict[str, object] = {
+                "q": query,
+                "format": "jsonv2",
+                "limit": 10,
+                "addressdetails": 1,
+                "extratags": 1,
+                "namedetails": 1,
+                "dedupe": 1,
+            }
+            if len(query) <= 2 and None not in (west, south, east, north):
+                params["viewbox"] = f"{west},{north},{east},{south}"
+
+            timeout = httpx.Timeout(LOCATION_SEARCH_TIMEOUT_S, connect=2.0)
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.get(
+                    LOCATION_SEARCH_URL,
+                    params=params,
+                    headers={
+                        "Accept-Language": "en",
+                        "User-Agent": "TERA Source Planner local web app; optional online geocode",
+                    },
+                )
+                response.raise_for_status()
+            online = True
+            for item in response.json():
+                item_lat = item.get("lat")
+                item_lon = item.get("lon")
+                if item_lat is None or item_lon is None:
+                    continue
+                display_name = str(item.get("display_name") or item.get("name") or query)
+                category = str(item.get("category") or "online geocoder")
+                place_type = str(item.get("type") or "place")
+                suggestion = LocationSuggestion(
+                    name=display_name.split(",")[0],
+                    detail=f"{category}/{place_type} - {display_name}",
+                    lat=float(item_lat),
+                    lon=float(item_lon),
+                    height_m=12000,
+                    source="online-geocoder",
+                )
+                suggestion.score = _score_online_location(
+                    query,
+                    suggestion,
+                    center_lat=lat if lat is not None else None,
+                    center_lon=lon if lon is not None else None,
+                    importance=_safe_float(item.get("importance")),
+                    category=category,
+                    place_type=place_type,
+                )
+                suggestions.append(suggestion)
+        except (httpx.HTTPError, ValueError) as exc:
+            detail_parts.append(f"Nominatim location lookup unavailable: {exc}")
+    else:
+        detail_parts.append(
+            "Numeric location searches need more context unless Google Maps Places is configured."
+        )
 
     deduped: list[LocationSuggestion] = []
     seen: set[tuple[int, int, str]] = set()
@@ -2233,7 +2751,7 @@ async def search_locations(
         query=query,
         suggestions=deduped[:8],
         online=online,
-        detail=detail,
+        detail=" | ".join(detail_parts) if detail_parts else None,
     )
 
 

--- a/llm_dev_kmh/app.py
+++ b/llm_dev_kmh/app.py
@@ -7,6 +7,7 @@ import json
 import math
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import zipfile
@@ -80,7 +81,7 @@ _load_dotenv_file(BASE_DIR.parent / ".env")
 _load_dotenv_file(BASE_DIR.parent / ".env.local")
 
 OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
-OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "gemma2:2b")
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "gemma3:4b")
 ANTHROPIC_API_URL = os.getenv(
     "ANTHROPIC_API_URL", "https://api.anthropic.com/v1/messages"
 )
@@ -88,14 +89,14 @@ ANTHROPIC_MODELS_URL = os.getenv(
     "ANTHROPIC_MODELS_URL", "https://api.anthropic.com/v1/models"
 )
 ANTHROPIC_VERSION = os.getenv("ANTHROPIC_VERSION", "2023-06-01")
-CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "Claude Sonnet 4.6")
+CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
 CLAUDE_MODEL_ALIASES = {
+    "claude-sonnet-4-6": "claude-sonnet-4-6",
+    "claude-sonnet-4.6": "claude-sonnet-4-6",
+    "claude sonnet 4.6": "claude-sonnet-4-6",
+    "sonnet 4.6": "claude-sonnet-4-6",
     "claude-sonnet-4-20250514": "claude-sonnet-4-20250514",
     "claude-sonnet-4-0": "claude-sonnet-4-20250514",
-    "claude-sonnet-4-6": "claude-sonnet-4-20250514",
-    "claude-sonnet-4.6": "claude-sonnet-4-20250514",
-    "claude sonnet 4.6": "claude-sonnet-4-20250514",
-    "sonnet 4.6": "claude-sonnet-4-20250514",
     "claude-sonnet-4": "claude-sonnet-4-20250514",
     "claude sonnet 4": "claude-sonnet-4-20250514",
     "claude-opus-4-1": "claude-opus-4-1-20250805",
@@ -118,6 +119,7 @@ CLAUDE_MODEL_ALIASES = {
     "claude-3-5-haiku-20241022": "claude-3-5-haiku-20241022",
 }
 CLAUDE_MODEL_FALLBACKS = (
+    "claude-sonnet-4-6",
     "claude-sonnet-4-20250514",
     "claude-opus-4-1-20250805",
     "claude-opus-4-20250514",
@@ -170,9 +172,24 @@ ESRI_TOKEN_CONFIGURED = bool(
 DEFAULT_LAT = float(os.getenv("DEFAULT_LAT", "37.7749"))
 DEFAULT_LON = float(os.getenv("DEFAULT_LON", "-122.4194"))
 DEFAULT_HEIGHT_M = float(os.getenv("DEFAULT_HEIGHT_M", "14000"))
+TERA_ATAK_MODEL = os.getenv("TERA_ATAK_MODEL", "gemma3:4b")
+TERA_ATAK_AGENT_PROFILE = os.getenv("TERA_ATAK_AGENT_PROFILE", "tera-atak-live")
+TERA_ATAK_DEVICE_URL = os.getenv("TERA_ATAK_DEVICE_URL", "").strip()
+TERA_ATAK_ACTIVATE_COMMAND = os.getenv("TERA_ATAK_AGENT_COMMAND", "").strip()
 ACTIVE_OLLAMA_BASE_URL: str | None = None
 ACTIVE_OLLAMA_MODEL: str | None = None
 ACTIVE_CLAUDE_MODELS: list[str] | None = None
+JETSON_ATAK_PROCESS: subprocess.Popen[bytes] | None = None
+JETSON_ATAK_MODE: dict[str, Any] = {
+    "active": False,
+    "status": "idle",
+    "detail": "ATAK local agent mode is idle.",
+    "model": TERA_ATAK_MODEL,
+    "provider": "ollama",
+    "agent_profile": TERA_ATAK_AGENT_PROFILE,
+    "atak_device_url": TERA_ATAK_DEVICE_URL or None,
+    "activated_at": None,
+}
 
 app = FastAPI(title="TERA Source Planner", version="0.2.0")
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
@@ -226,6 +243,35 @@ class RuntimeConfigResponse(BaseModel):
     default_lat: float
     default_lon: float
     default_height_m: float
+
+
+class JetsonAtakActivateRequest(BaseModel):
+    model: str | None = Field(default=None, max_length=200)
+    atak_device_url: str | None = Field(default=None, max_length=500)
+    agent_profile: str | None = Field(default=None, max_length=80)
+
+
+class JetsonAtakMirrorEvent(BaseModel):
+    id: str
+    timestamp: str
+    source: str
+    role: str
+    text: str
+    model: str | None = None
+    provider: str | None = None
+    direction: str | None = None
+
+
+class JetsonAtakModeResponse(BaseModel):
+    active: bool
+    status: str
+    detail: str
+    model: str
+    provider: str
+    agent_profile: str
+    atak_device_url: str | None = None
+    mirror_url: str
+    events: list[JetsonAtakMirrorEvent] = Field(default_factory=list)
 
 
 class LocationSuggestion(BaseModel):
@@ -2462,6 +2508,131 @@ def _read_json(path: Path) -> dict[str, Any] | None:
         return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
+
+
+def _runtime_dir() -> Path:
+    configured = os.getenv("TERA_RUNTIME_DIR", "").strip()
+    runtime_dir = Path(configured).expanduser().resolve() if configured else (
+        _offline_package_root() / "runtime"
+    )
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    return runtime_dir
+
+
+def _atak_mirror_log_path() -> Path:
+    configured = os.getenv("TERA_ATAK_MIRROR_LOG", "").strip()
+    return Path(configured).expanduser().resolve() if configured else (
+        _runtime_dir() / "atak_agent_mirror.jsonl"
+    )
+
+
+def _append_atak_mirror_event(
+    *,
+    source: str,
+    role: str,
+    text: str,
+    model: str | None = None,
+    provider: str | None = None,
+    direction: str | None = None,
+) -> JetsonAtakMirrorEvent:
+    event = JetsonAtakMirrorEvent(
+        id=str(uuid4()),
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        source=source,
+        role=role,
+        text=text,
+        model=model,
+        provider=provider,
+        direction=direction,
+    )
+    path = _atak_mirror_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(event.model_dump_json() + "\n")
+    return event
+
+
+def _read_atak_mirror_events(limit: int = 80) -> list[JetsonAtakMirrorEvent]:
+    path = _atak_mirror_log_path()
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+
+    events: list[JetsonAtakMirrorEvent] = []
+    for line in lines[-max(1, min(limit, 200)) :]:
+        try:
+            events.append(JetsonAtakMirrorEvent.model_validate_json(line))
+        except ValueError:
+            continue
+    return events
+
+
+def _request_is_atak_mirror_candidate(request: PromptRequest) -> bool:
+    profile = (request.agent_profile or "").strip().lower()
+    return bool(JETSON_ATAK_MODE.get("active")) or "atak" in profile
+
+
+def _mirror_source_for_request(request: PromptRequest) -> str:
+    profile = (request.agent_profile or "").strip().lower()
+    if "atak" in profile:
+        return "atak-plugin"
+    return "web-planner"
+
+
+def _jetson_atak_response(detail: str | None = None) -> JetsonAtakModeResponse:
+    return JetsonAtakModeResponse(
+        active=bool(JETSON_ATAK_MODE.get("active")),
+        status=str(JETSON_ATAK_MODE.get("status") or "idle"),
+        detail=detail or str(JETSON_ATAK_MODE.get("detail") or ""),
+        model=str(JETSON_ATAK_MODE.get("model") or TERA_ATAK_MODEL),
+        provider=str(JETSON_ATAK_MODE.get("provider") or "ollama"),
+        agent_profile=str(
+            JETSON_ATAK_MODE.get("agent_profile") or TERA_ATAK_AGENT_PROFILE
+        ),
+        atak_device_url=JETSON_ATAK_MODE.get("atak_device_url"),
+        mirror_url="/api/jetson/atak-agent/mirror",
+        events=_read_atak_mirror_events(),
+    )
+
+
+def _start_jetson_atak_command(
+    *, model: str, agent_profile: str, atak_device_url: str | None
+) -> str | None:
+    global JETSON_ATAK_PROCESS
+    if not TERA_ATAK_ACTIVATE_COMMAND:
+        return None
+    if JETSON_ATAK_PROCESS and JETSON_ATAK_PROCESS.poll() is None:
+        return f"activation command already running with pid {JETSON_ATAK_PROCESS.pid}"
+
+    args = shlex.split(TERA_ATAK_ACTIVATE_COMMAND)
+    if not args:
+        return None
+
+    command_log_path = _runtime_dir() / "atak_agent_command.log"
+    env = os.environ.copy()
+    env.update(
+        {
+            "OLLAMA_MODEL": model,
+            "TERA_GEMMA_MODEL": model,
+            "TERA_PHASE": "3",
+            "TERA_DEVICE_PROFILE": "austere",
+            "TERA_ATAK_AGENT_PROFILE": agent_profile,
+            "TERA_ATAK_MIRROR_LOG": str(_atak_mirror_log_path()),
+        }
+    )
+    if atak_device_url:
+        env["TERA_ATAK_DEVICE_URL"] = atak_device_url
+
+    with command_log_path.open("ab") as command_log:
+        JETSON_ATAK_PROCESS = subprocess.Popen(
+            args,
+            cwd=str(BASE_DIR.parent),
+            env=env,
+            stdout=command_log,
+            stderr=subprocess.STDOUT,
+        )
+    return f"activation command started with pid {JETSON_ATAK_PROCESS.pid}"
 
 
 def _manifest_path(package_id: str) -> Path:
@@ -5538,6 +5709,8 @@ async def _resolve_ollama_model(request: PromptRequest) -> str:
     requested_model = (request.model or "").strip()
     if requested_model:
         return requested_model
+    if JETSON_ATAK_MODE.get("active"):
+        return str(JETSON_ATAK_MODE.get("model") or TERA_ATAK_MODEL)
     if ACTIVE_OLLAMA_MODEL:
         return ACTIVE_OLLAMA_MODEL
 
@@ -5574,6 +5747,8 @@ def _request_llm_provider(request: PromptRequest) -> str:
 
 def _provider_sequence(request: PromptRequest) -> list[str]:
     provider = _request_llm_provider(request)
+    if JETSON_ATAK_MODE.get("active") and provider in {"auto", "ollama"}:
+        return ["ollama"]
     if provider == "ollama":
         return ["ollama"]
     return ["claude", "ollama"]
@@ -6480,6 +6655,90 @@ async def health() -> dict[str, str]:
     return {"status": "ok", "ollama_base_url": OLLAMA_BASE_URL}
 
 
+@app.get("/api/jetson/atak-agent/status", response_model=JetsonAtakModeResponse)
+async def jetson_atak_agent_status() -> JetsonAtakModeResponse:
+    return _jetson_atak_response()
+
+
+@app.get("/api/jetson/atak-agent/mirror", response_model=JetsonAtakModeResponse)
+async def jetson_atak_agent_mirror() -> JetsonAtakModeResponse:
+    return _jetson_atak_response()
+
+
+@app.post("/api/jetson/atak-agent/activate", response_model=JetsonAtakModeResponse)
+async def activate_jetson_atak_agent(
+    request: JetsonAtakActivateRequest,
+) -> JetsonAtakModeResponse:
+    global ACTIVE_OLLAMA_BASE_URL, ACTIVE_OLLAMA_MODEL
+    model = (request.model or TERA_ATAK_MODEL).strip() or TERA_ATAK_MODEL
+    agent_profile = (
+        request.agent_profile or TERA_ATAK_AGENT_PROFILE
+    ).strip() or TERA_ATAK_AGENT_PROFILE
+    atak_device_url = (request.atak_device_url or TERA_ATAK_DEVICE_URL).strip() or None
+
+    ACTIVE_OLLAMA_MODEL = model
+    JETSON_ATAK_MODE.update(
+        {
+            "active": True,
+            "status": "activating",
+            "detail": "Switching Jetson runtime to local Ollama ATAK agent mode.",
+            "model": model,
+            "provider": "ollama",
+            "agent_profile": agent_profile,
+            "atak_device_url": atak_device_url,
+            "activated_at": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+
+    model_detail = f"Configured local Ollama model {model}."
+    for base_url in _ollama_base_url_candidates():
+        try:
+            models = await _fetch_ollama_models_from(base_url)
+        except httpx.HTTPError:
+            continue
+        ACTIVE_OLLAMA_BASE_URL = base_url
+        if model in models:
+            model_detail = f"Ollama model {model} detected at {base_url}."
+            break
+        model_detail = (
+            f"Ollama is reachable at {base_url}, but {model} was not reported by /api/tags."
+        )
+        break
+
+    command_detail = _start_jetson_atak_command(
+        model=model,
+        agent_profile=agent_profile,
+        atak_device_url=atak_device_url,
+    )
+    details = [model_detail]
+    if command_detail:
+        details.append(command_detail)
+    else:
+        details.append(
+            "No TERA_ATAK_AGENT_COMMAND configured; this server will handle ATAK-profile "
+            "prompt calls directly."
+        )
+    if atak_device_url:
+        details.append(f"ATAK device target configured: {atak_device_url}.")
+    else:
+        details.append("Waiting for the ATAK plugin to POST prompts to this Jetson.")
+
+    detail = " ".join(details)
+    JETSON_ATAK_MODE.update({"status": "active", "detail": detail})
+    _append_atak_mirror_event(
+        source="jetson",
+        role="system",
+        text=(
+            f"Local TERA ATAK agent active on Ollama {model}. "
+            "Mirroring ATAK-profile prompt traffic in this panel."
+        ),
+        model=model,
+        provider="ollama",
+        direction="mode-switch",
+    )
+    return _jetson_atak_response(detail)
+
+
 @app.get("/api/config", response_model=RuntimeConfigResponse)
 async def runtime_config() -> RuntimeConfigResponse:
     return RuntimeConfigResponse(
@@ -7295,11 +7554,42 @@ async def create_package_cot(
 
 @app.post("/api/prompt", response_model=PromptResponse)
 async def prompt_ollama(request: PromptRequest) -> PromptResponse:
-    return await _post_prompt_with_fallback(request)
+    mirror = _request_is_atak_mirror_candidate(request)
+    if mirror:
+        _append_atak_mirror_event(
+            source=_mirror_source_for_request(request),
+            role="operator",
+            text=request.prompt,
+            model=request.model or str(JETSON_ATAK_MODE.get("model") or TERA_ATAK_MODEL),
+            provider=_request_llm_provider(request),
+            direction="inbound",
+        )
+    result = await _post_prompt_with_fallback(request)
+    if mirror:
+        _append_atak_mirror_event(
+            source="tera-agent",
+            role="assistant",
+            text=result.response,
+            model=result.model,
+            provider=result.provider,
+            direction="outbound",
+        )
+    return result
 
 
 @app.post("/api/prompt/stream")
 async def prompt_ollama_stream(request: PromptRequest) -> StreamingResponse:
+    mirror = _request_is_atak_mirror_candidate(request)
+    if mirror:
+        _append_atak_mirror_event(
+            source=_mirror_source_for_request(request),
+            role="operator",
+            text=request.prompt,
+            model=request.model or str(JETSON_ATAK_MODE.get("model") or TERA_ATAK_MODEL),
+            provider=_request_llm_provider(request),
+            direction="inbound",
+        )
+
     async def event_stream():
         global ACTIVE_OLLAMA_BASE_URL, ACTIVE_OLLAMA_MODEL
         failures: list[str] = []
@@ -7348,6 +7638,15 @@ async def prompt_ollama_stream(request: PromptRequest) -> StreamingResponse:
                         "provider": "claude",
                     }
                 )
+                if mirror:
+                    _append_atak_mirror_event(
+                        source="tera-agent",
+                        role="assistant",
+                        text=result.response,
+                        model=result.model,
+                        provider="claude",
+                        direction="outbound",
+                    )
                 yield _sse_event(
                     {
                         "type": "done",
@@ -7371,6 +7670,7 @@ async def prompt_ollama_stream(request: PromptRequest) -> StreamingResponse:
             )
             errors: list[str] = []
             for base_url in _ollama_base_url_candidates():
+                streamed_text = ""
                 try:
                     async with httpx.AsyncClient(timeout=timeout) as client:
                         async with client.stream(
@@ -7404,6 +7704,7 @@ async def prompt_ollama_stream(request: PromptRequest) -> StreamingResponse:
 
                                 text = str(chunk.get("response", ""))
                                 if text:
+                                    streamed_text += text
                                     yield _sse_event(
                                         {
                                             "type": "token",
@@ -7414,6 +7715,15 @@ async def prompt_ollama_stream(request: PromptRequest) -> StreamingResponse:
                                     )
 
                                 if chunk.get("done"):
+                                    if mirror:
+                                        _append_atak_mirror_event(
+                                            source="tera-agent",
+                                            role="assistant",
+                                            text=streamed_text,
+                                            model=model,
+                                            provider="ollama",
+                                            direction="outbound",
+                                        )
                                     yield _sse_event(
                                         {
                                             "type": "done",

--- a/llm_dev_kmh/app.py
+++ b/llm_dev_kmh/app.py
@@ -84,8 +84,11 @@ OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "gemma2:2b")
 ANTHROPIC_API_URL = os.getenv(
     "ANTHROPIC_API_URL", "https://api.anthropic.com/v1/messages"
 )
+ANTHROPIC_MODELS_URL = os.getenv(
+    "ANTHROPIC_MODELS_URL", "https://api.anthropic.com/v1/models"
+)
 ANTHROPIC_VERSION = os.getenv("ANTHROPIC_VERSION", "2023-06-01")
-CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
+CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "Claude Sonnet 4.6")
 CLAUDE_MODEL_ALIASES = {
     "claude-sonnet-4-20250514": "claude-sonnet-4-20250514",
     "claude-sonnet-4-0": "claude-sonnet-4-20250514",
@@ -95,16 +98,22 @@ CLAUDE_MODEL_ALIASES = {
     "sonnet 4.6": "claude-sonnet-4-20250514",
     "claude-sonnet-4": "claude-sonnet-4-20250514",
     "claude sonnet 4": "claude-sonnet-4-20250514",
-    "claude-opus-4-7": "claude-opus-4-7",
-    "claude opus 4.7": "claude-opus-4-7",
-    "opus 4.7": "claude-opus-4-7",
+    "claude-opus-4-1": "claude-opus-4-1-20250805",
+    "claude opus 4.1": "claude-opus-4-1-20250805",
+    "opus 4.1": "claude-opus-4-1-20250805",
+    "claude-opus-4-7": "claude-opus-4-1-20250805",
+    "claude opus 4.7": "claude-opus-4-1-20250805",
+    "opus 4.7": "claude-opus-4-1-20250805",
     "claude-opus-4": "claude-opus-4-20250514",
     "claude opus 4": "claude-opus-4-20250514",
     "opus 4": "claude-opus-4-20250514",
     "claude-opus-4-20250514": "claude-opus-4-20250514",
     "claude-opus-4-1-20250805": "claude-opus-4-1-20250805",
-    "claude-haiku-4-5": "claude-haiku-4-5",
-    "claude-haiku-4-5-20251001": "claude-haiku-4-5-20251001",
+    "claude-haiku-4-5": "claude-3-5-haiku-20241022",
+    "claude-haiku-4.5": "claude-3-5-haiku-20241022",
+    "claude haiku 4.5": "claude-3-5-haiku-20241022",
+    "claude-haiku-4-5-20251001": "claude-3-5-haiku-20241022",
+    "claude-haiku-3-5": "claude-3-5-haiku-20241022",
     "claude-3-7-sonnet-20250219": "claude-3-7-sonnet-20250219",
     "claude-3-5-haiku-20241022": "claude-3-5-haiku-20241022",
 }
@@ -163,6 +172,7 @@ DEFAULT_LON = float(os.getenv("DEFAULT_LON", "-122.4194"))
 DEFAULT_HEIGHT_M = float(os.getenv("DEFAULT_HEIGHT_M", "14000"))
 ACTIVE_OLLAMA_BASE_URL: str | None = None
 ACTIVE_OLLAMA_MODEL: str | None = None
+ACTIVE_CLAUDE_MODELS: list[str] | None = None
 
 app = FastAPI(title="TERA Source Planner", version="0.2.0")
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
@@ -183,7 +193,7 @@ class PromptRequest(BaseModel):
     prompt: str = Field(min_length=1, max_length=12000)
     system: str | None = Field(default=None, max_length=4000)
     model: str | None = Field(default=None, max_length=200)
-    llm_provider: str | None = Field(default="ollama", max_length=40)
+    llm_provider: str | None = Field(default="auto", max_length=40)
     cloud_model: str | None = Field(default=None, max_length=200)
     cloud_api_key: str | None = Field(default=None, max_length=500)
     agent_profile: str | None = Field(default="imagery-sourcing", max_length=80)
@@ -194,6 +204,8 @@ class PromptRequest(BaseModel):
 class PromptResponse(BaseModel):
     model: str
     response: str
+    provider: str | None = None
+    fallbacks: list[str] = Field(default_factory=list)
 
 
 class ModelsResponse(BaseModel):
@@ -208,6 +220,7 @@ class RuntimeConfigResponse(BaseModel):
     cesium_ion_token: str
     esri_token_configured: bool
     default_model: str
+    default_provider: str
     claude_default_model: str
     anthropic_api_key_configured: bool
     default_lat: float
@@ -5503,8 +5516,9 @@ def _build_system_prompt(request: PromptRequest) -> str:
     return base_prompt
 
 
-def _build_ollama_payload(request: PromptRequest, *, stream: bool) -> tuple[str, dict[str, object]]:
-    model = request.model or ACTIVE_OLLAMA_MODEL or OLLAMA_MODEL
+def _build_ollama_payload_for_model(
+    request: PromptRequest, model: str, *, stream: bool
+) -> dict[str, object]:
     payload: dict[str, object] = {
         "model": model,
         "stream": stream,
@@ -5516,14 +5530,93 @@ def _build_ollama_payload(request: PromptRequest, *, stream: bool) -> tuple[str,
             "num_predict": 512,
         },
     }
-    return model, payload
+    return payload
+
+
+async def _resolve_ollama_model(request: PromptRequest) -> str:
+    global ACTIVE_OLLAMA_BASE_URL, ACTIVE_OLLAMA_MODEL
+    requested_model = (request.model or "").strip()
+    if requested_model:
+        return requested_model
+    if ACTIVE_OLLAMA_MODEL:
+        return ACTIVE_OLLAMA_MODEL
+
+    for base_url in _ollama_base_url_candidates():
+        try:
+            models = await _fetch_ollama_models_from(base_url)
+        except httpx.HTTPError:
+            continue
+        default_model = _select_ollama_default_model(models)
+        ACTIVE_OLLAMA_BASE_URL = base_url
+        ACTIVE_OLLAMA_MODEL = default_model
+        return default_model
+
+    return OLLAMA_MODEL
+
+
+async def _build_ollama_payload(
+    request: PromptRequest, *, stream: bool
+) -> tuple[str, dict[str, object]]:
+    model = await _resolve_ollama_model(request)
+    return model, _build_ollama_payload_for_model(request, model, stream=stream)
 
 
 def _request_llm_provider(request: PromptRequest) -> str:
-    provider = (request.llm_provider or "ollama").strip().lower()
+    provider = (request.llm_provider or "auto").strip().lower()
+    if provider in {"auto", "default", "primary"}:
+        return "auto"
     if provider in {"claude", "anthropic"}:
         return "claude"
-    return "ollama"
+    if provider in {"ollama", "local", "llama"}:
+        return "ollama"
+    return "auto"
+
+
+def _provider_sequence(request: PromptRequest) -> list[str]:
+    provider = _request_llm_provider(request)
+    if provider == "ollama":
+        return ["ollama"]
+    return ["claude", "ollama"]
+
+
+def _default_provider() -> str:
+    return "auto" if os.getenv("ANTHROPIC_API_KEY", "").strip() else "ollama"
+
+
+def _anthropic_api_key(request: PromptRequest) -> str:
+    return (request.cloud_api_key or os.getenv("ANTHROPIC_API_KEY", "")).strip()
+
+
+def _failure_message(provider: str, exc: Exception) -> str:
+    if isinstance(exc, HTTPException):
+        detail = str(exc.detail)
+    else:
+        detail = str(exc)
+    return f"{provider}: {detail}"
+
+
+def _score_claude_model_for_default(model: str) -> int:
+    normalized = model.lower()
+    score = 0
+    if model == CLAUDE_MODEL:
+        score += 700
+    if "sonnet-4" in normalized:
+        score += 600
+    elif "opus-4-1" in normalized:
+        score += 450
+    elif "opus-4" in normalized:
+        score += 400
+    elif "3-7-sonnet" in normalized:
+        score += 300
+    elif "3-5-sonnet" in normalized:
+        score += 220
+    elif "3-5-haiku" in normalized:
+        score += 160
+    elif "haiku" in normalized:
+        score += 100
+    if normalized.endswith("-latest"):
+        score -= 50
+    return score
 
 
 def _normalize_claude_model(model: str | None) -> str:
@@ -5536,6 +5629,14 @@ def _normalize_claude_model(model: str | None) -> str:
     return CLAUDE_MODEL_ALIASES.get(compact, CLAUDE_MODEL_ALIASES.get(candidate.lower(), candidate))
 
 
+def _preferred_claude_model(request: PromptRequest) -> str:
+    if request.cloud_model:
+        return request.cloud_model
+    if _request_llm_provider(request) == "claude" and request.model:
+        return request.model
+    return CLAUDE_MODEL
+
+
 def _claude_model_candidates(preferred_model: str | None) -> list[str]:
     candidates = [
         _normalize_claude_model(preferred_model),
@@ -5546,6 +5647,49 @@ def _claude_model_candidates(preferred_model: str | None) -> list[str]:
         if candidate and candidate not in deduped:
             deduped.append(candidate)
     return deduped
+
+
+async def _fetch_anthropic_model_ids(api_key: str) -> list[str]:
+    global ACTIVE_CLAUDE_MODELS
+    if ACTIVE_CLAUDE_MODELS is not None:
+        return ACTIVE_CLAUDE_MODELS
+
+    timeout = httpx.Timeout(8.0, connect=3.0)
+    headers = {
+        "anthropic-version": ANTHROPIC_VERSION,
+        "x-api-key": api_key,
+    }
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.get(ANTHROPIC_MODELS_URL, headers=headers)
+        response.raise_for_status()
+    data = response.json()
+    models = [
+        str(model.get("id", "")).strip()
+        for model in data.get("data", [])
+        if isinstance(model, dict) and str(model.get("id", "")).strip()
+    ]
+    ACTIVE_CLAUDE_MODELS = models
+    return models
+
+
+async def _claude_model_candidates_for_key(
+    preferred_model: str | None, api_key: str
+) -> list[str]:
+    candidates = _claude_model_candidates(preferred_model)
+    try:
+        discovered = await _fetch_anthropic_model_ids(api_key)
+    except httpx.HTTPError as exc:
+        log.warning("claude_model_discovery_unavailable", error=str(exc))
+        discovered = []
+
+    for model in sorted(
+        discovered,
+        key=lambda candidate: (_score_claude_model_for_default(candidate), candidate),
+        reverse=True,
+    ):
+        if model and model not in candidates:
+            candidates.append(model)
+    return candidates
 
 
 def _build_claude_payload_for_model(
@@ -5572,7 +5716,7 @@ def _build_claude_payload_for_model(
 
 
 def _build_claude_payload(request: PromptRequest) -> tuple[str, dict[str, object]]:
-    model = _normalize_claude_model(request.cloud_model or request.model or CLAUDE_MODEL)
+    model = _normalize_claude_model(_preferred_claude_model(request))
     return model, _build_claude_payload_for_model(request, model)
 
 
@@ -5591,19 +5735,17 @@ def _extract_claude_response_text(data: dict[str, object]) -> str:
 
 
 async def _post_claude_message(request: PromptRequest) -> PromptResponse:
-    api_key = (request.cloud_api_key or os.getenv("ANTHROPIC_API_KEY", "")).strip()
+    api_key = _anthropic_api_key(request)
     if not api_key:
         raise HTTPException(
             status_code=400,
             detail=(
-                "Claude API key required. Open Model Provider, choose Claude API, "
-                "and add a key for this browser session."
+                "Claude API key required. Set ANTHROPIC_API_KEY on the Jetson "
+                "or add a key for this browser session."
             ),
         )
 
-    requested_model = _normalize_claude_model(
-        request.cloud_model or request.model or CLAUDE_MODEL
-    )
+    requested_model = _normalize_claude_model(_preferred_claude_model(request))
     timeout = httpx.Timeout(REQUEST_TIMEOUT_S, connect=10.0)
     headers = {
         "anthropic-version": ANTHROPIC_VERSION,
@@ -5612,7 +5754,7 @@ async def _post_claude_message(request: PromptRequest) -> PromptResponse:
     }
     model_errors: list[str] = []
 
-    for model in _claude_model_candidates(requested_model):
+    for model in await _claude_model_candidates_for_key(requested_model, api_key):
         payload = _build_claude_payload_for_model(request, model)
         try:
             async with httpx.AsyncClient(timeout=timeout) as client:
@@ -5652,13 +5794,78 @@ async def _post_claude_message(request: PromptRequest) -> PromptResponse:
         text = _extract_claude_response_text(response.json())
         if not text:
             raise HTTPException(status_code=502, detail="Claude returned an empty response.")
-        return PromptResponse(model=model, response=text)
+        return PromptResponse(model=model, response=text, provider="claude")
 
     detail = (
         "Claude API rejected every configured model candidate. "
         + " | ".join(model_errors)
     )
     raise HTTPException(status_code=502, detail=detail)
+
+
+async def _post_ollama_message(request: PromptRequest) -> PromptResponse:
+    global ACTIVE_OLLAMA_BASE_URL, ACTIVE_OLLAMA_MODEL
+    model, payload = await _build_ollama_payload(request, stream=False)
+
+    timeout = httpx.Timeout(REQUEST_TIMEOUT_S, connect=10.0)
+
+    errors: list[str] = []
+    for base_url in _ollama_base_url_candidates():
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.post(f"{base_url}/api/generate", json=payload)
+                response.raise_for_status()
+            ACTIVE_OLLAMA_BASE_URL = base_url
+            ACTIVE_OLLAMA_MODEL = model
+            break
+        except httpx.HTTPStatusError as exc:
+            body = exc.response.text[:500]
+            errors.append(f"{base_url} returned {exc.response.status_code}: {body}")
+            log.error(
+                "ollama_http_error",
+                status_code=exc.response.status_code,
+                body=body,
+                ollama_base_url=base_url,
+                model=model,
+            )
+        except httpx.HTTPError as exc:
+            errors.append(f"{base_url} unreachable: {exc}")
+            log.error(
+                "ollama_connection_error",
+                error=str(exc),
+                ollama_base_url=base_url,
+                model=model,
+            )
+    else:
+        raise HTTPException(
+            status_code=502,
+            detail="Could not reach a local Ollama host. " + " | ".join(errors),
+        )
+
+    data = response.json()
+    text = str(data.get("response", "")).strip()
+    if not text:
+        raise HTTPException(status_code=502, detail="Ollama returned an empty response.")
+
+    return PromptResponse(model=model, response=text, provider="ollama")
+
+
+async def _post_prompt_with_fallback(request: PromptRequest) -> PromptResponse:
+    fallbacks: list[str] = []
+    for provider in _provider_sequence(request):
+        try:
+            if provider == "claude":
+                result = await _post_claude_message(request)
+            else:
+                result = await _post_ollama_message(request)
+        except HTTPException as exc:
+            fallbacks.append(_failure_message(provider, exc))
+            continue
+        result.fallbacks = fallbacks
+        return result
+
+    detail = " | ".join(fallbacks) if fallbacks else "No model providers were configured."
+    raise HTTPException(status_code=502, detail=f"All model providers failed. {detail}")
 
 
 def _sse_event(payload: dict[str, object]) -> str:
@@ -6279,6 +6486,7 @@ async def runtime_config() -> RuntimeConfigResponse:
         cesium_ion_token=CESIUM_ION_TOKEN,
         esri_token_configured=ESRI_TOKEN_CONFIGURED,
         default_model=OLLAMA_MODEL,
+        default_provider=_default_provider(),
         claude_default_model=_normalize_claude_model(CLAUDE_MODEL),
         anthropic_api_key_configured=bool(os.getenv("ANTHROPIC_API_KEY", "").strip()),
         default_lat=DEFAULT_LAT,
@@ -7087,150 +7295,159 @@ async def create_package_cot(
 
 @app.post("/api/prompt", response_model=PromptResponse)
 async def prompt_ollama(request: PromptRequest) -> PromptResponse:
-    if _request_llm_provider(request) == "claude":
-        return await _post_claude_message(request)
-
-    model, payload = _build_ollama_payload(request, stream=False)
-
-    timeout = httpx.Timeout(REQUEST_TIMEOUT_S, connect=10.0)
-
-    errors: list[str] = []
-    for base_url in _ollama_base_url_candidates():
-        try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                response = await client.post(f"{base_url}/api/generate", json=payload)
-                response.raise_for_status()
-            break
-        except httpx.HTTPStatusError as exc:
-            body = exc.response.text[:500]
-            errors.append(f"{base_url} returned {exc.response.status_code}: {body}")
-            log.error(
-                "ollama_http_error",
-                status_code=exc.response.status_code,
-                body=body,
-                ollama_base_url=base_url,
-            )
-        except httpx.HTTPError as exc:
-            errors.append(f"{base_url} unreachable: {exc}")
-            log.error("ollama_connection_error", error=str(exc), ollama_base_url=base_url)
-    else:
-        raise HTTPException(
-            status_code=502,
-            detail="Could not reach a local Ollama host. " + " | ".join(errors),
-        )
-
-    data = response.json()
-    text = str(data.get("response", "")).strip()
-    if not text:
-        raise HTTPException(status_code=502, detail="Ollama returned an empty response.")
-
-    return PromptResponse(model=model, response=text)
+    return await _post_prompt_with_fallback(request)
 
 
 @app.post("/api/prompt/stream")
 async def prompt_ollama_stream(request: PromptRequest) -> StreamingResponse:
-    if _request_llm_provider(request) == "claude":
-        model, _payload = _build_claude_payload(request)
-
-        async def claude_event_stream():
-            yield _sse_event({"type": "start", "model": model, "provider": "claude"})
-            yield _sse_event(
-                {
-                    "type": "status",
-                    "detail": "Waiting for Claude API response",
-                    "model": model,
-                }
-            )
-            try:
-                result = await _post_claude_message(request)
-            except HTTPException as exc:
+    async def event_stream():
+        global ACTIVE_OLLAMA_BASE_URL, ACTIVE_OLLAMA_MODEL
+        failures: list[str] = []
+        sequence = _provider_sequence(request)
+        for provider in sequence:
+            if provider == "claude":
+                model, _payload = _build_claude_payload(request)
+                yield _sse_event({"type": "start", "model": model, "provider": "claude"})
                 yield _sse_event(
                     {
-                        "type": "error",
-                        "detail": str(exc.detail),
+                        "type": "status",
+                        "detail": "Waiting for Claude API response",
                         "model": model,
                         "provider": "claude",
                     }
                 )
+                try:
+                    result = await _post_claude_message(request)
+                except HTTPException as exc:
+                    failure = _failure_message("claude", exc)
+                    failures.append(failure)
+                    if "ollama" in sequence:
+                        yield _sse_event(
+                            {
+                                "type": "fallback",
+                                "detail": "Claude unavailable; trying local Ollama fallback.",
+                                "reason": failure,
+                                "provider": "claude",
+                            }
+                        )
+                        continue
+                    yield _sse_event(
+                        {
+                            "type": "error",
+                            "detail": str(exc.detail),
+                            "model": model,
+                            "provider": "claude",
+                        }
+                    )
+                    return
+                yield _sse_event(
+                    {
+                        "type": "token",
+                        "text": result.response,
+                        "model": result.model,
+                        "provider": "claude",
+                    }
+                )
+                yield _sse_event(
+                    {
+                        "type": "done",
+                        "model": result.model,
+                        "provider": "claude",
+                        "fallbacks": failures,
+                    }
+                )
                 return
+
+            model, payload = await _build_ollama_payload(request, stream=True)
+            timeout = httpx.Timeout(REQUEST_TIMEOUT_S, connect=10.0)
+            yield _sse_event({"type": "start", "model": model, "provider": "ollama"})
             yield _sse_event(
                 {
-                    "type": "token",
-                    "text": result.response,
-                    "model": result.model,
-                    "provider": "claude",
+                    "type": "status",
+                    "detail": "Waiting for local model tokens",
+                    "model": model,
+                    "provider": "ollama",
                 }
             )
-            yield _sse_event({"type": "done", "model": result.model, "provider": "claude"})
-
-        return StreamingResponse(
-            claude_event_stream(),
-            media_type="text/event-stream",
-            headers={
-                "Cache-Control": "no-cache",
-                "Connection": "keep-alive",
-                "X-Accel-Buffering": "no",
-            },
-        )
-
-    model, payload = _build_ollama_payload(request, stream=True)
-    timeout = httpx.Timeout(REQUEST_TIMEOUT_S, connect=10.0)
-
-    async def event_stream():
-        yield _sse_event({"type": "start", "model": model})
-        yield _sse_event(
-            {"type": "status", "detail": "Waiting for local model tokens", "model": model}
-        )
-        errors: list[str] = []
-        for base_url in _ollama_base_url_candidates():
-            try:
-                async with httpx.AsyncClient(timeout=timeout) as client:
-                    async with client.stream(
-                        "POST", f"{base_url}/api/generate", json=payload
-                    ) as response:
-                        if response.status_code >= 400:
-                            body = (await response.aread()).decode(
-                                "utf-8", errors="replace"
-                            )[:500]
-                            errors.append(
-                                f"{base_url} returned {response.status_code}: {body}"
-                            )
-                            log.error(
-                                "ollama_stream_http_error",
-                                status_code=response.status_code,
-                                body=body,
-                                ollama_base_url=base_url,
-                            )
-                            continue
-
-                        async for line in response.aiter_lines():
-                            if not line:
-                                continue
-                            try:
-                                chunk = json.loads(line)
-                            except json.JSONDecodeError:
+            errors: list[str] = []
+            for base_url in _ollama_base_url_candidates():
+                try:
+                    async with httpx.AsyncClient(timeout=timeout) as client:
+                        async with client.stream(
+                            "POST", f"{base_url}/api/generate", json=payload
+                        ) as response:
+                            if response.status_code >= 400:
+                                body = (await response.aread()).decode(
+                                    "utf-8", errors="replace"
+                                )[:500]
+                                errors.append(
+                                    f"{base_url} returned {response.status_code}: {body}"
+                                )
+                                log.error(
+                                    "ollama_stream_http_error",
+                                    status_code=response.status_code,
+                                    body=body,
+                                    ollama_base_url=base_url,
+                                    model=model,
+                                )
                                 continue
 
-                            text = str(chunk.get("response", ""))
-                            if text:
-                                yield _sse_event({"type": "token", "text": text, "model": model})
+                            ACTIVE_OLLAMA_BASE_URL = base_url
+                            ACTIVE_OLLAMA_MODEL = model
+                            async for line in response.aiter_lines():
+                                if not line:
+                                    continue
+                                try:
+                                    chunk = json.loads(line)
+                                except json.JSONDecodeError:
+                                    continue
 
-                            if chunk.get("done"):
-                                yield _sse_event({"type": "done", "model": model})
-                                return
-            except httpx.HTTPError as exc:
-                errors.append(f"{base_url} unreachable: {exc}")
-                log.error(
-                    "ollama_stream_connection_error",
-                    error=str(exc),
-                    ollama_base_url=base_url,
-                )
+                                text = str(chunk.get("response", ""))
+                                if text:
+                                    yield _sse_event(
+                                        {
+                                            "type": "token",
+                                            "text": text,
+                                            "model": model,
+                                            "provider": "ollama",
+                                        }
+                                    )
+
+                                if chunk.get("done"):
+                                    yield _sse_event(
+                                        {
+                                            "type": "done",
+                                            "model": model,
+                                            "provider": "ollama",
+                                            "fallbacks": failures,
+                                        }
+                                    )
+                                    return
+                except httpx.HTTPError as exc:
+                    errors.append(f"{base_url} unreachable: {exc}")
+                    log.error(
+                        "ollama_stream_connection_error",
+                        error=str(exc),
+                        ollama_base_url=base_url,
+                        model=model,
+                    )
+            failures.append("ollama: " + " | ".join(errors))
+            yield _sse_event(
+                {
+                    "type": "error",
+                    "detail": "All model providers failed. " + " | ".join(failures),
+                    "model": model,
+                    "provider": "ollama",
+                    "fallbacks": failures,
+                }
+            )
+            return
 
         yield _sse_event(
             {
                 "type": "error",
-                "detail": "Could not reach a local Ollama host. " + " | ".join(errors),
-                "model": model,
+                "detail": "No model providers were configured.",
+                "fallbacks": failures,
             }
         )
 

--- a/llm_dev_kmh/app.py
+++ b/llm_dev_kmh/app.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
+import asyncio
+import hashlib
+import hmac
 import json
 import math
 import os
 import re
+import shutil
+import subprocess
+import zipfile
+import xml.etree.ElementTree as ET
 from difflib import SequenceMatcher
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from textwrap import dedent
+from typing import Any, Iterable, Literal
+from urllib.parse import quote, urljoin
 from uuid import uuid4
 
 import httpx
@@ -16,6 +25,8 @@ from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
+
+from llm_dev_kmh.geo_algorithms import algorithm_catalog
 
 log = structlog.get_logger(__name__)
 
@@ -26,6 +37,11 @@ IMAGERY_SOURCING_PROMPT_FILE = (
 )
 INDEX_FILE = BASE_DIR / "static" / "index.html"
 STATIC_DIR = BASE_DIR / "static"
+DEFAULT_OFFLINE_PACKAGE_ROOT = BASE_DIR / "offline_packages"
+ESRI_TILE_EXPORT_POLL_INTERVAL_S = float(os.getenv("ESRI_TILE_EXPORT_POLL_INTERVAL_S", "3"))
+ESRI_TILE_EXPORT_MAX_POLLS = int(os.getenv("ESRI_TILE_EXPORT_MAX_POLLS", "120"))
+CESIUM_ARCHIVE_POLL_INTERVAL_S = float(os.getenv("CESIUM_ARCHIVE_POLL_INTERVAL_S", "3"))
+CESIUM_ARCHIVE_MAX_POLLS = int(os.getenv("CESIUM_ARCHIVE_MAX_POLLS", "240"))
 
 
 def _load_dotenv_file(path: Path) -> None:
@@ -69,24 +85,36 @@ ANTHROPIC_API_URL = os.getenv(
     "ANTHROPIC_API_URL", "https://api.anthropic.com/v1/messages"
 )
 ANTHROPIC_VERSION = os.getenv("ANTHROPIC_VERSION", "2023-06-01")
-CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6")
+CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
 CLAUDE_MODEL_ALIASES = {
-    "claude-sonnet-4-6": "claude-sonnet-4-6",
-    "claude-sonnet-4.6": "claude-sonnet-4-6",
-    "claude sonnet 4.6": "claude-sonnet-4-6",
-    "sonnet 4.6": "claude-sonnet-4-6",
-    "claude-sonnet-4": "claude-sonnet-4-6",
-    "claude sonnet 4": "claude-sonnet-4-6",
-    "claude-sonnet-4-20250514": "claude-sonnet-4-6",
+    "claude-sonnet-4-20250514": "claude-sonnet-4-20250514",
+    "claude-sonnet-4-0": "claude-sonnet-4-20250514",
+    "claude-sonnet-4-6": "claude-sonnet-4-20250514",
+    "claude-sonnet-4.6": "claude-sonnet-4-20250514",
+    "claude sonnet 4.6": "claude-sonnet-4-20250514",
+    "sonnet 4.6": "claude-sonnet-4-20250514",
+    "claude-sonnet-4": "claude-sonnet-4-20250514",
+    "claude sonnet 4": "claude-sonnet-4-20250514",
     "claude-opus-4-7": "claude-opus-4-7",
     "claude opus 4.7": "claude-opus-4-7",
     "opus 4.7": "claude-opus-4-7",
+    "claude-opus-4": "claude-opus-4-20250514",
+    "claude opus 4": "claude-opus-4-20250514",
+    "opus 4": "claude-opus-4-20250514",
+    "claude-opus-4-20250514": "claude-opus-4-20250514",
     "claude-opus-4-1-20250805": "claude-opus-4-1-20250805",
     "claude-haiku-4-5": "claude-haiku-4-5",
     "claude-haiku-4-5-20251001": "claude-haiku-4-5-20251001",
     "claude-3-7-sonnet-20250219": "claude-3-7-sonnet-20250219",
     "claude-3-5-haiku-20241022": "claude-3-5-haiku-20241022",
 }
+CLAUDE_MODEL_FALLBACKS = (
+    "claude-sonnet-4-20250514",
+    "claude-opus-4-1-20250805",
+    "claude-opus-4-20250514",
+    "claude-3-7-sonnet-20250219",
+    "claude-3-5-haiku-20241022",
+)
 REQUEST_TIMEOUT_S = float(os.getenv("REQUEST_TIMEOUT_S", "120"))
 LOCATION_SEARCH_TIMEOUT_S = float(os.getenv("LOCATION_SEARCH_TIMEOUT_S", "4"))
 LOCATION_SEARCH_URL = os.getenv(
@@ -122,6 +150,14 @@ CESIUM_ION_TOKEN = (
     or os.getenv("CESIUM_ION_ACCESS_TOKEN")
     or ""
 ).strip()
+ESRI_TOKEN_CONFIGURED = bool(
+    (
+        os.getenv("ESRI_ARCGIS_TOKEN")
+        or os.getenv("ARCGIS_TOKEN")
+        or os.getenv("ESRI_ACCESS_TOKEN")
+        or ""
+    ).strip()
+)
 DEFAULT_LAT = float(os.getenv("DEFAULT_LAT", "37.7749"))
 DEFAULT_LON = float(os.getenv("DEFAULT_LON", "-122.4194"))
 DEFAULT_HEIGHT_M = float(os.getenv("DEFAULT_HEIGHT_M", "14000"))
@@ -170,6 +206,7 @@ class ModelsResponse(BaseModel):
 
 class RuntimeConfigResponse(BaseModel):
     cesium_ion_token: str
+    esri_token_configured: bool
     default_model: str
     claude_default_model: str
     anthropic_api_key_configured: bool
@@ -221,6 +258,28 @@ class MapContext(BaseModel):
     location_confirmed: bool = False
 
 
+class SourceDownloadMethod(BaseModel):
+    id: str
+    label: str
+    endpoint: str
+    method: str = "GET"
+    output_format: str
+    local_artifact_template: str
+    params: dict[str, object] = Field(default_factory=dict)
+    requires_token_env: str | None = None
+    requires_account: bool = False
+    terms_url: str | None = None
+    notes: str = ""
+
+
+class JetsonQueryFormat(BaseModel):
+    artifact_type: str
+    local_path_template: str
+    query_interfaces: list[str]
+    feeds_algorithms: list[str]
+    notes: str = ""
+
+
 class SourceOption(BaseModel):
     id: str
     name: str
@@ -235,6 +294,10 @@ class SourceOption(BaseModel):
     required_for: list[str] = Field(default_factory=list)
     recommended_for: list[str] = Field(default_factory=list)
     derived_layers: list[str] = Field(default_factory=list)
+    source_url: str | None = None
+    license_or_terms: str | None = None
+    download_methods: list[SourceDownloadMethod] = Field(default_factory=list)
+    jetson_query_formats: list[JetsonQueryFormat] = Field(default_factory=list)
     notes: str = ""
 
 
@@ -267,6 +330,16 @@ class DownloadPlanRequest(BaseModel):
     package_name: str | None = Field(default=None, max_length=120)
 
 
+class StorageInfoResponse(BaseModel):
+    package_root: str
+    total_bytes: int
+    used_bytes: int
+    free_bytes: int
+    reserved_bytes: int
+    usable_bytes: int
+    existing_package_bytes: int
+
+
 class DownloadPlanResponse(BaseModel):
     package_id: str
     package_name: str
@@ -275,6 +348,52 @@ class DownloadPlanResponse(BaseModel):
     manifest: dict[str, object]
     warnings: list[str]
     download_url: str
+    execute_url: str
+    status_url: str
+    artifacts_url: str
+    estimated_bytes: int
+    storage_fit: bool
+    storage: StorageInfoResponse
+    storage_warning: str | None = None
+
+
+class PackageExecuteResponse(BaseModel):
+    package_id: str
+    state: str
+    status_url: str
+    artifacts_url: str
+    storage: StorageInfoResponse
+    message: str
+
+
+class TerrainQueryRequest(BaseModel):
+    query_type: Literal["sample", "window", "summary"] = "sample"
+    lat: float | None = Field(default=None, ge=-90, le=90)
+    lon: float | None = Field(default=None, ge=-180, le=180)
+    bbox: ViewBounds | None = None
+    max_cells: int = Field(default=10000, ge=1, le=250000)
+
+
+class AlgorithmRequest(BaseModel):
+    algorithm_id: str = Field(min_length=1, max_length=80)
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class PackageRouteRequest(BaseModel):
+    start: MapPoint
+    end: MapPoint
+    profile: str = Field(default="foot_covered", max_length=80)
+    avoid: list[str] = Field(default_factory=list)
+    mission_type: str = Field(default="terrain_route", max_length=80)
+
+
+class PackageCotRequest(BaseModel):
+    route_id: str | None = Field(default=None, max_length=120)
+    route: dict[str, Any] | None = None
+    waypoints: list[MapPoint] = Field(default_factory=list)
+    cot_type: Literal["route", "track"] = "route"
+    mission_type: str = Field(default="terrain_route", max_length=80)
+    rationale: str = Field(default="TERA generated route.", max_length=1000)
 
 
 def _extract_prompt_code_block(markdown: str) -> str:
@@ -303,13 +422,43 @@ def _load_imagery_sourcing_prompt() -> str:
         return fallback
 
 
+ESRI_TERMS_URL = "https://www.esri.com/en-us/legal/terms/full-master-agreement"
+ESRI_WORLD_IMAGERY_EXPORT_URL = (
+    "https://tiledbasemaps.arcgis.com/arcgis/rest/services/World_Imagery/MapServer"
+)
+ESRI_WORLD_ELEVATION_TERRAIN_URL = (
+    "https://elevation.arcgis.com/arcgis/rest/services/WorldElevation/Terrain/ImageServer"
+)
+EARTH_SEARCH_STAC_SEARCH_URL = "https://earth-search.aws.element84.com/v1/search"
+CESIUM_ION_ARCHIVES_URL = "https://api.cesium.com/v1/archives"
+CESIUM_ION_ARCHIVE_INFO_URL = "https://api.cesium.com/v1/archives/{archive_id}"
+CESIUM_ION_ARCHIVE_DOWNLOAD_URL = "https://api.cesium.com/v1/archives/{archive_id}/download"
+NAIP_AWS_BUCKET_URL_TEMPLATE = "https://{bucket}.s3.amazonaws.com"
+NAIP_AWS_DEFAULT_BUCKET = "naip-analytic"
+GEOFABRIK_BASE_URL = "https://download.geofabrik.de"
+COPERNICUS_DEM_30M_BASE_URL = "https://copernicus-dem-30m.s3.amazonaws.com"
+USGS_EARTHEXPLORER_URL = "https://earthexplorer.usgs.gov"
+USGS_IMAGERY_ONLY_TILE_URL = (
+    "https://basemap.nationalmap.gov/ArcGIS/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}"
+)
+NRL_NAIP_TILE_URL = (
+    "https://geoint.nrlssc.navy.mil/nrltileserver/wmts2?"
+    "SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=NAIP&STYLE=_null&"
+    "TILEMATRIXSET=GoogleMapsCompatible&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}&"
+    "FORMAT=image%2Fpng&WIDTH=256&HEIGHT=256"
+)
+
+
 SOURCE_CATALOG: list[SourceOption] = [
     SourceOption(
         id="esri_world_imagery",
         name="Esri World Imagery",
         provider="Esri ArcGIS Online",
         category="imagery",
-        purpose="High-resolution visual basemap for AO inspection and imagery context.",
+        purpose=(
+            "Optional visual imagery stream for AO inspection when an Esri account is "
+            "available."
+        ),
         useful_for=[
             "visual AO verification",
             "roads and tracks visible in imagery",
@@ -317,31 +466,301 @@ SOURCE_CATALOG: list[SourceOption] = [
             "vegetation and water body sanity checks",
         ],
         analysis_role=(
-            "Display stream only in this app; cache tiles for offline visualization and "
-            "pair with analytical imagery or vector extracts for database queries."
+            "Display-only fallback. Do not select for downloads unless the Jetson has "
+            "an ArcGIS token; use Sentinel-2 COGs or NAIP/open imagery for free offline files."
         ),
         stream_status="streamable",
-        download_status="manifest-only",
+        download_status="export-tiles-with-account",
         stream_layer="esri",
-        required_for=["imagery-preview"],
-        recommended_for=["terrain-routing", "water-access", "sar-planning", "evacuation"],
-        derived_layers=["visual_aoi_reference"],
-        notes="Do not use the visual tile stream as the sole analytical source.",
+        recommended_for=["licensed-imagery-preview"],
+        derived_layers=["cached_esri_imagery_tiles", "visual_aoi_reference"],
+        source_url=ESRI_WORLD_IMAGERY_EXPORT_URL,
+        license_or_terms=(
+            "Esri World Imagery for Export requires an ArcGIS organizational or "
+            "developer account and must be used under Esri terms."
+        ),
+        download_methods=[
+            SourceDownloadMethod(
+                id="esri_world_imagery_export_tiles",
+                label="ArcGIS Export Tiles job",
+                endpoint=f"{ESRI_WORLD_IMAGERY_EXPORT_URL}/exportTiles",
+                method="POST",
+                output_format="TPKX tile package",
+                local_artifact_template=(
+                    "offline_packages/{package_id}/tiles/esri_world_imagery/world_imagery.tpkx"
+                ),
+                params={
+                    "tilePackage": "true",
+                    "storageFormatType": "esriMapCacheStorageModeCompactV2",
+                    "exportBy": "LevelID",
+                    "levels": "{imagery_level_range}",
+                    "exportExtent": "{aoi_wgs84_json}",
+                    "optimizeTilesForSize": "true",
+                    "compressionQuality": 75,
+                    "f": "json",
+                    "token": "${ESRI_ARCGIS_TOKEN}",
+                },
+                requires_token_env="ESRI_ARCGIS_TOKEN",
+                requires_account=True,
+                terms_url=ESRI_TERMS_URL,
+                notes=(
+                    "Use the World Imagery for Export service rather than scraping "
+                    "individual stream tiles. Keep exports under Esri service limits."
+                ),
+            )
+        ],
+        jetson_query_formats=[
+            JetsonQueryFormat(
+                artifact_type="esri_tpkx_imagery_package",
+                local_path_template=(
+                    "offline_packages/{package_id}/tiles/esri_world_imagery/world_imagery.tpkx"
+                ),
+                query_interfaces=[
+                    "package_metadata()",
+                    "tile_package_bounds()",
+                    "imagery_metadata_at(lat, lon)",
+                ],
+                feeds_algorithms=["visual_aoi_reference", "operator_route_review"],
+                notes=(
+                    "RGB basemap tiles are queryable for display and human sanity checks; "
+                    "do not use them as the sole source for slope, hydrology, or graph routing."
+                ),
+            )
+        ],
+        notes=(
+            "Not selected by default because this workflow only has a Cesium token. "
+            "Keep it as an optional licensed source."
+        ),
     ),
     SourceOption(
         id="cesium_world_imagery",
         name="Cesium World Imagery",
         provider="Cesium ion",
         category="imagery",
-        purpose="Token-backed global imagery stream for Cesium preview.",
+        purpose="Token-backed global imagery stream for Cesium preview using the token available on this Jetson.",
         useful_for=["3D mission preview", "route visualization backdrop", "AO briefing"],
-        analysis_role="Display layer; pre-cache selected tiles for disconnected demos.",
+        analysis_role=(
+            "Primary stream/display imagery in the web app. It is not treated as the "
+            "free downloadable analysis source; Sentinel-2 COGs fill that role."
+        ),
         stream_status="streamable-with-token",
-        download_status="cache-via-cesium-pipeline",
+        download_status="stream-only-no-offline-copy",
         stream_layer="ion-satellite",
-        recommended_for=["imagery-preview", "terrain-routing"],
-        derived_layers=["cached_imagery_tiles"],
-        notes="Phase 3 runtime must read cached tiles rather than calling Cesium online.",
+        recommended_for=["imagery-preview", "terrain-routing", "water-access", "sar-planning", "evacuation"],
+        derived_layers=["preview_only_imagery_stream"],
+        notes=(
+            "Use for online preview with CESIUM_ION_TOKEN only. Do not download or "
+            "cache Cesium ion data into the Jetson package unless a Cesium license "
+            "explicitly grants offline clips/archives."
+        ),
+    ),
+    SourceOption(
+        id="cesium_ion_archive",
+        name="Cesium ion Offline Archive",
+        provider="Cesium ion",
+        category="imagery-terrain-archive",
+        purpose=(
+            "Licensed/user-owned Cesium ion archive or AO clip downloaded to the "
+            "Jetson for local preview, tile serving, and archive metadata queries."
+        ),
+        useful_for=[
+            "local Cesium preview",
+            "3D Tiles archive import",
+            "offline imagery/terrain clip validation",
+            "operator route review",
+        ],
+        analysis_role=(
+            "Download an already-created Cesium archive by id, or create an AO "
+            "clip from configured ion asset ids, then extract and index the files "
+            "under the Jetson package root. This is the only Cesium download path; "
+            "it does not scrape World Imagery or World Terrain stream tiles."
+        ),
+        stream_status="not-streamed",
+        download_status="download-required",
+        required_for=[],
+        recommended_for=["imagery-preview", "terrain-routing", "signal-planning"],
+        derived_layers=[
+            "cesium_archive_zip",
+            "cesium_tileset_index",
+            "cesium_layer_json",
+            "local_cesium_file_server",
+        ],
+        source_url=CESIUM_ION_ARCHIVES_URL,
+        license_or_terms=(
+            "Requires a Cesium ion token and an archive/export or clippable "
+            "user-owned asset that is permitted for offline use."
+        ),
+        download_methods=[
+            SourceDownloadMethod(
+                id="cesium_ion_archive_download",
+                label="Cesium ion archive download",
+                endpoint=CESIUM_ION_ARCHIVE_DOWNLOAD_URL,
+                output_format="Cesium archive ZIP",
+                local_artifact_template=(
+                    "offline_packages/{package_id}/cesium/archive/cesium_ion_archive.zip"
+                ),
+                params={
+                    "archive_id": "${CESIUM_ION_ARCHIVE_ID}",
+                    "token": "${CESIUM_ION_TOKEN}",
+                    "extract": True,
+                },
+                requires_token_env="CESIUM_ION_TOKEN",
+                requires_account=True,
+                terms_url="https://cesium.com/learn/ion/cesium-ion-archives-and-exports/",
+                notes=(
+                    "Set CESIUM_ION_ARCHIVE_ID to a completed archive id. The token "
+                    "is sent as an OAuth Bearer credential at download time and is "
+                    "not written to the manifest or artifact registry."
+                ),
+            ),
+            SourceDownloadMethod(
+                id="cesium_ion_clip_create_download",
+                label="Cesium ion AO clip create and download",
+                endpoint=CESIUM_ION_ARCHIVES_URL,
+                method="POST",
+                output_format="Cesium 3D Tiles archive ZIP",
+                local_artifact_template=(
+                    "offline_packages/{package_id}/cesium/archive/cesium_ion_clip.zip"
+                ),
+                params={
+                    "asset_ids": "${CESIUM_ION_ASSET_IDS}",
+                    "token": "${CESIUM_ION_TOKEN}",
+                    "type": "CLIP_LATITUDE_LONGITUDE_RECTANGLE",
+                    "format": "TILESET",
+                    "clip_region": "{aoi_bbox_radians}",
+                    "extract": True,
+                },
+                requires_token_env="CESIUM_ION_TOKEN",
+                requires_account=True,
+                terms_url="https://cesium.com/learn/ion/cesium-ion-archives-and-exports/",
+                notes=(
+                    "Creates a bounded clip when CESIUM_ION_ASSET_IDS identifies "
+                    "archive/export-permitted ion assets. This will fail for assets "
+                    "that Cesium does not allow to be archived or clipped."
+                ),
+            ),
+        ],
+        jetson_query_formats=[
+            JetsonQueryFormat(
+                artifact_type="cesium_offline_archive_index",
+                local_path_template=(
+                    "offline_packages/{package_id}/cesium/archive/cesium_archive_index.json"
+                ),
+                query_interfaces=[
+                    "cesium_archive_metadata()",
+                    "cesium_file(relative_path)",
+                    "tileset_json()",
+                    "layer_json()",
+                ],
+                feeds_algorithms=[
+                    "local_cesium_preview",
+                    "operator_route_review",
+                    "terrain_visual_context",
+                ],
+                notes=(
+                    "Archive metadata and 3D Tiles/terrain descriptors are queryable "
+                    "locally. DEM algorithms still prefer GeoTIFF/COG elevation unless "
+                    "a quantized-mesh terrain decoder is added."
+                ),
+            )
+        ],
+        notes=(
+            "Use this when the Jetson must actually download Cesium content. A plain "
+            "World Imagery/Terrain stream token is not treated as offline download permission."
+        ),
+    ),
+    SourceOption(
+        id="usgs_imagery_only",
+        name="USGS Imagery Only",
+        provider="USGS The National Map",
+        category="imagery",
+        purpose="Free U.S. imagery tile stream from The National Map for AO preview and offline visual tile cache.",
+        useful_for=["U.S. visual AO verification", "roads and clearings", "offline background tiles"],
+        analysis_role=(
+            "Free visual imagery layer from the WinTAK source folder. Cache bounded AO tiles "
+            "to the Jetson for offline TAK/planner display; use Sentinel-2 COGs for raster analysis."
+        ),
+        stream_status="streamable",
+        download_status="cache-tiles",
+        stream_layer="usgs-imagery",
+        recommended_for=["imagery-preview", "terrain-routing", "sar-planning", "evacuation"],
+        derived_layers=["cached_usgs_imagery_tiles", "visual_aoi_reference"],
+        source_url=USGS_IMAGERY_ONLY_TILE_URL,
+        license_or_terms="U.S. public basemap imagery source; verify local attribution and cache policy before broad redistribution.",
+        download_methods=[
+            SourceDownloadMethod(
+                id="usgs_imagery_tile_cache",
+                label="USGS imagery AO tile cache",
+                endpoint=USGS_IMAGERY_ONLY_TILE_URL,
+                output_format="XYZ PNG tile cache",
+                local_artifact_template=(
+                    "offline_packages/{package_id}/tiles/usgs_imagery_only/{z}/{x}/{y}.png"
+                ),
+                params={
+                    "tile_url_template": USGS_IMAGERY_ONLY_TILE_URL,
+                    "levels": "{imagery_level_range}",
+                    "min_zoom": 0,
+                    "max_zoom": 15,
+                },
+                notes="Caches only AO-intersecting tiles under the Jetson package root.",
+            )
+        ],
+        jetson_query_formats=[
+            JetsonQueryFormat(
+                artifact_type="xyz_imagery_tile_cache",
+                local_path_template="offline_packages/{package_id}/tiles/usgs_imagery_only/{z}/{x}/{y}.png",
+                query_interfaces=["tile(z, x, y)", "tiles_intersecting_bbox(west, south, east, north, zoom)"],
+                feeds_algorithms=["visual_aoi_reference", "operator_route_review"],
+                notes="Visual tiles are queryable for display, not for DEM/routing math.",
+            )
+        ],
+        notes="Imported from the WinTAK imagery source list as a free U.S. visual imagery stream.",
+    ),
+    SourceOption(
+        id="nrl_naip_conus",
+        name="NRL NAIP (CONUS)",
+        provider="NRL / USDA NAIP",
+        category="imagery",
+        purpose="Free CONUS NAIP tile stream from the WinTAK imagery folder for high-detail U.S. AO review.",
+        useful_for=["CONUS aerial imagery", "small clearings", "roads and tracks", "offline visual review"],
+        analysis_role=(
+            "High-detail U.S. visual imagery tile cache. Useful for operator review and feature sanity checks; "
+            "not a substitute for COG bands or DEMs in deterministic algorithms."
+        ),
+        stream_status="streamable",
+        download_status="cache-tiles",
+        recommended_for=["imagery-preview", "sar-planning", "evacuation"],
+        derived_layers=["cached_naip_tiles", "high_detail_aerial_reference"],
+        source_url=NRL_NAIP_TILE_URL,
+        license_or_terms="NAIP imagery is public-domain with attribution; confirm NRL tile service use/caching constraints.",
+        download_methods=[
+            SourceDownloadMethod(
+                id="nrl_naip_tile_cache",
+                label="NRL NAIP AO tile cache",
+                endpoint=NRL_NAIP_TILE_URL,
+                output_format="XYZ PNG tile cache",
+                local_artifact_template=(
+                    "offline_packages/{package_id}/tiles/nrl_naip_conus/{z}/{x}/{y}.png"
+                ),
+                params={
+                    "tile_url_template": NRL_NAIP_TILE_URL,
+                    "levels": "{imagery_level_range}",
+                    "min_zoom": 0,
+                    "max_zoom": 18,
+                },
+                notes="Caches AO-intersecting NAIP tiles to the Jetson for disconnected display.",
+            )
+        ],
+        jetson_query_formats=[
+            JetsonQueryFormat(
+                artifact_type="xyz_imagery_tile_cache",
+                local_path_template="offline_packages/{package_id}/tiles/nrl_naip_conus/{z}/{x}/{y}.png",
+                query_interfaces=["tile(z, x, y)", "tiles_intersecting_bbox(west, south, east, north, zoom)"],
+                feeds_algorithms=["visual_aoi_reference", "operator_route_review"],
+                notes="Visual cache for ATAK/planner background layers.",
+            )
+        ],
+        notes="Useful when the AO is in CONUS and high-detail visual context matters.",
     ),
     SourceOption(
         id="cesium_world_terrain",
@@ -352,11 +771,14 @@ SOURCE_CATALOG: list[SourceOption] = [
         useful_for=["3D landform awareness", "ridge/valley interpretation", "visual route review"],
         analysis_role="Display terrain; use DEM sources for deterministic slope and viewshed.",
         stream_status="streamable-with-token",
-        download_status="cache-via-cesium-pipeline",
+        download_status="stream-only-no-offline-copy",
         stream_layer="cesium-world",
         recommended_for=["terrain-routing", "signal-planning", "imagery-preview"],
-        derived_layers=["cached_terrain_tiles"],
-        notes="Good for visualization, not a substitute for indexed DEM rasters.",
+        derived_layers=["preview_only_terrain_stream"],
+        notes=(
+            "Good for online visualization, not a substitute for indexed DEM rasters. "
+            "Do not download Cesium World Terrain into offline packages by default."
+        ),
     ),
     SourceOption(
         id="esri_world_elevation",
@@ -364,8 +786,8 @@ SOURCE_CATALOG: list[SourceOption] = [
         provider="Esri ArcGIS Online / Living Atlas",
         category="terrain",
         purpose=(
-            "Queryable online elevation terrain source for AO sampling and DEM "
-            "fallback when authoritative DEM downloads are unavailable."
+            "Primary queryable terrain source for AO elevation export, terrain sampling, "
+            "slope, hillshade, viewshed, hydrology, and cost-surface preflight."
         ),
         useful_for=[
             "elevation sampling",
@@ -375,23 +797,106 @@ SOURCE_CATALOG: list[SourceOption] = [
             "terrain sanity checks",
         ],
         analysis_role=(
-            "Download or cache clipped AO elevation tiles/samples so the server "
-            "database can answer terrain queries offline when primary DEMs are "
-            "missing or delayed."
+            "Export clipped AO elevation rasters or LERC tiles, convert them to "
+            "Cloud Optimized GeoTIFFs, and build derived rasters so the Jetson can "
+            "answer terrain queries offline."
         ),
         stream_status="queryable-online",
         download_status="download-required",
         required_for=["terrain-routing", "signal-planning"],
         recommended_for=["water-access", "sar-planning", "evacuation"],
         derived_layers=[
+            "dem_cog",
             "elevation_samples",
             "slope_degrees",
+            "aspect",
+            "roughness",
+            "curvature",
+            "flow_accumulation",
             "hillshade",
             "viewshed_surfaces",
+            "walking_cost_surface",
+        ],
+        source_url=ESRI_WORLD_ELEVATION_TERRAIN_URL,
+        license_or_terms=(
+            "Use under ArcGIS Online/Living Atlas service terms with an authorized "
+            "ArcGIS account or token."
+        ),
+        download_methods=[
+            SourceDownloadMethod(
+                id="esri_world_elevation_export_image_tiff",
+                label="ArcGIS ImageServer exportImage",
+                endpoint=f"{ESRI_WORLD_ELEVATION_TERRAIN_URL}/exportImage",
+                method="POST",
+                output_format="GeoTIFF DEM",
+                local_artifact_template=(
+                    "offline_packages/{package_id}/rasters/esri_world_elevation/dem.tif"
+                ),
+                params={
+                    "bbox": "{aoi_bbox_wgs84}",
+                    "bboxSR": 4326,
+                    "imageSR": 4326,
+                    "size": "{terrain_export_size}",
+                    "format": "tiff",
+                    "pixelType": "F32",
+                    "interpolation": "RSP_BilinearInterpolation",
+                    "f": "image",
+                    "token": "${ESRI_ARCGIS_TOKEN}",
+                },
+                requires_token_env="ESRI_ARCGIS_TOKEN",
+                requires_account=True,
+                terms_url=ESRI_TERMS_URL,
+                notes=(
+                    "Use for clipped DEM files that become local COG inputs for "
+                    "slope, flow, cost-distance, and viewshed algorithms."
+                ),
+            ),
+            SourceDownloadMethod(
+                id="esri_world_elevation_get_samples",
+                label="ArcGIS ImageServer getSamples",
+                endpoint=f"{ESRI_WORLD_ELEVATION_TERRAIN_URL}/getSamples",
+                method="POST",
+                output_format="JSON elevation samples",
+                local_artifact_template=(
+                    "offline_packages/{package_id}/samples/esri_world_elevation/grid_samples.json"
+                ),
+                params={
+                    "geometry": "{sample_points_multipoint_json}",
+                    "geometryType": "esriGeometryMultipoint",
+                    "returnFirstValueOnly": "true",
+                    "f": "json",
+                    "token": "${ESRI_ARCGIS_TOKEN}",
+                },
+                requires_token_env="ESRI_ARCGIS_TOKEN",
+                requires_account=True,
+                terms_url=ESRI_TERMS_URL,
+                notes="Use for quick AO preflight and point checks; prefer GeoTIFF export for full routing.",
+            ),
+        ],
+        jetson_query_formats=[
+            JetsonQueryFormat(
+                artifact_type="cloud_optimized_geotiff_dem",
+                local_path_template=(
+                    "offline_packages/{package_id}/rasters/esri_world_elevation/dem_cog.tif"
+                ),
+                query_interfaces=[
+                    "sample_dem(lat, lon)",
+                    "read_window(west, south, east, north)",
+                    "derive_slope_aspect_roughness(bounds)",
+                ],
+                feeds_algorithms=[
+                    "terrain_derivatives",
+                    "flow_accumulation_d8",
+                    "raster_cost_distance",
+                    "viewshed",
+                    "isochrone_masks",
+                ],
+                notes="Main terrain artifact consumed by deterministic Jetson algorithms.",
+            )
         ],
         notes=(
-            "Treat as a queryable fallback or validation layer; prefer USGS 3DEP "
-            "or Copernicus DEM when available for authoritative analysis."
+            "Main terrain source for this planner. Supplement with USGS 3DEP or "
+            "Copernicus DEM when the AO needs an open authoritative DEM mirror."
         ),
     ),
     SourceOption(
@@ -412,21 +917,71 @@ SOURCE_CATALOG: list[SourceOption] = [
     SourceOption(
         id="osm_extract",
         name="OpenStreetMap PBF Extract",
-        provider="OpenStreetMap / Geofabrik / regional extract",
+        provider="Geofabrik / OpenStreetMap contributors",
         category="vector",
-        purpose="Local vector extract for roads, trails, paths, waterways, buildings, POIs, and barriers.",
+        purpose=(
+            "Geofabrik regional OSM PBF downloaded to the Jetson and clipped to "
+            "the selected AOI for roads, trails, waterways, buildings, POIs, and barriers."
+        ),
         useful_for=[
             "routable graph",
             "nearest road or trail",
             "waterway and POI lookup",
             "barrier and bridge/crossing context",
         ],
-        analysis_role="Primary local vector dataset for database-backed graph and feature queries.",
+        analysis_role=(
+            "Primary local vector dataset for database-backed graph, POI, hydro, "
+            "access, and Valhalla tile-build queries."
+        ),
         stream_status="not-streamed",
         download_status="download-required",
         required_for=["terrain-routing", "water-access", "evacuation", "sar-planning"],
         recommended_for=["access-control", "signal-planning"],
         derived_layers=["routable_graph", "poi_index", "waterway_index", "barrier_index"],
+        source_url=GEOFABRIK_BASE_URL,
+        license_or_terms="OpenStreetMap data from Geofabrik is under the Open Database License.",
+        download_methods=[
+            SourceDownloadMethod(
+                id="osm_geofabrik_pbf",
+                label="Geofabrik regional PBF download and AOI clip",
+                endpoint="{geofabrik_osm_pbf_url}",
+                output_format="OSM PBF",
+                local_artifact_template=(
+                    "offline_packages/{package_id}/vectors/osm/aoi.osm.pbf"
+                ),
+                params={
+                    "region_url": "{geofabrik_osm_pbf_url}",
+                    "region_slug": "{geofabrik_region_slug}",
+                    "clip_bbox": "{aoi_bbox_wgs84}",
+                    "clip_with_osmium": True,
+                },
+                terms_url="https://www.geofabrik.de/en/data/download.html",
+                notes=(
+                    "Downloads the AO's Geofabrik state/region extract. If osmium is "
+                    "installed on the Jetson, it clips to AOI; otherwise it registers "
+                    "the regional PBF and marks clipping as pending."
+                ),
+            )
+        ],
+        jetson_query_formats=[
+            JetsonQueryFormat(
+                artifact_type="osm_pbf_extract",
+                local_path_template="offline_packages/{package_id}/vectors/osm/aoi.osm.pbf",
+                query_interfaces=[
+                    "osmium tags-filter",
+                    "pyosmium scan",
+                    "valhalla_build_tiles",
+                    "find_pois(osm_tags, bbox)",
+                ],
+                feeds_algorithms=[
+                    "routable_graph",
+                    "nearest_feature",
+                    "water_source_lookup",
+                    "evacuation_route",
+                ],
+                notes="Main vector artifact for deterministic route and POI algorithms.",
+            )
+        ],
         notes="Clip tightly to AO and preserve source/version metadata.",
     ),
     SourceOption(
@@ -453,18 +1008,128 @@ SOURCE_CATALOG: list[SourceOption] = [
     ),
     SourceOption(
         id="copernicus_dem",
-        name="Copernicus DEM",
+        name="Copernicus DEM GLO-30 COG",
         provider="Copernicus",
         category="terrain",
-        purpose="Strong global DEM when U.S. 3DEP is unavailable.",
-        useful_for=["global slope", "viewshed", "terrain cost", "AO outside U.S."],
-        analysis_role="Primary or fallback analysis DEM for non-U.S. mission areas.",
+        purpose=(
+            "Free no-account 30 m terrain COG tiles from the public Copernicus DEM "
+            "S3 mirror for slope, viewshed, hydrology, and terrain-cost analysis."
+        ),
+        useful_for=["global slope", "viewshed", "terrain cost", "AO outside U.S.", "no-login terrain"],
+        analysis_role=(
+            "Main no-login terrain download path. Select 1-degree GLO-30 COG tiles "
+            "intersecting the AOI and store them under the Jetson package root."
+        ),
         stream_status="not-streamed",
         download_status="download-required",
         required_for=["terrain-routing", "signal-planning"],
         recommended_for=["water-access", "sar-planning"],
-        derived_layers=["slope_degrees", "roughness", "flow_accumulation", "viewshed_surfaces"],
-        notes="Confirm coverage, license, and void handling for the AO before packaging.",
+        derived_layers=[
+            "dem_cog",
+            "slope_degrees",
+            "aspect",
+            "roughness",
+            "flow_accumulation",
+            "viewshed_surfaces",
+            "walking_cost_surface",
+        ],
+        source_url=COPERNICUS_DEM_30M_BASE_URL,
+        license_or_terms="Copernicus DEM GLO-30 Public is free for public use under Copernicus DEM terms.",
+        download_methods=[
+            SourceDownloadMethod(
+                id="copernicus_dem_glo30_cog",
+                label="Copernicus GLO-30 public S3 COG tiles",
+                endpoint=COPERNICUS_DEM_30M_BASE_URL,
+                output_format="Cloud Optimized GeoTIFF DEM tiles",
+                local_artifact_template=(
+                    "offline_packages/{package_id}/rasters/copernicus_dem/{tile_id}.tif"
+                ),
+                params={
+                    "tile_urls": "{copernicus_dem_tile_urls}",
+                    "bbox": "{aoi_bbox_wgs84}",
+                    "resolution_arc_seconds": 10,
+                },
+                terms_url="https://copernicus-dem-30m.s3.amazonaws.com/readme.html",
+                notes=(
+                    "Downloads only AO-intersecting 1-degree COG tiles. Missing ocean "
+                    "or unreleased tiles are recorded in the DEM index."
+                ),
+            )
+        ],
+        jetson_query_formats=[
+            JetsonQueryFormat(
+                artifact_type="copernicus_dem_cog_index",
+                local_path_template="offline_packages/{package_id}/rasters/copernicus_dem/copernicus_dem_index.json",
+                query_interfaces=[
+                    "sample_dem(lat, lon)",
+                    "read_window(west, south, east, north)",
+                    "derive_slope_aspect_roughness(bounds)",
+                ],
+                feeds_algorithms=[
+                    "terrain_derivatives",
+                    "flow_accumulation_d8",
+                    "raster_cost_distance",
+                    "viewshed",
+                ],
+                notes="COG tiles are local raster inputs for deterministic terrain algorithms.",
+            )
+        ],
+        notes="Use as the default no-login terrain source; add DTED when an EarthExplorer DTED package is staged.",
+    ),
+    SourceOption(
+        id="dted_earth_explorer",
+        name="DTED from USGS EarthExplorer",
+        provider="USGS EarthExplorer",
+        category="terrain",
+        purpose=(
+            "Operator-staged DTED-2/DTED cells from EarthExplorer imported to the "
+            "Jetson package and converted to GeoTIFF when GDAL is installed."
+        ),
+        useful_for=["DTED-2 30 m terrain", "military terrain interchange", "offline DEM fallback"],
+        analysis_role=(
+            "EarthExplorer requires account login, so the web app imports a local "
+            "staging directory of downloaded .dt0/.dt1/.dt2 files. It then converts "
+            "each file with gdal_translate when available and registers both raw "
+            "DTED and GeoTIFF artifacts."
+        ),
+        stream_status="not-streamed",
+        download_status="manual-stage-import",
+        recommended_for=["terrain-routing", "signal-planning"],
+        derived_layers=["dted_cells", "geotiff_dem", "slope_degrees", "viewshed_surfaces"],
+        source_url=USGS_EARTHEXPLORER_URL,
+        license_or_terms="Use under USGS EarthExplorer dataset terms for the downloaded DTED product.",
+        download_methods=[
+            SourceDownloadMethod(
+                id="dted_earthexplorer_import_convert",
+                label="Import staged EarthExplorer DTED and convert with GDAL",
+                endpoint="${DTED_SOURCE_DIR}",
+                output_format="DTED cells and GeoTIFF DEMs",
+                local_artifact_template=(
+                    "offline_packages/{package_id}/rasters/dted/dted_index.json"
+                ),
+                params={
+                    "source_dir": "${DTED_SOURCE_DIR}",
+                    "bbox": "{aoi_bbox_wgs84}",
+                    "convert_to_geotiff": True,
+                },
+                requires_account=True,
+                terms_url="https://www.usgs.gov/tools/earthexplorer",
+                notes=(
+                    "Set DTED_SOURCE_DIR to the folder containing EarthExplorer .dt2 "
+                    "downloads. gdal_translate input.dt2 output.tif is used when present."
+                ),
+            )
+        ],
+        jetson_query_formats=[
+            JetsonQueryFormat(
+                artifact_type="dted_geotiff_index",
+                local_path_template="offline_packages/{package_id}/rasters/dted/dted_index.json",
+                query_interfaces=["sample_dem(lat, lon)", "read_window(west, south, east, north)", "gdalinfo"],
+                feeds_algorithms=["terrain_derivatives", "raster_cost_distance", "viewshed"],
+                notes="Converted GeoTIFFs are preferred; raw DTED remains available for GDAL readers.",
+            )
+        ],
+        notes="Use when the operator has already pulled DTED from EarthExplorer; otherwise prefer Copernicus GLO-30.",
     ),
     SourceOption(
         id="srtm",
@@ -583,16 +1248,70 @@ SOURCE_CATALOG: list[SourceOption] = [
     SourceOption(
         id="sentinel_2",
         name="Sentinel-2 Multispectral",
-        provider="ESA Copernicus",
+        provider="ESA Copernicus / Element 84 Earth Search",
         category="imagery-analysis",
-        purpose="Multispectral imagery for vegetation, water, burn, and surface-condition indices.",
+        purpose=(
+            "Free global multispectral COG imagery for offline AO context, vegetation, "
+            "water, burn, and surface-condition indices."
+        ),
         useful_for=["NDVI", "NDWI", "water detection", "vegetation condition", "recent surface context"],
-        analysis_role="Analysis imagery source for derived indices, not just visual backdrop.",
+        analysis_role=(
+            "Primary free downloadable imagery source for this planner. Download selected "
+            "COG assets from the public Earth Search STAC API to the Jetson package root."
+        ),
         stream_status="not-streamed",
         download_status="download-required",
-        recommended_for=["water-access", "sar-planning", "imagery-preview"],
-        derived_layers=["ndvi", "ndwi", "vegetation_condition", "water_detection"],
-        notes="Cloud cover and date filtering matter; preserve acquisition timestamp.",
+        required_for=["imagery-preview"],
+        recommended_for=["terrain-routing", "water-access", "sar-planning", "evacuation"],
+        derived_layers=["sentinel2_visual_cog", "ndvi", "ndwi", "vegetation_condition", "water_detection"],
+        source_url=EARTH_SEARCH_STAC_SEARCH_URL,
+        license_or_terms="Sentinel data access is free, full, and open under Copernicus terms.",
+        download_methods=[
+            SourceDownloadMethod(
+                id="sentinel_2_stac_cog",
+                label="Earth Search Sentinel-2 COG STAC download",
+                endpoint=EARTH_SEARCH_STAC_SEARCH_URL,
+                method="POST",
+                output_format="COG GeoTIFF bands",
+                local_artifact_template=(
+                    "offline_packages/{package_id}/imagery/sentinel_2/{item_id}_{asset}.tif"
+                ),
+                params={
+                    "collections": ["sentinel-2-l2a"],
+                    "bbox": "{aoi_bbox_array}",
+                    "datetime": "{recent_24_month_interval}",
+                    "limit": 1,
+                    "query": {"eo:cloud_cover": {"lt": 30}},
+                    "sortby": [{"field": "properties.datetime", "direction": "desc"}],
+                    "assets": ["visual", "red", "green", "blue", "nir", "scl"],
+                },
+                terms_url="https://registry.opendata.aws/sentinel-2-l2a-cogs/",
+                notes=(
+                    "No Esri token or AWS account is required for Earth Search HTTP COG hrefs. "
+                    "The Jetson downloads only selected scene assets intersecting the AO."
+                ),
+            )
+        ],
+        jetson_query_formats=[
+            JetsonQueryFormat(
+                artifact_type="sentinel2_cog_band_stack",
+                local_path_template="offline_packages/{package_id}/imagery/sentinel_2/*.tif",
+                query_interfaces=[
+                    "read_band_window(asset, west, south, east, north)",
+                    "compute_ndvi(red, nir)",
+                    "compute_ndwi(green, nir)",
+                    "visual_chip(west, south, east, north)",
+                ],
+                feeds_algorithms=[
+                    "vegetation_condition",
+                    "water_detection",
+                    "operator_route_review",
+                    "sar_probability_context",
+                ],
+                notes="Free imagery COGs are queryable by raster windows on the Jetson.",
+            )
+        ],
+        notes="Cloud cover and date filtering matter; preserve acquisition timestamp and STAC metadata.",
     ),
     SourceOption(
         id="landsat_collection_2",
@@ -611,15 +1330,86 @@ SOURCE_CATALOG: list[SourceOption] = [
     SourceOption(
         id="naip",
         name="NAIP Aerial Imagery",
-        provider="USDA",
+        provider="USDA / USGS EarthExplorer / AWS Open Data",
         category="imagery-analysis",
-        purpose="High-resolution U.S. aerial imagery for detailed visual feature extraction.",
-        useful_for=["small roads/tracks", "buildings", "clearings", "agricultural features"],
-        analysis_role="Analysis imagery and offline basemap source for U.S. AO detail.",
+        purpose=(
+            "High-resolution U.S. aerial imagery downloaded to the Jetson from "
+            "EarthExplorer GeoTIFF staging or NAIP public S3 prefixes."
+        ),
+        useful_for=["small roads/tracks", "buildings", "clearings", "agricultural features", "offline AO imagery"],
+        analysis_role=(
+            "Primary high-detail U.S. imagery source for this workflow. Use "
+            "EarthExplorer GeoTIFFs when staged, or pull public NAIP AWS state/year/"
+            "resolution prefixes with requester-pays headers for local query and serving."
+        ),
         stream_status="not-streamed",
         download_status="download-required",
-        recommended_for=["imagery-preview", "sar-planning", "evacuation"],
-        derived_layers=["high_detail_aerial_reference", "feature_extraction_review"],
+        required_for=["imagery-preview"],
+        recommended_for=["sar-planning", "evacuation", "terrain-routing"],
+        derived_layers=["naip_local_imagery", "high_detail_aerial_reference", "feature_extraction_review"],
+        source_url="https://registry.opendata.aws/naip/",
+        license_or_terms="NAIP on AWS is public domain with attribution; EarthExplorer downloads follow USGS terms.",
+        download_methods=[
+            SourceDownloadMethod(
+                id="naip_aws_public_prefix",
+                label="NAIP AWS public S3 prefix download",
+                endpoint=NAIP_AWS_BUCKET_URL_TEMPLATE,
+                output_format="NAIP MRF/GeoTIFF/COG files",
+                local_artifact_template=(
+                    "offline_packages/{package_id}/imagery/naip/aws/naip_index.json"
+                ),
+                params={
+                    "bucket": "{naip_aws_bucket}",
+                    "prefix": "{naip_s3_prefix}",
+                    "state": "{naip_state}",
+                    "year": "{naip_year}",
+                    "resolution": "{naip_resolution}",
+                    "bandset": "{naip_bandset}",
+                    "max_files": "{naip_max_files}",
+                    "request_payer": "requester",
+                },
+                terms_url="https://registry.opendata.aws/naip/",
+                notes=(
+                    "Mirrors the operator workflow `aws s3 cp s3://naip-analytic/"
+                    "<state>/<year>/<resolution>/rgbir/ ... --recursive`. Limit "
+                    "max files and confirm storage before pulling large state prefixes."
+                ),
+            ),
+            SourceDownloadMethod(
+                id="naip_earthexplorer_geotiff_import",
+                label="Import staged EarthExplorer NAIP GeoTIFFs",
+                endpoint="${NAIP_EARTHEXPLORER_DIR}",
+                output_format="NAIP GeoTIFF imagery",
+                local_artifact_template=(
+                    "offline_packages/{package_id}/imagery/naip/earthexplorer/naip_earthexplorer_index.json"
+                ),
+                params={
+                    "source_dir": "${NAIP_EARTHEXPLORER_DIR}",
+                    "bbox": "{aoi_bbox_wgs84}",
+                    "max_files": "{naip_max_files}",
+                },
+                requires_account=True,
+                terms_url="https://www.usgs.gov/tools/earthexplorer",
+                notes=(
+                    "Set NAIP_EARTHEXPLORER_DIR to the folder containing downloaded "
+                    "NAIP GeoTIFFs from EarthExplorer."
+                ),
+            ),
+        ],
+        jetson_query_formats=[
+            JetsonQueryFormat(
+                artifact_type="naip_imagery_index",
+                local_path_template="offline_packages/{package_id}/imagery/naip/**/naip*_index.json",
+                query_interfaces=[
+                    "imagery_file(relative_path)",
+                    "rasterio.open()",
+                    "read_window(west, south, east, north)",
+                    "visual_chip(west, south, east, north)",
+                ],
+                feeds_algorithms=["operator_route_review", "feature_extraction_review", "sar_probability_context"],
+                notes="Local NAIP files are served to the planner/TERA plugin and can be read by GDAL/rasterio.",
+            )
+        ],
         notes="Check acquisition date; may be stale for fast-changing environments.",
     ),
     SourceOption(
@@ -766,8 +1556,14 @@ SOURCE_CATALOG: list[SourceOption] = [
 ]
 
 SOURCE_BY_ID: dict[str, SourceOption] = {source.id: source for source in SOURCE_CATALOG}
-PRIMARY_STREAM_SOURCE_IDS = ["esri_world_imagery", "cesium_world_terrain", "osm_basemap"]
+PRIMARY_STREAM_SOURCE_IDS = [
+    "cesium_world_imagery",
+    "usgs_imagery_only",
+    "cesium_world_terrain",
+    "osm_basemap",
+]
 PACKAGE_MANIFESTS: dict[str, dict[str, object]] = {}
+PACKAGE_TASKS: dict[str, asyncio.Task[None]] = {}
 
 FOCUS_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("water-access", ("water", "stream", "river", "spring", "lake", "potable", "hydrate")),
@@ -993,6 +1789,2824 @@ def _format_manifest_bounds(map_context: MapContext | None) -> dict[str, float |
     }
 
 
+def _manifest_bounds_from_context(map_context: MapContext | None) -> ViewBounds | None:
+    if map_context is None:
+        return None
+    return map_context.selected_area or map_context.view_bounds
+
+
+def _format_wgs84_extent_json(bounds: ViewBounds | None) -> dict[str, object] | str:
+    if bounds is None:
+        return "{aoi_wgs84_json}"
+    return {
+        "xmin": bounds.west,
+        "ymin": bounds.south,
+        "xmax": bounds.east,
+        "ymax": bounds.north,
+        "spatialReference": {"wkid": 4326},
+    }
+
+
+def _format_bbox_csv(bounds: ViewBounds | None) -> str:
+    if bounds is None:
+        return "{aoi_bbox_wgs84}"
+    return f"{bounds.west},{bounds.south},{bounds.east},{bounds.north}"
+
+
+def _format_bbox_array(bounds: ViewBounds | None) -> list[float] | str:
+    if bounds is None:
+        return "{aoi_bbox_array}"
+    return [bounds.west, bounds.south, bounds.east, bounds.north]
+
+
+def _format_bbox_radians(bounds: ViewBounds | None) -> list[float] | str:
+    if bounds is None:
+        return "{aoi_bbox_radians}"
+    return [
+        math.radians(bounds.west),
+        math.radians(bounds.south),
+        math.radians(bounds.east),
+        math.radians(bounds.north),
+    ]
+
+
+US_STATE_BBOXES: dict[str, tuple[str, str, tuple[float, float, float, float]]] = {
+    "al": ("alabama", "al", (-88.6, 30.1, -84.9, 35.1)),
+    "az": ("arizona", "az", (-114.9, 31.2, -109.0, 37.1)),
+    "ar": ("arkansas", "ar", (-94.7, 33.0, -89.6, 36.6)),
+    "ca": ("california", "ca", (-124.5, 32.4, -114.1, 42.1)),
+    "co": ("colorado", "co", (-109.1, 36.9, -102.0, 41.1)),
+    "ct": ("connecticut", "ct", (-73.8, 40.9, -71.7, 42.1)),
+    "de": ("delaware", "de", (-75.9, 38.4, -75.0, 39.9)),
+    "fl": ("florida", "fl", (-87.7, 24.4, -80.0, 31.1)),
+    "ga": ("georgia", "ga", (-85.7, 30.3, -80.8, 35.1)),
+    "id": ("idaho", "id", (-117.3, 42.0, -111.0, 49.1)),
+    "il": ("illinois", "il", (-91.6, 36.9, -87.5, 42.6)),
+    "in": ("indiana", "in", (-88.2, 37.7, -84.7, 41.8)),
+    "ia": ("iowa", "ia", (-96.7, 40.3, -90.1, 43.6)),
+    "ks": ("kansas", "ks", (-102.1, 36.9, -94.5, 40.1)),
+    "ky": ("kentucky", "ky", (-89.6, 36.4, -81.9, 39.2)),
+    "la": ("louisiana", "la", (-94.1, 28.8, -88.7, 33.1)),
+    "me": ("maine", "me", (-71.2, 43.0, -66.8, 47.5)),
+    "md": ("maryland", "md", (-79.6, 37.8, -75.0, 39.8)),
+    "ma": ("massachusetts", "ma", (-73.6, 41.1, -69.8, 42.9)),
+    "mi": ("michigan", "mi", (-90.5, 41.6, -82.1, 48.4)),
+    "mn": ("minnesota", "mn", (-97.3, 43.4, -89.4, 49.4)),
+    "ms": ("mississippi", "ms", (-91.8, 30.1, -88.0, 35.1)),
+    "mo": ("missouri", "mo", (-95.8, 35.9, -89.0, 40.7)),
+    "mt": ("montana", "mt", (-116.1, 44.3, -104.0, 49.1)),
+    "ne": ("nebraska", "ne", (-104.1, 39.9, -95.3, 43.1)),
+    "nv": ("nevada", "nv", (-120.1, 35.0, -114.0, 42.1)),
+    "nh": ("new-hampshire", "nh", (-72.6, 42.6, -70.6, 45.4)),
+    "nj": ("new-jersey", "nj", (-75.6, 38.8, -73.8, 41.4)),
+    "nm": ("new-mexico", "nm", (-109.1, 31.2, -103.0, 37.1)),
+    "ny": ("new-york", "ny", (-79.8, 40.4, -71.8, 45.1)),
+    "nc": ("north-carolina", "nc", (-84.4, 33.7, -75.4, 36.7)),
+    "nd": ("north-dakota", "nd", (-104.1, 45.9, -96.5, 49.1)),
+    "oh": ("ohio", "oh", (-84.9, 38.3, -80.5, 42.1)),
+    "ok": ("oklahoma", "ok", (-103.1, 33.5, -94.4, 37.1)),
+    "or": ("oregon", "or", (-124.7, 41.9, -116.4, 46.4)),
+    "pa": ("pennsylvania", "pa", (-80.6, 39.7, -74.6, 42.6)),
+    "ri": ("rhode-island", "ri", (-71.9, 41.1, -71.1, 42.1)),
+    "sc": ("south-carolina", "sc", (-83.4, 32.0, -78.5, 35.3)),
+    "sd": ("south-dakota", "sd", (-104.1, 42.4, -96.4, 45.9)),
+    "tn": ("tennessee", "tn", (-90.4, 34.9, -81.6, 36.8)),
+    "tx": ("texas", "tx", (-106.7, 25.8, -93.5, 36.6)),
+    "ut": ("utah", "ut", (-114.1, 36.9, -109.0, 42.1)),
+    "vt": ("vermont", "vt", (-73.5, 42.7, -71.4, 45.1)),
+    "va": ("virginia", "va", (-83.8, 36.5, -75.2, 39.5)),
+    "wa": ("washington", "wa", (-124.9, 45.5, -116.9, 49.1)),
+    "wv": ("west-virginia", "wv", (-82.7, 37.1, -77.7, 40.7)),
+    "wi": ("wisconsin", "wi", (-92.9, 42.4, -86.7, 47.1)),
+    "wy": ("wyoming", "wy", (-111.1, 40.9, -104.0, 45.1)),
+}
+
+
+def _infer_us_state(bounds: ViewBounds | None) -> tuple[str, str] | None:
+    if bounds is None:
+        return None
+    lat = bounds.center_lat if bounds.center_lat is not None else (bounds.south + bounds.north) / 2
+    lon = bounds.center_lon if bounds.center_lon is not None else (bounds.west + bounds.east) / 2
+    candidates: list[tuple[float, str, str]] = []
+    for slug, code, (west, south, east, north) in US_STATE_BBOXES.values():
+        if west <= lon <= east and south <= lat <= north:
+            candidates.append(((east - west) * (north - south), slug, code))
+    if not candidates:
+        return None
+    _area, slug, code = sorted(candidates)[0]
+    return slug, code
+
+
+def _naip_state_code(bounds: ViewBounds | None) -> str:
+    configured = os.getenv("NAIP_AWS_STATE", "").strip().lower()
+    if configured:
+        return configured
+    inferred = _infer_us_state(bounds)
+    return inferred[1] if inferred else "nv"
+
+
+def _naip_year() -> str:
+    return os.getenv("NAIP_AWS_YEAR", "2022").strip() or "2022"
+
+
+def _naip_resolution() -> str:
+    return os.getenv("NAIP_AWS_RESOLUTION", "60cm").strip() or "60cm"
+
+
+def _naip_bandset() -> str:
+    return os.getenv("NAIP_AWS_BANDSET", "rgbir").strip() or "rgbir"
+
+
+def _naip_bucket() -> str:
+    return os.getenv("NAIP_AWS_BUCKET", NAIP_AWS_DEFAULT_BUCKET).strip() or NAIP_AWS_DEFAULT_BUCKET
+
+
+def _naip_s3_prefix(bounds: ViewBounds | None) -> str:
+    configured = os.getenv("NAIP_AWS_PREFIX", "").strip().strip("/")
+    if configured:
+        return f"{configured}/"
+    return f"{_naip_state_code(bounds)}/{_naip_year()}/{_naip_resolution()}/{_naip_bandset()}/"
+
+
+def _geofabrik_region_slug(bounds: ViewBounds | None) -> str:
+    configured = os.getenv("GEOFABRIK_REGION_SLUG", "").strip().strip("/")
+    if configured:
+        return configured
+    inferred = _infer_us_state(bounds)
+    return f"north-america/us/{inferred[0]}" if inferred else "north-america/us/nevada"
+
+
+def _geofabrik_osm_pbf_url(bounds: ViewBounds | None) -> str:
+    configured = os.getenv("GEOFABRIK_PBF_URL", "").strip()
+    if configured:
+        return configured
+    return f"{GEOFABRIK_BASE_URL}/{_geofabrik_region_slug(bounds)}-latest.osm.pbf"
+
+
+def _format_lat_token(lat_floor: int) -> str:
+    return ("N" if lat_floor >= 0 else "S") + f"{abs(lat_floor):02d}_00"
+
+
+def _format_lon_token(lon_floor: int) -> str:
+    return ("E" if lon_floor >= 0 else "W") + f"{abs(lon_floor):03d}_00"
+
+
+def _copernicus_dem_tiles(bounds: ViewBounds | None) -> list[dict[str, object]]:
+    if bounds is None:
+        return []
+    lat_start = math.floor(bounds.south)
+    lat_end = math.ceil(bounds.north) - 1
+    lon_start = math.floor(bounds.west)
+    lon_end = math.ceil(bounds.east) - 1
+    tiles: list[dict[str, object]] = []
+    for lat_floor in range(lat_start, lat_end + 1):
+        for lon_floor in range(lon_start, lon_end + 1):
+            lat_token = _format_lat_token(lat_floor)
+            lon_token = _format_lon_token(lon_floor)
+            tile_id = f"Copernicus_DSM_COG_10_{lat_token}_{lon_token}_DEM"
+            tiles.append(
+                {
+                    "tile_id": tile_id,
+                    "lat_floor": lat_floor,
+                    "lon_floor": lon_floor,
+                    "url": f"{COPERNICUS_DEM_30M_BASE_URL}/{tile_id}/{tile_id}.tif",
+                }
+            )
+    return tiles
+
+
+def _env_path(name: str) -> str:
+    return os.getenv(name, "").strip()
+
+
+def _recent_interval(days: int = 730) -> str:
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(days=days)
+    return f"{start.date().isoformat()}/{end.date().isoformat()}"
+
+
+def _bbox_area_km2(bounds: ViewBounds | None) -> float:
+    if bounds is None:
+        return 0.0
+    mid_lat = ((bounds.south + bounds.north) / 2.0) * math.pi / 180.0
+    width_km = abs(bounds.east - bounds.west) * 111.32 * max(0.1, math.cos(mid_lat))
+    height_km = abs(bounds.north - bounds.south) * 111.32
+    return width_km * height_km
+
+
+def _lon_to_tile_x(lon: float, zoom: int) -> int:
+    return int((lon + 180.0) / 360.0 * (2**zoom))
+
+
+def _lat_to_tile_y(lat: float, zoom: int) -> int:
+    lat = max(min(lat, 85.05112878), -85.05112878)
+    lat_rad = math.radians(lat)
+    return int(
+        (1.0 - math.log(math.tan(lat_rad) + (1.0 / math.cos(lat_rad))) / math.pi)
+        / 2.0
+        * (2**zoom)
+    )
+
+
+def _estimate_slippy_tile_count(bounds: ViewBounds | None, levels: Iterable[int]) -> int:
+    if bounds is None:
+        return 0
+    total = 0
+    for zoom in levels:
+        x_min = _lon_to_tile_x(bounds.west, zoom)
+        x_max = _lon_to_tile_x(bounds.east, zoom)
+        y_min = _lat_to_tile_y(bounds.north, zoom)
+        y_max = _lat_to_tile_y(bounds.south, zoom)
+        total += (abs(x_max - x_min) + 1) * (abs(y_max - y_min) + 1)
+    return total
+
+
+def _choose_imagery_levels(bounds: ViewBounds | None) -> list[int]:
+    area_km2 = _bbox_area_km2(bounds)
+    if area_km2 <= 0:
+        return [10, 11, 12, 13, 14]
+    if area_km2 <= 25:
+        return [12, 13, 14, 15, 16]
+    if area_km2 <= 150:
+        return [11, 12, 13, 14, 15]
+    if area_km2 <= 800:
+        return [10, 11, 12, 13, 14]
+    return [8, 9, 10, 11, 12]
+
+
+def _levels_to_range(levels: list[int]) -> str:
+    if not levels:
+        return ""
+    return f"{min(levels)}-{max(levels)}"
+
+
+def _parse_level_range(value: object) -> list[int]:
+    if isinstance(value, list):
+        levels = []
+        for item in value:
+            try:
+                levels.append(int(item))
+            except (TypeError, ValueError):
+                continue
+        return levels
+    text = str(value or "").strip()
+    if not text:
+        return []
+    if "-" in text:
+        left, _separator, right = text.partition("-")
+        try:
+            start = int(left)
+            end = int(right)
+        except ValueError:
+            return []
+        return list(range(min(start, end), max(start, end) + 1))
+    try:
+        return [int(text)]
+    except ValueError:
+        return []
+
+
+def _tile_ranges(bounds: ViewBounds, levels: Iterable[int]) -> list[tuple[int, range, range]]:
+    ranges: list[tuple[int, range, range]] = []
+    for zoom in levels:
+        x_min = min(_lon_to_tile_x(bounds.west, zoom), _lon_to_tile_x(bounds.east, zoom))
+        x_max = max(_lon_to_tile_x(bounds.west, zoom), _lon_to_tile_x(bounds.east, zoom))
+        y_min = min(_lat_to_tile_y(bounds.north, zoom), _lat_to_tile_y(bounds.south, zoom))
+        y_max = max(_lat_to_tile_y(bounds.north, zoom), _lat_to_tile_y(bounds.south, zoom))
+        ranges.append((zoom, range(x_min, x_max + 1), range(y_min, y_max + 1)))
+    return ranges
+
+
+def _choose_terrain_export_size(bounds: ViewBounds | None) -> str:
+    area_km2 = _bbox_area_km2(bounds)
+    if area_km2 <= 25:
+        return "1024,1024"
+    if area_km2 <= 150:
+        return "1536,1536"
+    if area_km2 <= 800:
+        return "2048,2048"
+    return "4096,4096"
+
+
+def _sample_points_placeholder(bounds: ViewBounds | None) -> dict[str, object] | str:
+    if bounds is None:
+        return "{sample_points_multipoint_json}"
+    center_lat = bounds.center_lat if bounds.center_lat is not None else (bounds.south + bounds.north) / 2
+    center_lon = bounds.center_lon if bounds.center_lon is not None else (bounds.west + bounds.east) / 2
+    return {
+        "points": [
+            [bounds.west, bounds.south],
+            [bounds.east, bounds.south],
+            [bounds.east, bounds.north],
+            [bounds.west, bounds.north],
+            [center_lon, center_lat],
+        ],
+        "spatialReference": {"wkid": 4326},
+    }
+
+
+def _substitute_download_params(
+    params: dict[str, object],
+    *,
+    bounds: ViewBounds | None,
+    imagery_levels: list[int],
+) -> dict[str, object]:
+    substituted: dict[str, object] = {}
+    for key, value in params.items():
+        if value == "{imagery_level_range}":
+            substituted[key] = _levels_to_range(imagery_levels)
+        elif value == "{aoi_wgs84_json}":
+            substituted[key] = _format_wgs84_extent_json(bounds)
+        elif value == "{aoi_bbox_wgs84}":
+            substituted[key] = _format_bbox_csv(bounds)
+        elif value == "{aoi_bbox_array}":
+            substituted[key] = _format_bbox_array(bounds)
+        elif value == "{aoi_bbox_radians}":
+            substituted[key] = _format_bbox_radians(bounds)
+        elif value == "{geofabrik_osm_pbf_url}":
+            substituted[key] = _geofabrik_osm_pbf_url(bounds)
+        elif value == "{geofabrik_region_slug}":
+            substituted[key] = _geofabrik_region_slug(bounds)
+        elif value == "{naip_aws_bucket}":
+            substituted[key] = _naip_bucket()
+        elif value == "{naip_s3_prefix}":
+            substituted[key] = _naip_s3_prefix(bounds)
+        elif value == "{naip_state}":
+            substituted[key] = _naip_state_code(bounds)
+        elif value == "{naip_year}":
+            substituted[key] = _naip_year()
+        elif value == "{naip_resolution}":
+            substituted[key] = _naip_resolution()
+        elif value == "{naip_bandset}":
+            substituted[key] = _naip_bandset()
+        elif value == "{naip_max_files}":
+            substituted[key] = int(os.getenv("NAIP_MAX_FILES", "50"))
+        elif value == "{copernicus_dem_tile_urls}":
+            substituted[key] = _copernicus_dem_tiles(bounds)
+        elif value == "{terrain_export_size}":
+            substituted[key] = _choose_terrain_export_size(bounds)
+        elif value == "{sample_points_multipoint_json}":
+            substituted[key] = _sample_points_placeholder(bounds)
+        elif value == "{recent_24_month_interval}":
+            substituted[key] = _recent_interval()
+        else:
+            substituted[key] = value
+    return substituted
+
+
+def _substitute_download_endpoint(endpoint: str, bounds: ViewBounds | None) -> str:
+    return (
+        endpoint.replace("{geofabrik_osm_pbf_url}", _geofabrik_osm_pbf_url(bounds))
+        .replace("{bucket}", _naip_bucket())
+        .replace("${NAIP_EARTHEXPLORER_DIR}", "${NAIP_EARTHEXPLORER_DIR}")
+        .replace("${DTED_SOURCE_DIR}", "${DTED_SOURCE_DIR}")
+    )
+
+
+def _build_source_download_operations(
+    *,
+    package_id: str,
+    sources: list[SourceOption],
+    bounds: ViewBounds | None,
+) -> list[dict[str, object]]:
+    imagery_levels = _choose_imagery_levels(bounds)
+    estimated_imagery_tiles = _estimate_slippy_tile_count(bounds, imagery_levels)
+    operations: list[dict[str, object]] = []
+
+    for source in sources:
+        for method in source.download_methods:
+            if source.id == "cesium_ion_archive":
+                archive_id_configured = bool(_get_cesium_archive_id())
+                asset_ids_configured = bool(
+                    (
+                        os.getenv("CESIUM_ION_ASSET_IDS")
+                        or os.getenv("CESIUM_ASSET_IDS")
+                        or os.getenv("CESIUM_ION_ASSET_ID")
+                        or ""
+                    ).strip()
+                )
+                if method.id == "cesium_ion_archive_download" and not archive_id_configured:
+                    continue
+                if method.id == "cesium_ion_clip_create_download" and (
+                    archive_id_configured or not asset_ids_configured
+                ):
+                    continue
+            if method.id == "naip_earthexplorer_geotiff_import" and not _env_path("NAIP_EARTHEXPLORER_DIR"):
+                continue
+            if method.id == "dted_earthexplorer_import_convert" and not _env_path("DTED_SOURCE_DIR"):
+                continue
+            local_artifact = method.local_artifact_template.replace("{package_id}", package_id)
+            operation: dict[str, object] = {
+                "id": method.id,
+                "source_id": source.id,
+                "source_name": source.name,
+                "label": method.label,
+                "method": method.method,
+                "endpoint": _substitute_download_endpoint(method.endpoint, bounds),
+                "params": _substitute_download_params(
+                    method.params,
+                    bounds=bounds,
+                    imagery_levels=imagery_levels,
+                ),
+                "output_format": method.output_format,
+                "local_artifact": local_artifact,
+                "requires_token_env": method.requires_token_env,
+                "requires_account": method.requires_account,
+                "terms_url": method.terms_url,
+                "notes": method.notes,
+            }
+            if source.id == "esri_world_imagery":
+                operation["estimated_tile_count"] = estimated_imagery_tiles
+                operation["tile_limit_warning"] = (
+                    "Estimated AO exceeds Esri's common 100,000 tile export limit; "
+                    "reduce AO or zoom levels."
+                    if estimated_imagery_tiles > 100000
+                    else ""
+                )
+            if source.id == "sentinel_2":
+                operation["free_imagery_source"] = True
+                operation["requires_account"] = False
+            if method.id in {"usgs_imagery_tile_cache", "nrl_naip_tile_cache"}:
+                levels = _parse_level_range(operation["params"].get("levels") if isinstance(operation.get("params"), dict) else "")
+                if isinstance(operation.get("params"), dict):
+                    max_zoom = int(operation["params"].get("max_zoom") or max(levels or [0]))
+                    levels = [level for level in levels if level <= max_zoom]
+                operation["estimated_tile_count"] = _estimate_slippy_tile_count(bounds, levels)
+                operation["free_imagery_source"] = True
+                operation["tile_limit_warning"] = (
+                    "Estimated tile cache is large; reduce AO or zoom levels before Jetson download."
+                    if int(operation["estimated_tile_count"]) > int(os.getenv("MAX_TILE_DOWNLOAD_COUNT", "5000"))
+                    else ""
+                )
+            operations.append(operation)
+
+    return operations
+
+
+def _build_jetson_query_contracts(
+    *,
+    package_id: str,
+    sources: list[SourceOption],
+) -> list[dict[str, object]]:
+    contracts: list[dict[str, object]] = []
+    for source in sources:
+        for query_format in source.jetson_query_formats:
+            contracts.append(
+                {
+                    "source_id": source.id,
+                    "source_name": source.name,
+                    "artifact_type": query_format.artifact_type,
+                    "local_path": query_format.local_path_template.replace(
+                        "{package_id}",
+                        package_id,
+                    ),
+                    "query_interfaces": query_format.query_interfaces,
+                    "feeds_algorithms": query_format.feeds_algorithms,
+                    "notes": query_format.notes,
+                }
+            )
+    return contracts
+
+
+def _offline_package_root() -> Path:
+    configured = os.getenv("OFFLINE_PACKAGE_ROOT", "").strip()
+    return Path(configured).expanduser().resolve() if configured else DEFAULT_OFFLINE_PACKAGE_ROOT.resolve()
+
+
+def _package_reserve_bytes() -> int:
+    gb = float(os.getenv("PACKAGE_MIN_FREE_GB", "10"))
+    return max(0, int(gb * 1024 * 1024 * 1024))
+
+
+def _safe_package_id(package_id: str) -> str:
+    safe = re.sub(r"[^a-zA-Z0-9_.-]+", "-", package_id).strip(".-")
+    if not safe:
+        raise HTTPException(status_code=400, detail="Invalid package id.")
+    return safe[:120]
+
+
+def _package_dir(package_id: str) -> Path:
+    root = _offline_package_root()
+    package_path = (root / _safe_package_id(package_id)).resolve()
+    if root not in (package_path, *package_path.parents):
+        raise HTTPException(status_code=400, detail="Package path escapes package root.")
+    return package_path
+
+
+def _existing_disk_path(path: Path) -> Path:
+    cursor = path
+    while not cursor.exists() and cursor.parent != cursor:
+        cursor = cursor.parent
+    return cursor
+
+
+def _directory_size_bytes(path: Path) -> int:
+    if not path.exists():
+        return 0
+    total = 0
+    for item in path.rglob("*"):
+        try:
+            if item.is_file():
+                total += item.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _storage_info(package_id: str | None = None) -> StorageInfoResponse:
+    root = _offline_package_root()
+    usage = shutil.disk_usage(_existing_disk_path(root))
+    reserved = _package_reserve_bytes()
+    existing = _directory_size_bytes(_package_dir(package_id)) if package_id else (
+        _directory_size_bytes(root) if root.exists() else 0
+    )
+    usable = max(0, int(usage.free) - reserved)
+    return StorageInfoResponse(
+        package_root=str(root),
+        total_bytes=int(usage.total),
+        used_bytes=int(usage.used),
+        free_bytes=int(usage.free),
+        reserved_bytes=reserved,
+        usable_bytes=usable,
+        existing_package_bytes=existing,
+    )
+
+
+def _parse_size_param(value: object) -> tuple[int, int]:
+    if isinstance(value, str):
+        left, _separator, right = value.partition(",")
+        try:
+            return max(1, int(left)), max(1, int(right))
+        except ValueError:
+            return 1024, 1024
+    if isinstance(value, (list, tuple)) and len(value) >= 2:
+        try:
+            return max(1, int(value[0])), max(1, int(value[1]))
+        except (TypeError, ValueError):
+            return 1024, 1024
+    return 1024, 1024
+
+
+def _estimate_operation_bytes(operation: dict[str, object]) -> int:
+    operation_id = str(operation.get("id", ""))
+    if operation_id in {"usgs_imagery_tile_cache", "nrl_naip_tile_cache"}:
+        tile_count = int(operation.get("estimated_tile_count") or 0)
+        avg_tile_bytes = int(os.getenv("OPEN_TILE_ESTIMATED_BYTES", "80000"))
+        return max(10 * 1024 * 1024, tile_count * avg_tile_bytes)
+    if operation_id == "sentinel_2_stac_cog":
+        params = operation.get("params")
+        assets = params.get("assets") if isinstance(params, dict) else []
+        asset_count = len(assets) if isinstance(assets, list) else 4
+        avg_asset_bytes = int(os.getenv("SENTINEL2_ESTIMATED_ASSET_BYTES", str(80 * 1024 * 1024)))
+        return max(100 * 1024 * 1024, asset_count * avg_asset_bytes)
+    if operation_id == "esri_world_imagery_export_tiles":
+        tile_count = int(operation.get("estimated_tile_count") or 0)
+        avg_tile_bytes = int(os.getenv("ESRI_ESTIMATED_TILE_BYTES", "50000"))
+        return max(20 * 1024 * 1024, tile_count * avg_tile_bytes)
+    if operation_id == "esri_world_elevation_export_image_tiff":
+        params = operation.get("params")
+        width, height = _parse_size_param(params.get("size") if isinstance(params, dict) else None)
+        return int(width * height * 4 * 1.5) + (8 * 1024 * 1024)
+    if operation_id == "esri_world_elevation_get_samples":
+        return 512 * 1024
+    if operation_id in {"cesium_ion_archive_download", "cesium_ion_clip_create_download"}:
+        return int(os.getenv("CESIUM_ARCHIVE_ESTIMATED_BYTES", str(2 * 1024 * 1024 * 1024)))
+    if operation_id == "naip_aws_public_prefix":
+        params = operation.get("params")
+        max_files_value = params.get("max_files") if isinstance(params, dict) else None
+        max_files = int(max_files_value or os.getenv("NAIP_MAX_FILES", "50"))
+        avg_bytes = int(os.getenv("NAIP_ESTIMATED_FILE_BYTES", str(25 * 1024 * 1024)))
+        return max(50 * 1024 * 1024, max_files * avg_bytes)
+    if operation_id == "naip_earthexplorer_geotiff_import":
+        max_files = int(os.getenv("NAIP_MAX_FILES", "50"))
+        avg_bytes = int(os.getenv("NAIP_ESTIMATED_FILE_BYTES", str(25 * 1024 * 1024)))
+        return max(50 * 1024 * 1024, max_files * avg_bytes)
+    if operation_id == "osm_geofabrik_pbf":
+        return int(os.getenv("GEOFABRIK_ESTIMATED_BYTES", str(750 * 1024 * 1024)))
+    if operation_id == "copernicus_dem_glo30_cog":
+        params = operation.get("params")
+        tiles = params.get("tile_urls") if isinstance(params, dict) else []
+        tile_count = len(tiles) if isinstance(tiles, list) else 1
+        avg_bytes = int(os.getenv("COPERNICUS_DEM_ESTIMATED_TILE_BYTES", str(25 * 1024 * 1024)))
+        return max(25 * 1024 * 1024, tile_count * avg_bytes)
+    if operation_id == "dted_earthexplorer_import_convert":
+        max_files = int(os.getenv("DTED_IMPORT_MAX_FILES", "100"))
+        avg_bytes = int(os.getenv("DTED_ESTIMATED_FILE_BYTES", str(25 * 1024 * 1024)))
+        return max(25 * 1024 * 1024, max_files * avg_bytes)
+    return 0
+
+
+def _estimate_manifest_bytes(manifest: dict[str, object]) -> int:
+    operations = manifest.get("download_operations")
+    if not isinstance(operations, list):
+        return 0
+    return sum(
+        _estimate_operation_bytes(operation)
+        for operation in operations
+        if isinstance(operation, dict)
+    )
+
+
+def _storage_warning(estimated_bytes: int, storage: StorageInfoResponse) -> str | None:
+    if estimated_bytes <= storage.usable_bytes:
+        return None
+    shortage = estimated_bytes - storage.usable_bytes
+    return (
+        "Estimated package size exceeds Jetson usable storage after reserve "
+        f"by {shortage} bytes."
+    )
+
+
+def _relative_artifact_path(local_artifact: object, package_id: str) -> Path:
+    raw = str(local_artifact or "").replace("\\", "/").strip("/")
+    parts = [part for part in raw.split("/") if part and part not in {".", ".."}]
+    if package_id in parts:
+        parts = parts[parts.index(package_id) + 1 :]
+    elif parts[:2] == ["offline_packages", package_id]:
+        parts = parts[2:]
+    if not parts:
+        parts = ["artifacts", "artifact.bin"]
+    return Path(*parts)
+
+
+def _artifact_path(package_id: str, local_artifact: object) -> Path:
+    package_path = _package_dir(package_id)
+    artifact_path = (package_path / _relative_artifact_path(local_artifact, package_id)).resolve()
+    if package_path not in (artifact_path, *artifact_path.parents):
+        raise HTTPException(status_code=400, detail="Artifact path escapes package root.")
+    return artifact_path
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _manifest_path(package_id: str) -> Path:
+    return _package_dir(package_id) / "manifest.json"
+
+
+def _status_path(package_id: str) -> Path:
+    return _package_dir(package_id) / "status.json"
+
+
+def _artifacts_path(package_id: str) -> Path:
+    return _package_dir(package_id) / "artifacts.json"
+
+
+def _routes_dir(package_id: str) -> Path:
+    return _package_dir(package_id) / "routes"
+
+
+def _cot_dir(package_id: str) -> Path:
+    return _package_dir(package_id) / "cot"
+
+
+def _load_package_manifest(package_id: str) -> dict[str, Any] | None:
+    manifest = PACKAGE_MANIFESTS.get(package_id)
+    if isinstance(manifest, dict):
+        return manifest
+    disk_manifest = _read_json(_manifest_path(package_id))
+    if disk_manifest is not None:
+        PACKAGE_MANIFESTS[package_id] = disk_manifest
+    return disk_manifest
+
+
+def _persist_package_manifest(package_id: str, manifest: dict[str, object]) -> None:
+    package_path = _package_dir(package_id)
+    package_path.mkdir(parents=True, exist_ok=True)
+    _write_json(_manifest_path(package_id), manifest)
+
+
+def _empty_artifact_registry(package_id: str) -> dict[str, Any]:
+    manifest = _load_package_manifest(package_id) or {}
+    return {
+        "package_id": package_id,
+        "package_name": manifest.get("package_name", package_id),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "artifacts": [],
+    }
+
+
+def _load_artifact_registry(package_id: str) -> dict[str, Any]:
+    registry = _read_json(_artifacts_path(package_id))
+    if registry is None:
+        return _empty_artifact_registry(package_id)
+    registry.setdefault("artifacts", [])
+    return registry
+
+
+def _save_artifact_registry(package_id: str, registry: dict[str, Any]) -> None:
+    registry["updated_at"] = datetime.now(timezone.utc).isoformat()
+    _write_json(_artifacts_path(package_id), registry)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _operation_status(
+    operation: dict[str, object],
+    *,
+    state: str = "planned",
+    message: str = "",
+) -> dict[str, object]:
+    return {
+        "id": operation.get("id"),
+        "source_id": operation.get("source_id"),
+        "source_name": operation.get("source_name"),
+        "state": state,
+        "message": message,
+        "estimated_bytes": _estimate_operation_bytes(operation),
+        "bytes_written": 0,
+        "artifact_path": None,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _initial_package_status(package_id: str, manifest: dict[str, object]) -> dict[str, Any]:
+    operations = [
+        _operation_status(operation)
+        for operation in manifest.get("download_operations", [])
+        if isinstance(operation, dict)
+    ]
+    return {
+        "package_id": package_id,
+        "package_name": manifest.get("package_name", package_id),
+        "state": "planned",
+        "message": "Package manifest is ready. Downloads have not started.",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "estimated_bytes": _estimate_manifest_bytes(manifest),
+        "bytes_written": 0,
+        "operations": operations,
+    }
+
+
+def _load_package_status(package_id: str) -> dict[str, Any]:
+    status = _read_json(_status_path(package_id))
+    if status is not None:
+        return status
+    manifest = _load_package_manifest(package_id)
+    if manifest is None:
+        raise HTTPException(status_code=404, detail="Source package manifest not found.")
+    return _initial_package_status(package_id, manifest)
+
+
+def _save_package_status(package_id: str, status: dict[str, Any]) -> None:
+    status["updated_at"] = datetime.now(timezone.utc).isoformat()
+    _write_json(_status_path(package_id), status)
+
+
+def _update_operation_status(
+    status: dict[str, Any],
+    operation_id: str,
+    *,
+    state: str,
+    message: str = "",
+    bytes_written: int | None = None,
+    artifact_path: str | None = None,
+) -> None:
+    for operation in status.get("operations", []):
+        if operation.get("id") == operation_id:
+            operation["state"] = state
+            operation["message"] = message
+            operation["updated_at"] = datetime.now(timezone.utc).isoformat()
+            if bytes_written is not None:
+                operation["bytes_written"] = bytes_written
+            if artifact_path is not None:
+                operation["artifact_path"] = artifact_path
+            break
+    status["bytes_written"] = sum(
+        int(operation.get("bytes_written") or 0)
+        for operation in status.get("operations", [])
+        if isinstance(operation, dict)
+    )
+
+
+def _get_esri_token() -> str:
+    return (
+        os.getenv("ESRI_ARCGIS_TOKEN")
+        or os.getenv("ARCGIS_TOKEN")
+        or os.getenv("ESRI_ACCESS_TOKEN")
+        or ""
+    ).strip()
+
+
+def _get_cesium_token() -> str:
+    return (
+        os.getenv("CESIUM_ION_TOKEN")
+        or os.getenv("CESIUM_TOKEN")
+        or os.getenv("CESIUM_ACCESS_TOKEN")
+        or os.getenv("CESIUM_ION_ACCESS_TOKEN")
+        or ""
+    ).strip()
+
+
+def _get_cesium_archive_id() -> str:
+    return (os.getenv("CESIUM_ION_ARCHIVE_ID") or os.getenv("CESIUM_ARCHIVE_ID") or "").strip()
+
+
+def _get_cesium_asset_ids() -> list[int]:
+    raw = (
+        os.getenv("CESIUM_ION_ASSET_IDS")
+        or os.getenv("CESIUM_ASSET_IDS")
+        or os.getenv("CESIUM_ION_ASSET_ID")
+        or ""
+    )
+    asset_ids: list[int] = []
+    for item in re.split(r"[,;\s]+", raw.strip()):
+        if not item:
+            continue
+        try:
+            asset_ids.append(int(item))
+        except ValueError as error:
+            raise RuntimeError(f"Invalid Cesium asset id: {item}") from error
+    return asset_ids
+
+
+def _params_with_runtime_token(params: dict[str, object]) -> dict[str, object]:
+    materialized: dict[str, object] = {}
+    for key, value in params.items():
+        if value == "${ESRI_ARCGIS_TOKEN}":
+            token = _get_esri_token()
+            if not token:
+                raise RuntimeError("ESRI_ARCGIS_TOKEN is required on the Jetson for Esri downloads.")
+            materialized[key] = token
+        elif value == "${CESIUM_ION_TOKEN}":
+            token = _get_cesium_token()
+            if not token:
+                raise RuntimeError("CESIUM_ION_TOKEN is required on the Jetson for Cesium archive downloads.")
+            materialized[key] = token
+        elif value == "${CESIUM_ION_ARCHIVE_ID}":
+            archive_id = _get_cesium_archive_id()
+            if not archive_id:
+                raise RuntimeError(
+                    "CESIUM_ION_ARCHIVE_ID is required to download a prebuilt Cesium archive."
+                )
+            materialized[key] = archive_id
+        elif value == "${CESIUM_ION_ASSET_IDS}":
+            asset_ids = _get_cesium_asset_ids()
+            if not asset_ids:
+                raise RuntimeError(
+                    "CESIUM_ION_ASSET_IDS is required to create and download a Cesium AO clip."
+                )
+            materialized[key] = asset_ids
+        elif value == "${NAIP_EARTHEXPLORER_DIR}":
+            source_dir = _env_path("NAIP_EARTHEXPLORER_DIR")
+            if not source_dir:
+                raise RuntimeError("NAIP_EARTHEXPLORER_DIR is required to import staged NAIP GeoTIFFs.")
+            materialized[key] = source_dir
+        elif value == "${DTED_SOURCE_DIR}":
+            source_dir = _env_path("DTED_SOURCE_DIR")
+            if not source_dir:
+                raise RuntimeError("DTED_SOURCE_DIR is required to import staged EarthExplorer DTED files.")
+            materialized[key] = source_dir
+        else:
+            materialized[key] = json.dumps(value) if isinstance(value, dict) else value
+    return materialized
+
+
+def _raise_for_esri_error(payload: dict[str, Any]) -> None:
+    error = payload.get("error")
+    if isinstance(error, dict):
+        message = error.get("message") or error.get("details") or "Esri service error."
+        raise RuntimeError(str(message))
+
+
+def _extract_url_recursive(value: Any, base_url: str) -> str | None:
+    if isinstance(value, str):
+        lower = value.lower()
+        if lower.startswith("http://") or lower.startswith("https://"):
+            return value
+        if any(suffix in lower for suffix in (".tpkx", ".tpk", ".zip", ".tif", ".tiff")):
+            return urljoin(base_url, value)
+    if isinstance(value, dict):
+        for key in ("url", "href", "value", "itemUrl", "resultUrl", "paramUrl"):
+            found = _extract_url_recursive(value.get(key), base_url)
+            if found:
+                return found
+        for child in value.values():
+            found = _extract_url_recursive(child, base_url)
+            if found:
+                return found
+    if isinstance(value, list):
+        for child in value:
+            found = _extract_url_recursive(child, base_url)
+            if found:
+                return found
+    return None
+
+
+async def _request_esri_json(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    params: dict[str, object],
+) -> dict[str, Any]:
+    if method.upper() == "POST":
+        response = await client.post(url, data=params)
+    else:
+        response = await client.get(url, params=params)
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise RuntimeError("Esri response was not a JSON object.")
+    _raise_for_esri_error(payload)
+    return payload
+
+
+async def _download_binary(
+    client: httpx.AsyncClient,
+    url: str,
+    path: Path,
+    *,
+    params: dict[str, object] | None = None,
+    headers: dict[str, str] | None = None,
+) -> int:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    bytes_written = 0
+    async with client.stream("GET", url, params=params, headers=headers) as response:
+        response.raise_for_status()
+        with path.open("wb") as handle:
+            async for chunk in response.aiter_bytes():
+                if not chunk:
+                    continue
+                handle.write(chunk)
+                bytes_written += len(chunk)
+    return bytes_written
+
+
+async def _poll_esri_export_job(
+    client: httpx.AsyncClient,
+    *,
+    operation_endpoint: str,
+    job_id: str,
+    token: str,
+) -> dict[str, Any]:
+    service_url = operation_endpoint.rsplit("/exportTiles", 1)[0]
+    job_url = f"{service_url}/jobs/{job_id}"
+    for _attempt in range(ESRI_TILE_EXPORT_MAX_POLLS):
+        payload = await _request_esri_json(
+            client,
+            "GET",
+            job_url,
+            {"f": "json", "token": token},
+        )
+        job_status = str(payload.get("jobStatus") or payload.get("status") or "").lower()
+        if "failed" in job_status or "cancelled" in job_status:
+            raise RuntimeError(f"Esri export job {job_id} ended with {job_status}.")
+        if "succeeded" in job_status or "completed" in job_status:
+            return payload
+        await asyncio.sleep(ESRI_TILE_EXPORT_POLL_INTERVAL_S)
+    raise RuntimeError(f"Timed out waiting for Esri export job {job_id}.")
+
+
+def _copy_or_create_cog(src_path: Path, cog_path: Path) -> bool:
+    cog_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        import rasterio
+
+        with rasterio.open(src_path) as src:
+            profile = src.profile.copy()
+            profile.update(
+                driver="GTiff",
+                tiled=True,
+                blockxsize=256,
+                blockysize=256,
+                compress="deflate",
+                BIGTIFF="IF_SAFER",
+            )
+            with rasterio.open(cog_path, "w", **profile) as dst:
+                for index in range(1, src.count + 1):
+                    dst.write(src.read(index), index)
+        return True
+    except Exception as error:
+        log.warning("cog_conversion_fallback", error=str(error))
+        shutil.copyfile(src_path, cog_path)
+        return False
+
+
+def _artifact_record(
+    *,
+    package_id: str,
+    operation: dict[str, object],
+    path: Path,
+    artifact_type: str,
+    output_format: str,
+    query_interfaces: list[str] | None = None,
+    feeds_algorithms: list[str] | None = None,
+    metadata: dict[str, object] | None = None,
+) -> dict[str, object]:
+    package_path = _package_dir(package_id)
+    relative_path = path.resolve().relative_to(package_path).as_posix()
+    return {
+        "artifact_id": f"{operation.get('id')}-{hashlib.sha256(relative_path.encode()).hexdigest()[:8]}",
+        "source_id": operation.get("source_id"),
+        "source_name": operation.get("source_name"),
+        "operation_id": operation.get("id"),
+        "artifact_type": artifact_type,
+        "format": output_format,
+        "path": str(path),
+        "relative_path": relative_path,
+        "bytes": path.stat().st_size if path.exists() else 0,
+        "sha256": _sha256_file(path) if path.exists() and path.is_file() else "",
+        "query_interfaces": query_interfaces or [],
+        "feeds_algorithms": feeds_algorithms or [],
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "metadata": metadata or {},
+    }
+
+
+def _query_contract_for_operation(
+    manifest: dict[str, object],
+    operation: dict[str, object],
+) -> dict[str, object] | None:
+    source_id = operation.get("source_id")
+    contracts = manifest.get("jetson_query_contracts")
+    if not isinstance(contracts, list):
+        return None
+    for contract in contracts:
+        if isinstance(contract, dict) and contract.get("source_id") == source_id:
+            return contract
+    return None
+
+
+async def _execute_esri_imagery_export(
+    client: httpx.AsyncClient,
+    *,
+    package_id: str,
+    manifest: dict[str, object],
+    operation: dict[str, object],
+) -> dict[str, object]:
+    params = _params_with_runtime_token(operation.get("params") if isinstance(operation.get("params"), dict) else {})
+    endpoint = str(operation["endpoint"])
+    submit_payload = await _request_esri_json(client, str(operation.get("method", "POST")), endpoint, params)
+    package_url = _extract_url_recursive(submit_payload, endpoint)
+    job_id = str(submit_payload.get("jobId") or submit_payload.get("job_id") or "").strip()
+    if not package_url and job_id:
+        poll_payload = await _poll_esri_export_job(
+            client,
+            operation_endpoint=endpoint,
+            job_id=job_id,
+            token=str(params["token"]),
+        )
+        package_url = _extract_url_recursive(poll_payload, endpoint)
+    if not package_url:
+        raise RuntimeError("Esri imagery export did not return a downloadable tile package URL.")
+
+    path = _artifact_path(package_id, operation.get("local_artifact"))
+    await _download_binary(client, package_url, path, params={"token": params["token"]})
+    contract = _query_contract_for_operation(manifest, operation) or {}
+    return _artifact_record(
+        package_id=package_id,
+        operation=operation,
+        path=path,
+        artifact_type=str(contract.get("artifact_type") or "esri_tpkx_imagery_package"),
+        output_format=str(operation.get("output_format") or "TPKX tile package"),
+        query_interfaces=list(contract.get("query_interfaces") or ["package_metadata()"]),
+        feeds_algorithms=list(contract.get("feeds_algorithms") or ["operator_route_review"]),
+        metadata={
+            "download_url_redacted": True,
+            "job_id": job_id or None,
+            "estimated_tile_count": operation.get("estimated_tile_count"),
+            "tile_limit_warning": operation.get("tile_limit_warning"),
+        },
+    )
+
+
+async def _execute_esri_terrain_export(
+    client: httpx.AsyncClient,
+    *,
+    package_id: str,
+    manifest: dict[str, object],
+    operation: dict[str, object],
+) -> list[dict[str, object]]:
+    params = _params_with_runtime_token(operation.get("params") if isinstance(operation.get("params"), dict) else {})
+    endpoint = str(operation["endpoint"])
+    raw_path = _artifact_path(package_id, operation.get("local_artifact"))
+    if str(operation.get("method", "POST")).upper() == "POST":
+        response = await client.post(endpoint, data=params)
+    else:
+        response = await client.get(endpoint, params=params)
+    response.raise_for_status()
+    content_type = response.headers.get("content-type", "").lower()
+    if "json" in content_type:
+        payload = response.json()
+        _raise_for_esri_error(payload)
+        href = _extract_url_recursive(payload, endpoint)
+        if not href:
+            raise RuntimeError("Esri terrain export returned JSON without a raster URL.")
+        await _download_binary(client, href, raw_path, params={"token": params["token"]})
+    else:
+        raw_path.parent.mkdir(parents=True, exist_ok=True)
+        raw_path.write_bytes(response.content)
+
+    cog_path = raw_path.with_name("dem_cog.tif")
+    cog_native = _copy_or_create_cog(raw_path, cog_path)
+    contract = _query_contract_for_operation(manifest, operation) or {}
+    common_metadata = {
+        "bbox": params.get("bbox"),
+        "bboxSR": params.get("bboxSR"),
+        "imageSR": params.get("imageSR"),
+        "size": params.get("size"),
+        "pixelType": params.get("pixelType"),
+    }
+    return [
+        _artifact_record(
+            package_id=package_id,
+            operation=operation,
+            path=raw_path,
+            artifact_type="geotiff_dem",
+            output_format="GeoTIFF DEM",
+            query_interfaces=["rasterio.open()", "read_window()"],
+            feeds_algorithms=["terrain_derivatives"],
+            metadata=common_metadata,
+        ),
+        _artifact_record(
+            package_id=package_id,
+            operation=operation,
+            path=cog_path,
+            artifact_type=str(contract.get("artifact_type") or "cloud_optimized_geotiff_dem"),
+            output_format="COG GeoTIFF DEM" if cog_native else "GeoTIFF DEM copied to COG path",
+            query_interfaces=list(contract.get("query_interfaces") or ["sample_dem(lat, lon)", "read_window(west, south, east, north)"]),
+            feeds_algorithms=list(contract.get("feeds_algorithms") or ["terrain_derivatives", "raster_cost_distance", "viewshed"]),
+            metadata={**common_metadata, "cog_native": cog_native},
+        ),
+    ]
+
+
+async def _execute_esri_samples(
+    client: httpx.AsyncClient,
+    *,
+    package_id: str,
+    operation: dict[str, object],
+) -> dict[str, object]:
+    params = _params_with_runtime_token(operation.get("params") if isinstance(operation.get("params"), dict) else {})
+    endpoint = str(operation["endpoint"])
+    payload = await _request_esri_json(client, str(operation.get("method", "POST")), endpoint, params)
+    path = _artifact_path(package_id, operation.get("local_artifact"))
+    _write_json(path, payload)
+    return _artifact_record(
+        package_id=package_id,
+        operation=operation,
+        path=path,
+        artifact_type="elevation_samples_json",
+        output_format="JSON elevation samples",
+        query_interfaces=["sample_points()"],
+        feeds_algorithms=["terrain_preflight"],
+        metadata={"sample_count": len(payload.get("samples", [])) if isinstance(payload.get("samples"), list) else None},
+    )
+
+
+async def _execute_sentinel2_stac_cogs(
+    client: httpx.AsyncClient,
+    *,
+    package_id: str,
+    operation: dict[str, object],
+) -> list[dict[str, object]]:
+    params = operation.get("params") if isinstance(operation.get("params"), dict) else {}
+    search_payload = {key: value for key, value in params.items() if key != "assets"}
+    requested_assets = params.get("assets")
+    asset_names = requested_assets if isinstance(requested_assets, list) else ["visual", "red", "green", "blue", "nir"]
+    response = await client.post(str(operation["endpoint"]), json=search_payload)
+    response.raise_for_status()
+    payload = response.json()
+    features = payload.get("features", []) if isinstance(payload, dict) else []
+    if not features:
+        raise RuntimeError("Earth Search returned no Sentinel-2 scenes for the AO/date/cloud filters.")
+    item = features[0]
+    if not isinstance(item, dict):
+        raise RuntimeError("Earth Search returned an invalid Sentinel-2 item.")
+    item_id = re.sub(r"[^a-zA-Z0-9_.-]+", "-", str(item.get("id") or "sentinel2")).strip("-")
+    assets = item.get("assets", {})
+    if not isinstance(assets, dict):
+        raise RuntimeError("Sentinel-2 STAC item does not contain assets.")
+
+    base_dir = _package_dir(package_id) / "imagery" / "sentinel_2"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    metadata_path = base_dir / f"{item_id}_stac_item.json"
+    _write_json(metadata_path, item)
+    records = [
+        _artifact_record(
+            package_id=package_id,
+            operation=operation,
+            path=metadata_path,
+            artifact_type="sentinel2_stac_item",
+            output_format="STAC Item JSON",
+            query_interfaces=["stac_metadata()"],
+            feeds_algorithms=["imagery_provenance"],
+            metadata={
+                "collection": item.get("collection"),
+                "datetime": (item.get("properties") or {}).get("datetime")
+                if isinstance(item.get("properties"), dict)
+                else None,
+            },
+        )
+    ]
+
+    for asset_name in asset_names:
+        asset = assets.get(str(asset_name))
+        if not isinstance(asset, dict):
+            continue
+        href = str(asset.get("href") or "")
+        if not href.lower().startswith(("http://", "https://")):
+            continue
+        suffix = ".tif"
+        if href.lower().split("?", 1)[0].endswith(".jp2"):
+            suffix = ".jp2"
+        asset_path = base_dir / f"{item_id}_{asset_name}{suffix}"
+        await _download_binary(client, href, asset_path)
+        records.append(
+            _artifact_record(
+                package_id=package_id,
+                operation=operation,
+                path=asset_path,
+                artifact_type="sentinel2_cog_band",
+                output_format=str(asset.get("type") or "Cloud Optimized GeoTIFF"),
+                query_interfaces=["rasterio.open()", "read_window(west, south, east, north)"],
+                feeds_algorithms=["visual_aoi_reference", "ndvi", "ndwi", "water_detection"],
+                metadata={
+                    "stac_item_id": item_id,
+                    "asset": asset_name,
+                    "title": asset.get("title"),
+                    "datetime": (item.get("properties") or {}).get("datetime")
+                    if isinstance(item.get("properties"), dict)
+                    else None,
+                    "cloud_cover": (item.get("properties") or {}).get("eo:cloud_cover")
+                    if isinstance(item.get("properties"), dict)
+                    else None,
+                },
+            )
+        )
+
+    if len(records) == 1:
+        raise RuntimeError("No downloadable Sentinel-2 COG assets were found in the STAC item.")
+    return records
+
+
+def _s3_request_headers(request_payer: object = None) -> dict[str, str]:
+    if str(request_payer or "").lower() == "requester":
+        return {"x-amz-request-payer": "requester"}
+    return {}
+
+
+def _parse_s3_list_response(xml_text: str) -> tuple[list[dict[str, object]], str | None]:
+    root = ET.fromstring(xml_text)
+    namespace = ""
+    if root.tag.startswith("{"):
+        namespace = root.tag.split("}", 1)[0] + "}"
+    objects: list[dict[str, object]] = []
+    for contents in root.findall(f".//{namespace}Contents"):
+        key = contents.findtext(f"{namespace}Key")
+        size_text = contents.findtext(f"{namespace}Size") or "0"
+        if not key:
+            continue
+        try:
+            size = int(size_text)
+        except ValueError:
+            size = 0
+        objects.append({"key": key, "size": size})
+    token = root.findtext(f"{namespace}NextContinuationToken")
+    return objects, token
+
+
+def _downloadable_naip_key(key: str) -> bool:
+    suffixes = (
+        ".tif",
+        ".tiff",
+        ".mrf",
+        ".idx",
+        ".lrc",
+        ".xml",
+        ".aux",
+        ".json",
+        ".txt",
+    )
+    return key.lower().endswith(suffixes)
+
+
+async def _execute_naip_aws_prefix(
+    client: httpx.AsyncClient,
+    *,
+    package_id: str,
+    operation: dict[str, object],
+) -> list[dict[str, object]]:
+    params = operation.get("params") if isinstance(operation.get("params"), dict) else {}
+    bucket = str(params.get("bucket") or _naip_bucket()).strip()
+    prefix = str(params.get("prefix") or "").strip().lstrip("/")
+    max_files = int(params.get("max_files") or os.getenv("NAIP_MAX_FILES", "50"))
+    endpoint = str(operation.get("endpoint") or NAIP_AWS_BUCKET_URL_TEMPLATE).replace("{bucket}", bucket)
+    headers = _s3_request_headers(params.get("request_payer"))
+
+    listed: list[dict[str, object]] = []
+    continuation: str | None = None
+    while len(listed) < max_files:
+        list_params: dict[str, object] = {
+            "list-type": "2",
+            "prefix": prefix,
+            "max-keys": min(1000, max_files - len(listed)),
+        }
+        if continuation:
+            list_params["continuation-token"] = continuation
+        response = await client.get(endpoint, params=list_params, headers=headers)
+        response.raise_for_status()
+        objects, continuation = _parse_s3_list_response(response.text)
+        listed.extend(
+            item
+            for item in objects
+            if isinstance(item.get("key"), str) and _downloadable_naip_key(str(item["key"]))
+        )
+        if not continuation or not objects:
+            break
+
+    if not listed:
+        raise RuntimeError(
+            f"NAIP S3 prefix {bucket}/{prefix} returned no downloadable files. "
+            "Check NAIP_AWS_STATE, NAIP_AWS_YEAR, NAIP_AWS_RESOLUTION, and bucket."
+        )
+
+    package_path = _package_dir(package_id)
+    base_dir = package_path / "imagery" / "naip" / "aws"
+    downloaded: list[dict[str, object]] = []
+    errors: list[str] = []
+    for item in listed[:max_files]:
+        key = str(item["key"])
+        relative_key = key[len(prefix) :].lstrip("/") if key.startswith(prefix) else key
+        relative_key = relative_key or Path(key).name
+        target = (base_dir / relative_key).resolve()
+        if base_dir.resolve() not in (target, *target.parents):
+            raise RuntimeError("NAIP S3 key escapes NAIP package directory.")
+        url = f"https://{bucket}.s3.amazonaws.com/{quote(key)}"
+        try:
+            bytes_written = await _download_binary(client, url, target, headers=headers)
+            downloaded.append(
+                {
+                    "key": key,
+                    "relative_path": target.relative_to(package_path).as_posix(),
+                    "bytes": bytes_written,
+                    "query_url": (
+                        f"/api/source-package/{package_id}/query/imagery/files/"
+                        f"{target.relative_to(package_path).as_posix()}"
+                    ),
+                }
+            )
+        except Exception as error:
+            if len(errors) < 10:
+                errors.append(f"{key}: {error}")
+
+    if not downloaded:
+        raise RuntimeError(f"NAIP S3 prefix listed files but downloads failed: {'; '.join(errors)}")
+
+    index_path = _artifact_path(package_id, operation.get("local_artifact"))
+    _write_json(
+        index_path,
+        {
+            "source_id": operation.get("source_id"),
+            "source_name": operation.get("source_name"),
+            "bucket": bucket,
+            "prefix": prefix,
+            "request_payer": params.get("request_payer"),
+            "state": params.get("state"),
+            "year": params.get("year"),
+            "resolution": params.get("resolution"),
+            "bandset": params.get("bandset"),
+            "max_files": max_files,
+            "listed_file_count": len(listed),
+            "downloaded_file_count": len(downloaded),
+            "files": downloaded,
+            "errors": errors,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    return [
+        _artifact_record(
+            package_id=package_id,
+            operation=operation,
+            path=index_path,
+            artifact_type="naip_imagery_index",
+            output_format="JSON NAIP imagery index",
+            query_interfaces=["imagery_file(relative_path)", "rasterio.open()", "read_window(west, south, east, north)"],
+            feeds_algorithms=["operator_route_review", "feature_extraction_review"],
+            metadata={
+                "bucket": bucket,
+                "prefix": prefix,
+                "downloaded_file_count": len(downloaded),
+                "errors": errors,
+            },
+        )
+    ]
+
+
+async def _execute_naip_earthexplorer_import(
+    *,
+    package_id: str,
+    operation: dict[str, object],
+) -> list[dict[str, object]]:
+    params = _params_with_runtime_token(operation.get("params") if isinstance(operation.get("params"), dict) else {})
+    source_dir = Path(str(params["source_dir"])).expanduser().resolve()
+    if not source_dir.exists() or not source_dir.is_dir():
+        raise RuntimeError(f"NAIP_EARTHEXPLORER_DIR does not exist or is not a directory: {source_dir}")
+    max_files = int(params.get("max_files") or os.getenv("NAIP_MAX_FILES", "50"))
+    files = [
+        path
+        for path in sorted(source_dir.rglob("*"))
+        if path.is_file() and path.suffix.lower() in {".tif", ".tiff"}
+    ][:max_files]
+    if not files:
+        raise RuntimeError("No NAIP GeoTIFF files found in NAIP_EARTHEXPLORER_DIR.")
+
+    package_path = _package_dir(package_id)
+    dest_dir = package_path / "imagery" / "naip" / "earthexplorer"
+    copied: list[dict[str, object]] = []
+    for src in files:
+        target = dest_dir / src.name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, target)
+        copied.append(
+            {
+                "source_name": src.name,
+                "relative_path": target.relative_to(package_path).as_posix(),
+                "bytes": target.stat().st_size,
+                "query_url": (
+                    f"/api/source-package/{package_id}/query/imagery/files/"
+                    f"{target.relative_to(package_path).as_posix()}"
+                ),
+            }
+        )
+
+    index_path = _artifact_path(package_id, operation.get("local_artifact"))
+    _write_json(
+        index_path,
+        {
+            "source_dir": str(source_dir),
+            "file_count": len(copied),
+            "files": copied,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    return [
+        _artifact_record(
+            package_id=package_id,
+            operation=operation,
+            path=index_path,
+            artifact_type="naip_imagery_index",
+            output_format="JSON NAIP EarthExplorer import index",
+            query_interfaces=["imagery_file(relative_path)", "rasterio.open()"],
+            feeds_algorithms=["operator_route_review", "feature_extraction_review"],
+            metadata={"file_count": len(copied), "source_dir": str(source_dir)},
+        )
+    ]
+
+
+async def _execute_xyz_tile_cache(
+    client: httpx.AsyncClient,
+    *,
+    package_id: str,
+    operation: dict[str, object],
+) -> list[dict[str, object]]:
+    params = operation.get("params") if isinstance(operation.get("params"), dict) else {}
+    template = str(params.get("tile_url_template") or operation.get("endpoint") or "")
+    levels = _parse_level_range(params.get("levels"))
+    min_zoom = int(params.get("min_zoom") or 0)
+    max_zoom = int(params.get("max_zoom") or max(levels or [0]))
+    levels = [level for level in levels if min_zoom <= level <= max_zoom]
+    manifest = _load_package_manifest(package_id) or {}
+    aoi = manifest.get("aoi") if isinstance(manifest.get("aoi"), dict) else {}
+    bounds_data = aoi.get("selected_area") or aoi.get("view_bounds") if isinstance(aoi, dict) else None
+    if not isinstance(bounds_data, dict):
+        raise RuntimeError("Tile cache download requires AO bounds in the package manifest.")
+    bounds = ViewBounds(**bounds_data)
+    tile_limit = int(os.getenv("MAX_TILE_DOWNLOAD_COUNT", "5000"))
+    tile_count = _estimate_slippy_tile_count(bounds, levels)
+    if tile_count > tile_limit:
+        raise RuntimeError(
+            f"Tile cache would download {tile_count} tiles, above MAX_TILE_DOWNLOAD_COUNT={tile_limit}."
+        )
+
+    package_path = _package_dir(package_id)
+    relative_template = _relative_artifact_path(operation.get("local_artifact"), package_id).as_posix()
+    downloaded = 0
+    bytes_written = 0
+    errors: list[str] = []
+    for zoom, xs, ys in _tile_ranges(bounds, levels):
+        for x in xs:
+            for y in ys:
+                url = template.replace("{z}", str(zoom)).replace("{x}", str(x)).replace("{y}", str(y))
+                url = url.replace("{$z}", str(zoom)).replace("{$x}", str(x)).replace("{$y}", str(y))
+                relative = (
+                    relative_template.replace("{z}", str(zoom))
+                    .replace("{x}", str(x))
+                    .replace("{y}", str(y))
+                )
+                path = (package_path / relative).resolve()
+                if package_path not in (path, *path.parents):
+                    raise RuntimeError("Tile cache path escapes package root.")
+                try:
+                    bytes_written += await _download_binary(client, url, path)
+                    downloaded += 1
+                except Exception as error:
+                    if len(errors) < 5:
+                        errors.append(f"{zoom}/{x}/{y}: {error}")
+
+    index_path = package_path / "tiles" / str(operation.get("source_id")) / "tile_index.json"
+    _write_json(
+        index_path,
+        {
+            "source_id": operation.get("source_id"),
+            "source_name": operation.get("source_name"),
+            "url_template_redacted": False,
+            "url_template": template,
+            "levels": levels,
+            "aoi": bounds.model_dump(),
+            "estimated_tile_count": tile_count,
+            "downloaded_tile_count": downloaded,
+            "errors": errors,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    return [
+        _artifact_record(
+            package_id=package_id,
+            operation=operation,
+            path=index_path,
+            artifact_type="xyz_imagery_tile_cache",
+            output_format=str(operation.get("output_format") or "XYZ tile cache"),
+            query_interfaces=["tile(z, x, y)", "tiles_intersecting_bbox(west, south, east, north, zoom)"],
+            feeds_algorithms=["visual_aoi_reference", "operator_route_review"],
+            metadata={
+                "levels": levels,
+                "estimated_tile_count": tile_count,
+                "downloaded_tile_count": downloaded,
+                "bytes_written": bytes_written,
+                "errors": errors,
+            },
+        )
+    ]
+
+
+def _cesium_headers(token: object) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _request_cesium_json(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    *,
+    token: object,
+    payload: dict[str, object] | None = None,
+) -> dict[str, Any]:
+    headers = _cesium_headers(token)
+    if method.upper() == "POST":
+        response = await client.post(url, json=payload or {}, headers=headers)
+    else:
+        response = await client.get(url, headers=headers)
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        raise RuntimeError("Cesium ion response was not a JSON object.")
+    return data
+
+
+async def _poll_cesium_archive(
+    client: httpx.AsyncClient,
+    *,
+    archive_id: object,
+    token: object,
+) -> dict[str, Any]:
+    info_url = CESIUM_ION_ARCHIVE_INFO_URL.replace("{archive_id}", str(archive_id))
+    last_payload: dict[str, Any] = {}
+    for _attempt in range(CESIUM_ARCHIVE_MAX_POLLS):
+        payload = await _request_cesium_json(client, "GET", info_url, token=token)
+        last_payload = payload
+        status = str(payload.get("status") or "").upper()
+        if status in {"COMPLETE", "COMPLETED"}:
+            return payload
+        if status in {"FAILED", "CANCELLED", "CANCELED"}:
+            raise RuntimeError(f"Cesium archive {archive_id} ended with status {status}.")
+        await asyncio.sleep(CESIUM_ARCHIVE_POLL_INTERVAL_S)
+    raise RuntimeError(
+        f"Timed out waiting for Cesium archive {archive_id}; last status={last_payload.get('status')!r}."
+    )
+
+
+def _safe_extract_zip(zip_path: Path, extract_dir: Path) -> list[Path]:
+    extract_dir.mkdir(parents=True, exist_ok=True)
+    extracted: list[Path] = []
+    try:
+        with zipfile.ZipFile(zip_path) as archive:
+            for member in archive.infolist():
+                target = (extract_dir / member.filename).resolve()
+                if extract_dir not in (target, *target.parents):
+                    raise RuntimeError("Cesium archive contains a path outside the extract directory.")
+            archive.extractall(extract_dir)
+    except zipfile.BadZipFile as error:
+        raise RuntimeError("Cesium archive download was not a valid ZIP file.") from error
+
+    for path in extract_dir.rglob("*"):
+        if path.is_file():
+            extracted.append(path)
+    return extracted
+
+
+def _read_descriptor_json(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _index_cesium_archive(
+    *,
+    package_id: str,
+    operation: dict[str, object],
+    archive_path: Path,
+    archive_info: dict[str, Any],
+) -> tuple[Path, dict[str, Any]]:
+    package_path = _package_dir(package_id)
+    extract_dir = package_path / "cesium" / "archive" / "extracted"
+    extracted_files = _safe_extract_zip(archive_path, extract_dir)
+
+    files: list[dict[str, object]] = []
+    tilesets: list[dict[str, object]] = []
+    terrain_layers: list[dict[str, object]] = []
+    imagery_layers: list[dict[str, object]] = []
+    for path in sorted(extracted_files):
+        relative_path = path.resolve().relative_to(package_path).as_posix()
+        name = path.name.lower()
+        item: dict[str, object] = {
+            "relative_path": relative_path,
+            "bytes": path.stat().st_size,
+            "query_url": f"/api/source-package/{package_id}/query/cesium/files/{relative_path}",
+        }
+        files.append(item)
+        if name == "tileset.json":
+            descriptor = _read_descriptor_json(path) or {}
+            tilesets.append(
+                {
+                    **item,
+                    "root_refine": (descriptor.get("root") or {}).get("refine")
+                    if isinstance(descriptor.get("root"), dict)
+                    else None,
+                    "asset_version": (descriptor.get("asset") or {}).get("version")
+                    if isinstance(descriptor.get("asset"), dict)
+                    else None,
+                }
+            )
+        elif name == "layer.json":
+            descriptor = _read_descriptor_json(path) or {}
+            layer_record = {
+                **item,
+                "format": descriptor.get("format"),
+                "version": descriptor.get("version"),
+                "attribution": descriptor.get("attribution"),
+            }
+            if str(descriptor.get("format") or "").lower() in {"quantized-mesh-1.0", "heightmap-1.0"}:
+                terrain_layers.append(layer_record)
+            else:
+                imagery_layers.append(layer_record)
+
+    index = {
+        "package_id": package_id,
+        "source_id": operation.get("source_id"),
+        "source_name": operation.get("source_name"),
+        "operation_id": operation.get("id"),
+        "archive_id": archive_info.get("id"),
+        "archive_name": archive_info.get("name"),
+        "archive_type": archive_info.get("type"),
+        "archive_format": archive_info.get("format"),
+        "archive_status": archive_info.get("status"),
+        "bytes_archived": archive_info.get("bytesArchived"),
+        "archive_zip": archive_path.resolve().relative_to(package_path).as_posix(),
+        "files": files,
+        "tilesets": tilesets,
+        "terrain_layers": terrain_layers,
+        "imagery_layers": imagery_layers,
+        "query_interfaces": [
+            "GET /api/source-package/{package_id}/query/cesium",
+            "GET /api/source-package/{package_id}/query/cesium/files/{relative_path}",
+        ],
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    index_path = package_path / "cesium" / "archive" / "cesium_archive_index.json"
+    _write_json(index_path, index)
+    return index_path, index
+
+
+async def _execute_cesium_archive_download(
+    client: httpx.AsyncClient,
+    *,
+    package_id: str,
+    manifest: dict[str, object],
+    operation: dict[str, object],
+) -> list[dict[str, object]]:
+    params = _params_with_runtime_token(operation.get("params") if isinstance(operation.get("params"), dict) else {})
+    token = params["token"]
+    archive_id = params["archive_id"]
+    archive_info = await _poll_cesium_archive(client, archive_id=archive_id, token=token)
+    download_url = CESIUM_ION_ARCHIVE_DOWNLOAD_URL.replace("{archive_id}", str(archive_id))
+    archive_path = _artifact_path(package_id, operation.get("local_artifact"))
+    await _download_binary(client, download_url, archive_path, headers=_cesium_headers(token))
+    index_path, index = _index_cesium_archive(
+        package_id=package_id,
+        operation=operation,
+        archive_path=archive_path,
+        archive_info=archive_info,
+    )
+    contract = _query_contract_for_operation(manifest, operation) or {}
+    return [
+        _artifact_record(
+            package_id=package_id,
+            operation=operation,
+            path=archive_path,
+            artifact_type="cesium_archive_zip",
+            output_format=str(operation.get("output_format") or "Cesium archive ZIP"),
+            query_interfaces=["downloaded_archive_zip()"],
+            feeds_algorithms=["local_cesium_preview"],
+            metadata={
+                "archive_id": archive_info.get("id"),
+                "archive_status": archive_info.get("status"),
+                "bytes_archived": archive_info.get("bytesArchived"),
+            },
+        ),
+        _artifact_record(
+            package_id=package_id,
+            operation=operation,
+            path=index_path,
+            artifact_type=str(contract.get("artifact_type") or "cesium_offline_archive_index"),
+            output_format="JSON Cesium archive index",
+            query_interfaces=list(
+                contract.get("query_interfaces")
+                or ["cesium_archive_metadata()", "cesium_file(relative_path)"]
+            ),
+            feeds_algorithms=list(contract.get("feeds_algorithms") or ["local_cesium_preview"]),
+            metadata={
+                "archive_id": archive_info.get("id"),
+                "file_count": len(index.get("files", [])),
+                "tileset_count": len(index.get("tilesets", [])),
+                "terrain_layer_count": len(index.get("terrain_layers", [])),
+                "imagery_layer_count": len(index.get("imagery_layers", [])),
+            },
+        ),
+    ]
+
+
+async def _execute_cesium_clip_create_download(
+    client: httpx.AsyncClient,
+    *,
+    package_id: str,
+    manifest: dict[str, object],
+    operation: dict[str, object],
+) -> list[dict[str, object]]:
+    params = _params_with_runtime_token(operation.get("params") if isinstance(operation.get("params"), dict) else {})
+    token = params["token"]
+    if not isinstance(params.get("asset_ids"), list):
+        raise RuntimeError("Cesium AO clip requires CESIUM_ION_ASSET_IDS.")
+    if not isinstance(params.get("clip_region"), list):
+        raise RuntimeError("Cesium AO clip requires confirmed AO bounds.")
+    payload = {
+        "assetIds": params["asset_ids"],
+        "format": params.get("format", "TILESET"),
+        "type": params.get("type", "CLIP_LATITUDE_LONGITUDE_RECTANGLE"),
+        "clipRegion": params["clip_region"],
+    }
+    archive_info = await _request_cesium_json(
+        client,
+        "POST",
+        str(operation["endpoint"]),
+        token=token,
+        payload=payload,
+    )
+    archive_id = archive_info.get("id")
+    if archive_id is None:
+        raise RuntimeError("Cesium ion did not return an archive id for the AO clip.")
+
+    download_operation = {**operation}
+    download_operation["params"] = {
+        "archive_id": str(archive_id),
+        "token": "${CESIUM_ION_TOKEN}",
+        "extract": True,
+    }
+    records = await _execute_cesium_archive_download(
+        client,
+        package_id=package_id,
+        manifest=manifest,
+        operation=download_operation,
+    )
+    for record in records:
+        metadata = record.setdefault("metadata", {})
+        if isinstance(metadata, dict):
+            metadata["created_from_asset_ids"] = params["asset_ids"]
+            metadata["clip_region_radians"] = params["clip_region"]
+    return records
+
+
+def _run_subprocess(args: list[str]) -> tuple[bool, str]:
+    try:
+        result = subprocess.run(args, capture_output=True, text=True, check=False)
+    except OSError as error:
+        return False, str(error)
+    output = (result.stdout or "") + (result.stderr or "")
+    return result.returncode == 0, output.strip()
+
+
+async def _execute_osm_geofabrik_pbf(
+    client: httpx.AsyncClient,
+    *,
+    package_id: str,
+    operation: dict[str, object],
+) -> list[dict[str, object]]:
+    params = operation.get("params") if isinstance(operation.get("params"), dict) else {}
+    region_url = str(params.get("region_url") or operation.get("endpoint") or "").strip()
+    if not region_url:
+        raise RuntimeError("Geofabrik OSM operation did not include a region URL.")
+    package_path = _package_dir(package_id)
+    vector_dir = package_path / "vectors" / "osm"
+    region_path = vector_dir / "geofabrik_region.osm.pbf"
+    clipped_path = _artifact_path(package_id, operation.get("local_artifact"))
+    await _download_binary(client, region_url, region_path)
+
+    clip_bbox = str(params.get("clip_bbox") or "").strip()
+    clipped = False
+    clip_message = "osmium not available; regional PBF registered without AO clip."
+    osmium = shutil.which("osmium")
+    if osmium and clip_bbox and "{" not in clip_bbox:
+        clipped_path.parent.mkdir(parents=True, exist_ok=True)
+        ok, output = _run_subprocess(
+            [
+                osmium,
+                "extract",
+                f"--bbox={clip_bbox}",
+                str(region_path),
+                "-o",
+                str(clipped_path),
+                "--overwrite",
+            ]
+        )
+        clipped = ok and clipped_path.exists()
+        clip_message = output or ("AO clip created." if clipped else "osmium extract failed.")
+    if not clipped:
+        clipped_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(region_path, clipped_path)
+
+    index_path = vector_dir / "osm_index.json"
+    _write_json(
+        index_path,
+        {
+            "source_id": operation.get("source_id"),
+            "source_name": operation.get("source_name"),
+            "region_url": region_url,
+            "region_slug": params.get("region_slug"),
+            "clip_bbox": clip_bbox,
+            "clipped_with_osmium": clipped,
+            "clip_message": clip_message,
+            "region_pbf": region_path.relative_to(package_path).as_posix(),
+            "aoi_pbf": clipped_path.relative_to(package_path).as_posix(),
+            "query_interfaces": [
+                "osmium tags-filter",
+                "pyosmium scan",
+                "valhalla_build_tiles",
+                "find_pois(osm_tags, bbox)",
+            ],
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    return [
+        _artifact_record(
+            package_id=package_id,
+            operation=operation,
+            path=clipped_path,
+            artifact_type="osm_pbf_extract",
+            output_format="OSM PBF",
+            query_interfaces=["osmium tags-filter", "pyosmium scan", "valhalla_build_tiles"],
+            feeds_algorithms=["routable_graph", "nearest_feature", "water_source_lookup"],
+            metadata={
+                "region_url": region_url,
+                "clip_bbox": clip_bbox,
+                "clipped_with_osmium": clipped,
+                "clip_message": clip_message,
+            },
+        ),
+        _artifact_record(
+            package_id=package_id,
+            operation=operation,
+            path=index_path,
+            artifact_type="osm_query_index",
+            output_format="JSON OSM package index",
+            query_interfaces=["osm_artifacts()", "osm_file(relative_path)"],
+            feeds_algorithms=["routable_graph", "nearest_feature"],
+            metadata={"region_url": region_url, "clipped_with_osmium": clipped},
+        ),
+    ]
+
+
+async def _execute_copernicus_dem_cogs(
+    client: httpx.AsyncClient,
+    *,
+    package_id: str,
+    operation: dict[str, object],
+) -> list[dict[str, object]]:
+    params = operation.get("params") if isinstance(operation.get("params"), dict) else {}
+    tiles = params.get("tile_urls") if isinstance(params.get("tile_urls"), list) else []
+    if not tiles:
+        raise RuntimeError("Copernicus DEM download requires AO bounds to derive tile URLs.")
+    package_path = _package_dir(package_id)
+    dem_dir = package_path / "rasters" / "copernicus_dem"
+    downloaded: list[dict[str, object]] = []
+    errors: list[str] = []
+    records: list[dict[str, object]] = []
+    for tile in tiles:
+        if not isinstance(tile, dict):
+            continue
+        tile_id = re.sub(r"[^a-zA-Z0-9_.-]+", "-", str(tile.get("tile_id") or "copernicus_dem"))
+        url = str(tile.get("url") or "")
+        if not url:
+            continue
+        path = dem_dir / f"{tile_id}.tif"
+        try:
+            await _download_binary(client, url, path)
+        except Exception as error:
+            if len(errors) < 10:
+                errors.append(f"{tile_id}: {error}")
+            continue
+        downloaded.append(
+            {
+                "tile_id": tile_id,
+                "url": url,
+                "relative_path": path.relative_to(package_path).as_posix(),
+                "bytes": path.stat().st_size,
+                "query_url": f"/api/source-package/{package_id}/query/terrain/files/{path.relative_to(package_path).as_posix()}",
+            }
+        )
+        records.append(
+            _artifact_record(
+                package_id=package_id,
+                operation=operation,
+                path=path,
+                artifact_type="copernicus_dem_cog",
+                output_format="Cloud Optimized GeoTIFF DEM",
+                query_interfaces=["sample_dem(lat, lon)", "read_window(west, south, east, north)", "rasterio.open()"],
+                feeds_algorithms=["terrain_derivatives", "raster_cost_distance", "viewshed"],
+                metadata={"tile_id": tile_id, "url": url, "bbox": params.get("bbox")},
+            )
+        )
+
+    if not downloaded:
+        raise RuntimeError(f"No Copernicus DEM tiles downloaded. Errors: {'; '.join(errors)}")
+
+    index_path = dem_dir / "copernicus_dem_index.json"
+    _write_json(
+        index_path,
+        {
+            "source_id": operation.get("source_id"),
+            "source_name": operation.get("source_name"),
+            "bbox": params.get("bbox"),
+            "requested_tiles": tiles,
+            "downloaded_tiles": downloaded,
+            "errors": errors,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    records.append(
+        _artifact_record(
+            package_id=package_id,
+            operation=operation,
+            path=index_path,
+            artifact_type="copernicus_dem_cog_index",
+            output_format="JSON Copernicus DEM tile index",
+            query_interfaces=["terrain_artifacts()", "terrain_file(relative_path)"],
+            feeds_algorithms=["terrain_derivatives", "raster_cost_distance", "viewshed"],
+            metadata={"tile_count": len(downloaded), "errors": errors},
+        )
+    )
+    return records
+
+
+def _dted_matches_aoi(path: Path, tiles: list[dict[str, object]]) -> bool:
+    name = path.as_posix().lower()
+    for tile in tiles:
+        lat_floor = int(tile.get("lat_floor", 999))
+        lon_floor = int(tile.get("lon_floor", 999))
+        lat_tokens = {f"n{lat_floor:02d}", f"s{abs(lat_floor):02d}"}
+        lon_tokens = {f"e{lon_floor:03d}", f"w{abs(lon_floor):03d}"}
+        if any(token in name for token in lat_tokens) and any(token in name for token in lon_tokens):
+            return True
+    return False
+
+
+async def _execute_dted_import_convert(
+    *,
+    package_id: str,
+    operation: dict[str, object],
+) -> list[dict[str, object]]:
+    params = _params_with_runtime_token(operation.get("params") if isinstance(operation.get("params"), dict) else {})
+    source_dir = Path(str(params["source_dir"])).expanduser().resolve()
+    if not source_dir.exists() or not source_dir.is_dir():
+        raise RuntimeError(f"DTED_SOURCE_DIR does not exist or is not a directory: {source_dir}")
+    manifest = _load_package_manifest(package_id) or {}
+    aoi = manifest.get("aoi") if isinstance(manifest.get("aoi"), dict) else {}
+    bounds = ViewBounds(**aoi) if aoi else None
+    tiles = _copernicus_dem_tiles(bounds) if bounds else []
+    all_dted = [
+        path
+        for path in sorted(source_dir.rglob("*"))
+        if path.is_file() and path.suffix.lower() in {".dt0", ".dt1", ".dt2"}
+    ]
+    matched = [path for path in all_dted if _dted_matches_aoi(path, tiles)] if tiles else []
+    selected = matched or all_dted
+    selected = selected[: int(os.getenv("DTED_IMPORT_MAX_FILES", "100"))]
+    if not selected:
+        raise RuntimeError("No .dt0/.dt1/.dt2 files found in DTED_SOURCE_DIR.")
+
+    package_path = _package_dir(package_id)
+    raw_dir = package_path / "rasters" / "dted" / "raw"
+    tif_dir = package_path / "rasters" / "dted" / "geotiff"
+    gdal_translate = shutil.which("gdal_translate")
+    raw_files: list[dict[str, object]] = []
+    converted_files: list[dict[str, object]] = []
+    records: list[dict[str, object]] = []
+    conversion_errors: list[str] = []
+    for src in selected:
+        raw_target = raw_dir / src.name
+        raw_target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, raw_target)
+        raw_record = {
+            "source_name": src.name,
+            "relative_path": raw_target.relative_to(package_path).as_posix(),
+            "bytes": raw_target.stat().st_size,
+        }
+        raw_files.append(raw_record)
+        if gdal_translate:
+            tif_target = tif_dir / f"{src.stem}.tif"
+            tif_target.parent.mkdir(parents=True, exist_ok=True)
+            ok, output = _run_subprocess([gdal_translate, str(raw_target), str(tif_target)])
+            if ok and tif_target.exists():
+                converted_files.append(
+                    {
+                        "source_name": src.name,
+                        "relative_path": tif_target.relative_to(package_path).as_posix(),
+                        "bytes": tif_target.stat().st_size,
+                        "query_url": f"/api/source-package/{package_id}/query/terrain/files/{tif_target.relative_to(package_path).as_posix()}",
+                    }
+                )
+                records.append(
+                    _artifact_record(
+                        package_id=package_id,
+                        operation=operation,
+                        path=tif_target,
+                        artifact_type="dted_geotiff_dem",
+                        output_format="GeoTIFF DEM converted from DTED",
+                        query_interfaces=["sample_dem(lat, lon)", "read_window(west, south, east, north)", "rasterio.open()"],
+                        feeds_algorithms=["terrain_derivatives", "raster_cost_distance", "viewshed"],
+                        metadata={"source_dted": raw_record["relative_path"]},
+                    )
+                )
+            elif len(conversion_errors) < 10:
+                conversion_errors.append(f"{src.name}: {output}")
+
+    index_path = _artifact_path(package_id, operation.get("local_artifact"))
+    _write_json(
+        index_path,
+        {
+            "source_dir": str(source_dir),
+            "raw_files": raw_files,
+            "converted_files": converted_files,
+            "gdal_translate": bool(gdal_translate),
+            "conversion_errors": conversion_errors,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    records.append(
+        _artifact_record(
+            package_id=package_id,
+            operation=operation,
+            path=index_path,
+            artifact_type="dted_geotiff_index",
+            output_format="JSON DTED import index",
+            query_interfaces=["terrain_artifacts()", "terrain_file(relative_path)", "gdalinfo"],
+            feeds_algorithms=["terrain_derivatives", "raster_cost_distance", "viewshed"],
+            metadata={
+                "raw_file_count": len(raw_files),
+                "converted_file_count": len(converted_files),
+                "gdal_translate": bool(gdal_translate),
+                "conversion_errors": conversion_errors,
+            },
+        )
+    )
+    return records
+
+
+async def _execute_operation(
+    client: httpx.AsyncClient,
+    *,
+    package_id: str,
+    manifest: dict[str, object],
+    operation: dict[str, object],
+) -> list[dict[str, object]]:
+    operation_id = str(operation.get("id", ""))
+    if operation_id == "naip_aws_public_prefix":
+        return await _execute_naip_aws_prefix(
+            client,
+            package_id=package_id,
+            operation=operation,
+        )
+    if operation_id == "naip_earthexplorer_geotiff_import":
+        return await _execute_naip_earthexplorer_import(
+            package_id=package_id,
+            operation=operation,
+        )
+    if operation_id == "osm_geofabrik_pbf":
+        return await _execute_osm_geofabrik_pbf(
+            client,
+            package_id=package_id,
+            operation=operation,
+        )
+    if operation_id == "copernicus_dem_glo30_cog":
+        return await _execute_copernicus_dem_cogs(
+            client,
+            package_id=package_id,
+            operation=operation,
+        )
+    if operation_id == "dted_earthexplorer_import_convert":
+        return await _execute_dted_import_convert(
+            package_id=package_id,
+            operation=operation,
+        )
+    if operation_id in {"usgs_imagery_tile_cache", "nrl_naip_tile_cache"}:
+        return await _execute_xyz_tile_cache(
+            client,
+            package_id=package_id,
+            operation=operation,
+        )
+    if operation_id == "sentinel_2_stac_cog":
+        return await _execute_sentinel2_stac_cogs(
+            client,
+            package_id=package_id,
+            operation=operation,
+        )
+    if operation_id == "cesium_ion_archive_download":
+        return await _execute_cesium_archive_download(
+            client,
+            package_id=package_id,
+            manifest=manifest,
+            operation=operation,
+        )
+    if operation_id == "cesium_ion_clip_create_download":
+        return await _execute_cesium_clip_create_download(
+            client,
+            package_id=package_id,
+            manifest=manifest,
+            operation=operation,
+        )
+    if operation_id == "esri_world_imagery_export_tiles":
+        return [
+            await _execute_esri_imagery_export(
+                client,
+                package_id=package_id,
+                manifest=manifest,
+                operation=operation,
+            )
+        ]
+    if operation_id == "esri_world_elevation_export_image_tiff":
+        return await _execute_esri_terrain_export(
+            client,
+            package_id=package_id,
+            manifest=manifest,
+            operation=operation,
+        )
+    if operation_id == "esri_world_elevation_get_samples":
+        return [
+            await _execute_esri_samples(
+                client,
+                package_id=package_id,
+                operation=operation,
+            )
+        ]
+    return []
+
+
+async def _execute_package_job(package_id: str, manifest: dict[str, object]) -> None:
+    status = _load_package_status(package_id)
+    status["state"] = "running"
+    status["message"] = "Downloading selected sources to the Jetson package root."
+    _save_package_status(package_id, status)
+
+    registry = _load_artifact_registry(package_id)
+    timeout = httpx.Timeout(REQUEST_TIMEOUT_S, connect=20.0)
+    try:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            for operation in manifest.get("download_operations", []):
+                if not isinstance(operation, dict):
+                    continue
+                operation_id = str(operation.get("id", ""))
+                _update_operation_status(
+                    status,
+                    operation_id,
+                    state="running",
+                    message="Downloading on Jetson.",
+                )
+                _save_package_status(package_id, status)
+                try:
+                    artifacts = await _execute_operation(
+                        client,
+                        package_id=package_id,
+                        manifest=manifest,
+                        operation=operation,
+                    )
+                    if not artifacts:
+                        _update_operation_status(
+                            status,
+                            operation_id,
+                            state="skipped",
+                            message="No executable downloader is implemented for this supplemental source.",
+                        )
+                        continue
+                    registry["artifacts"].extend(artifacts)
+                    _save_artifact_registry(package_id, registry)
+                    bytes_written = sum(int(artifact.get("bytes") or 0) for artifact in artifacts)
+                    artifact_paths = ", ".join(str(artifact.get("relative_path")) for artifact in artifacts)
+                    _update_operation_status(
+                        status,
+                        operation_id,
+                        state="succeeded",
+                        message="Saved to Jetson package root.",
+                        bytes_written=bytes_written,
+                        artifact_path=artifact_paths,
+                    )
+                    _save_package_status(package_id, status)
+                except Exception as error:
+                    _update_operation_status(
+                        status,
+                        operation_id,
+                        state="failed",
+                        message=str(error),
+                    )
+                    status["state"] = "failed"
+                    status["message"] = str(error)
+                    _save_package_status(package_id, status)
+                    return
+        status["state"] = "succeeded"
+        status["message"] = "Package downloads completed on Jetson."
+        _save_package_status(package_id, status)
+    finally:
+        PACKAGE_TASKS.pop(package_id, None)
+
+
+def _artifact_file(package_id: str, artifact: dict[str, Any]) -> Path:
+    package_path = _package_dir(package_id)
+    relative = str(artifact.get("relative_path") or "").replace("\\", "/")
+    path = (package_path / relative).resolve()
+    if package_path not in (path, *path.parents):
+        raise HTTPException(status_code=400, detail="Artifact path escapes package root.")
+    return path
+
+
+def _package_file_response(
+    package_id: str,
+    relative_path: str,
+    *,
+    allowed_roots: tuple[str, ...],
+) -> FileResponse:
+    package_id = _safe_package_id(package_id)
+    if _load_package_manifest(package_id) is None:
+        raise HTTPException(status_code=404, detail="Source package manifest not found.")
+    package_path = _package_dir(package_id)
+    clean_parts = [
+        part
+        for part in relative_path.replace("\\", "/").split("/")
+        if part and part not in {".", ".."}
+    ]
+    if not clean_parts:
+        raise HTTPException(status_code=400, detail="Artifact file path is required.")
+    target = (package_path / Path(*clean_parts)).resolve()
+    allowed = [(package_path / root).resolve() for root in allowed_roots]
+    if package_path not in (target, *target.parents) or not any(
+        root in (target, *target.parents) for root in allowed
+    ):
+        raise HTTPException(status_code=400, detail="Artifact file path is outside the allowed package roots.")
+    if not target.exists() or not target.is_file():
+        raise HTTPException(status_code=404, detail="Artifact file not found.")
+    return FileResponse(target)
+
+
+def _registry_artifacts_by_prefix(
+    package_id: str,
+    *,
+    source_ids: set[str] | None = None,
+    artifact_types: set[str] | None = None,
+) -> list[dict[str, object]]:
+    registry = _load_artifact_registry(package_id)
+    artifacts: list[dict[str, object]] = []
+    for artifact in registry.get("artifacts", []):
+        if not isinstance(artifact, dict):
+            continue
+        if source_ids is not None and str(artifact.get("source_id")) not in source_ids:
+            continue
+        if artifact_types is not None and str(artifact.get("artifact_type")) not in artifact_types:
+            continue
+        artifacts.append(artifact)
+    return artifacts
+
+
+def _find_terrain_artifact(package_id: str) -> dict[str, Any] | None:
+    registry = _load_artifact_registry(package_id)
+    artifacts = registry.get("artifacts", [])
+    priority = {
+        "cloud_optimized_geotiff_dem": 0,
+        "geotiff_dem": 1,
+        "copernicus_dem_cog": 1,
+        "dted_geotiff_dem": 1,
+        "elevation_grid_json": 2,
+        "elevation_samples_json": 3,
+    }
+    terrain = [
+        artifact
+        for artifact in artifacts
+        if isinstance(artifact, dict)
+        and artifact.get("artifact_type") in priority
+        and artifact.get("source_id")
+        in {"esri_world_elevation", "copernicus_dem", "dted_earth_explorer", "test_dem", None}
+    ]
+    terrain.sort(key=lambda item: priority.get(str(item.get("artifact_type")), 99))
+    return terrain[0] if terrain else None
+
+
+def _grid_bbox_from_artifact(artifact: dict[str, Any]) -> dict[str, float] | None:
+    metadata = artifact.get("metadata") if isinstance(artifact.get("metadata"), dict) else {}
+    bbox = metadata.get("bbox") if isinstance(metadata, dict) else None
+    if isinstance(bbox, str):
+        parts = [part.strip() for part in bbox.split(",")]
+        if len(parts) == 4:
+            try:
+                return {
+                    "west": float(parts[0]),
+                    "south": float(parts[1]),
+                    "east": float(parts[2]),
+                    "north": float(parts[3]),
+                }
+            except ValueError:
+                return None
+    if isinstance(bbox, dict):
+        try:
+            return {
+                "west": float(bbox["west"]),
+                "south": float(bbox["south"]),
+                "east": float(bbox["east"]),
+                "north": float(bbox["north"]),
+            }
+        except (KeyError, TypeError, ValueError):
+            return None
+    return None
+
+
+def _load_json_grid(path: Path) -> tuple[list[list[float]], dict[str, float] | None, float]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    grid = payload.get("elevation_grid") or payload.get("elevation") or payload.get("grid")
+    if not isinstance(grid, list):
+        raise RuntimeError("JSON terrain artifact does not contain an elevation grid.")
+    numeric = [[float(value) for value in row] for row in grid]
+    bbox = payload.get("bbox") if isinstance(payload.get("bbox"), dict) else None
+    cell_size = float(payload.get("cell_size_m") or 30.0)
+    return numeric, bbox, cell_size
+
+
+def _load_raster_grid(path: Path, max_cells: int = 250000) -> tuple[list[list[float]], dict[str, float] | None, float]:
+    try:
+        import rasterio
+    except ImportError as error:
+        raise RuntimeError("rasterio is required to query GeoTIFF/COG terrain artifacts.") from error
+    with rasterio.open(path) as dataset:
+        width = dataset.width
+        height = dataset.height
+        if width * height > max_cells:
+            scale = math.sqrt((width * height) / max_cells)
+            out_width = max(1, int(width / scale))
+            out_height = max(1, int(height / scale))
+            data = dataset.read(1, out_shape=(out_height, out_width), masked=True)
+        else:
+            data = dataset.read(1, masked=True)
+        rows = data.filled(float("nan")).tolist()
+        bounds = dataset.bounds
+        bbox = {
+            "west": float(bounds.left),
+            "south": float(bounds.bottom),
+            "east": float(bounds.right),
+            "north": float(bounds.top),
+        }
+        cell_size = abs(float(dataset.transform.a)) or 30.0
+        return rows, bbox, cell_size
+
+
+def _load_package_terrain_grid(
+    package_id: str,
+    *,
+    max_cells: int = 250000,
+) -> tuple[list[list[float]], dict[str, float] | None, float, dict[str, Any]]:
+    artifact = _find_terrain_artifact(package_id)
+    if artifact is None:
+        raise HTTPException(status_code=404, detail="No queryable terrain artifact is registered.")
+    path = _artifact_file(package_id, artifact)
+    artifact_type = str(artifact.get("artifact_type") or "")
+    if artifact_type == "elevation_grid_json" or path.suffix.lower() == ".json":
+        grid, bbox, cell_size = _load_json_grid(path)
+        return grid, bbox or _grid_bbox_from_artifact(artifact), cell_size, artifact
+    grid, bbox, cell_size = _load_raster_grid(path, max_cells=max_cells)
+    return grid, bbox or _grid_bbox_from_artifact(artifact), cell_size, artifact
+
+
+def _coord_to_cell(
+    lat: float,
+    lon: float,
+    bbox: dict[str, float] | None,
+    rows: int,
+    cols: int,
+) -> tuple[int, int]:
+    if not bbox or rows <= 0 or cols <= 0:
+        return 0, 0
+    lon_span = bbox["east"] - bbox["west"]
+    lat_span = bbox["north"] - bbox["south"]
+    if lon_span == 0 or lat_span == 0:
+        return 0, 0
+    col = int(round((lon - bbox["west"]) / lon_span * (cols - 1)))
+    row = int(round((bbox["north"] - lat) / lat_span * (rows - 1)))
+    return max(0, min(rows - 1, row)), max(0, min(cols - 1, col))
+
+
+def _cell_to_coord(
+    row: int,
+    col: int,
+    bbox: dict[str, float] | None,
+    rows: int,
+    cols: int,
+) -> tuple[float, float]:
+    if not bbox or rows <= 1 or cols <= 1:
+        return 0.0, 0.0
+    lon = bbox["west"] + (col / (cols - 1)) * (bbox["east"] - bbox["west"])
+    lat = bbox["north"] - (row / (rows - 1)) * (bbox["north"] - bbox["south"])
+    return lat, lon
+
+
+def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    radius = 6_371_000.0
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    d_phi = math.radians(lat2 - lat1)
+    d_lambda = math.radians(lon2 - lon1)
+    a = math.sin(d_phi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(d_lambda / 2) ** 2
+    return 2 * radius * math.asin(math.sqrt(a))
+
+
+def _route_hash(feature: dict[str, Any]) -> str:
+    return hashlib.sha256(json.dumps(feature, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _feature_distance_m(feature: dict[str, Any]) -> float:
+    coords = feature.get("geometry", {}).get("coordinates", [])
+    total = 0.0
+    for left, right in zip(coords, coords[1:]):
+        total += _haversine_m(float(left[1]), float(left[0]), float(right[1]), float(right[0]))
+    return total
+
+
+def _run_algorithm(package_id: str, request: AlgorithmRequest) -> dict[str, Any]:
+    from llm_dev_kmh import geo_algorithms
+
+    algorithm_id = request.algorithm_id
+    params = request.parameters
+    if algorithm_id == "sar_sector_partition":
+        center = params.get("center") if isinstance(params.get("center"), dict) else {}
+        return {
+            "algorithm_id": algorithm_id,
+            "sectors": geo_algorithms.radial_sar_sectors(
+                float(center.get("lat", 0.0)),
+                float(center.get("lon", 0.0)),
+                float(params.get("radius_m", 1000.0)),
+                int(params.get("sector_count", 8)),
+            ),
+        }
+
+    grid, bbox, cell_size, artifact = _load_package_terrain_grid(package_id)
+    rows = len(grid)
+    cols = len(grid[0]) if rows else 0
+
+    if algorithm_id in {"terrain_derivatives", "slope_aspect_roughness"}:
+        return {
+            "algorithm_id": algorithm_id,
+            "artifact": artifact.get("relative_path"),
+            "bbox": bbox,
+            "cell_size_m": cell_size,
+            "layers": geo_algorithms.derive_terrain_layers(grid, cell_size_m=cell_size),
+        }
+    if algorithm_id == "flow_accumulation_d8":
+        return {
+            "algorithm_id": algorithm_id,
+            "artifact": artifact.get("relative_path"),
+            "bbox": bbox,
+            "accumulation": geo_algorithms.flow_accumulation_d8(grid, cell_size_m=cell_size),
+        }
+    if algorithm_id == "viewshed":
+        observer = params.get("observer_cell") or [rows // 2, cols // 2]
+        return {
+            "algorithm_id": algorithm_id,
+            "artifact": artifact.get("relative_path"),
+            "bbox": bbox,
+            "visible": geo_algorithms.viewshed(
+                grid,
+                (int(observer[0]), int(observer[1])),
+                cell_size_m=cell_size,
+                max_radius_cells=params.get("max_radius_cells"),
+            ),
+        }
+    if algorithm_id == "raster_cost_distance":
+        terrain = geo_algorithms.derive_terrain_layers(grid, cell_size_m=cell_size)
+        cost = geo_algorithms.build_walking_cost_surface(
+            terrain["slope_degrees"],
+            max_slope_deg=float(params.get("max_slope_deg", 35.0)),
+        )
+        start = params.get("start_cell") or [0, 0]
+        target = params.get("target_cell")
+        result = geo_algorithms.raster_cost_distance(cost, [(int(start[0]), int(start[1]))])
+        payload: dict[str, Any] = {
+            "algorithm_id": algorithm_id,
+            "artifact": artifact.get("relative_path"),
+            "bbox": bbox,
+            "distance": result.distance,
+        }
+        if target:
+            payload["path"] = geo_algorithms.backtrack_least_cost_path(
+                result,
+                (int(target[0]), int(target[1])),
+            )
+        return payload
+    if algorithm_id == "sar_probability_surface":
+        last_known = params.get("last_known_cell") or [rows // 2, cols // 2]
+        return {
+            "algorithm_id": algorithm_id,
+            "bbox": bbox,
+            "probability": geo_algorithms.sar_probability_surface(
+                rows,
+                cols,
+                (int(last_known[0]), int(last_known[1])),
+                sigma_cells=float(params.get("sigma_cells", 6.0)),
+            ),
+        }
+    if algorithm_id == "route_score":
+        return {
+            "algorithm_id": algorithm_id,
+            "score": geo_algorithms.score_route(
+                normalized_time=float(params.get("normalized_time", 0.5)),
+                normalized_energy=float(params.get("normalized_energy", 0.5)),
+                hazard_exposure=float(params.get("hazard_exposure", 0.2)),
+                data_uncertainty=float(params.get("data_uncertainty", 0.2)),
+                resource_value=float(params.get("resource_value", 0.0)),
+                rescue_visibility=float(params.get("rescue_visibility", 0.0)),
+            ),
+        }
+    raise HTTPException(status_code=400, detail=f"Unsupported algorithm_id: {algorithm_id}")
+
+
+def _build_route_from_package(package_id: str, request: PackageRouteRequest) -> dict[str, Any]:
+    from llm_dev_kmh import geo_algorithms
+
+    route_id = f"TERA-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{uuid4().hex[:6]}"
+    coordinates = [[request.start.lon, request.start.lat], [request.end.lon, request.end.lat]]
+    cost_breakdown: dict[str, float] = {
+        "distance_m": _haversine_m(request.start.lat, request.start.lon, request.end.lat, request.end.lon),
+        "time_s": _haversine_m(request.start.lat, request.start.lon, request.end.lat, request.end.lon) / 1.1,
+        "elevation_gain_m": 0.0,
+    }
+    provenance: dict[str, Any] = {"package_id": package_id, "terrain_artifact": None}
+
+    try:
+        grid, bbox, cell_size, artifact = _load_package_terrain_grid(package_id)
+        rows = len(grid)
+        cols = len(grid[0]) if rows else 0
+        start_cell = _coord_to_cell(request.start.lat, request.start.lon, bbox, rows, cols)
+        end_cell = _coord_to_cell(request.end.lat, request.end.lon, bbox, rows, cols)
+        terrain = geo_algorithms.derive_terrain_layers(grid, cell_size_m=cell_size)
+        cost_surface = geo_algorithms.build_walking_cost_surface(
+            terrain["slope_degrees"],
+            max_slope_deg=35.0 if "max_slope_35" in request.avoid else 45.0,
+        )
+        cost_result = geo_algorithms.raster_cost_distance(cost_surface, [start_cell])
+        path = geo_algorithms.backtrack_least_cost_path(cost_result, end_cell)
+        if path:
+            coordinates = []
+            elevation_gain = 0.0
+            previous_elevation = grid[path[0][0]][path[0][1]]
+            for row, col in path:
+                lat, lon = _cell_to_coord(row, col, bbox, rows, cols)
+                coordinates.append([lon, lat])
+                elevation = grid[row][col]
+                if math.isfinite(elevation) and math.isfinite(previous_elevation):
+                    elevation_gain += max(0.0, elevation - previous_elevation)
+                previous_elevation = elevation
+            distance_m = sum(
+                _haversine_m(left[1], left[0], right[1], right[0])
+                for left, right in zip(coordinates, coordinates[1:])
+            )
+            cost_breakdown = {
+                "distance_m": distance_m,
+                "time_s": distance_m / 1.1,
+                "elevation_gain_m": elevation_gain,
+                "raster_cost": float(cost_result.distance[end_cell[0]][end_cell[1]]),
+            }
+            provenance = {
+                "package_id": package_id,
+                "terrain_artifact": artifact.get("relative_path"),
+                "cell_size_m": cell_size,
+                "routing_method": "raster_cost_distance",
+            }
+    except HTTPException:
+        pass
+    except Exception as error:
+        provenance["terrain_route_error"] = str(error)
+
+    feature = {
+        "type": "Feature",
+        "geometry": {"type": "LineString", "coordinates": coordinates},
+        "properties": {
+            "route_id": route_id,
+            "profile": request.profile,
+            "avoid": request.avoid,
+            "package_id": package_id,
+        },
+    }
+    route_hash = _route_hash(feature)
+    response = {
+        "route_id": route_id,
+        "route_hash": route_hash,
+        "route": feature,
+        "waypoints": [
+            {"lat": request.start.lat, "lon": request.start.lon, "label": "Start"},
+            {"lat": request.end.lat, "lon": request.end.lon, "label": "End"},
+        ],
+        "rationale": (
+            f"Generated {request.profile.replace('_', ' ')} route from Jetson package "
+            f"{package_id}; distance {cost_breakdown['distance_m'] / 1000.0:.2f} km."
+        ),
+        "cost_breakdown": cost_breakdown,
+        "provenance": provenance,
+        "trust": {
+            "schema_valid": True,
+            "policy_valid": True,
+            "operator_approved": False,
+            "signature_valid": False,
+            "untrusted_inputs_used": False,
+            "trust_status": "needs_review",
+        },
+    }
+    routes_dir = _routes_dir(package_id)
+    _write_json(routes_dir / f"{route_id}.json", response)
+    return response
+
+
+def _load_route_artifact(package_id: str, route_id: str) -> dict[str, Any]:
+    path = _routes_dir(package_id) / f"{_safe_package_id(route_id)}.json"
+    route = _read_json(path)
+    if route is None:
+        raise HTTPException(status_code=404, detail="Route artifact not found.")
+    return route
+
+
+def _build_cot_xml(
+    *,
+    uid: str,
+    cot_type: str,
+    lat: float,
+    lon: float,
+    route: dict[str, Any],
+) -> str:
+    now = datetime.now(timezone.utc)
+    now_text = now.isoformat().replace("+00:00", "Z")
+    stale_text = datetime.fromtimestamp(now.timestamp() + 3600, timezone.utc).isoformat().replace("+00:00", "Z")
+    root = ET.Element(
+        "event",
+        {
+            "version": "2.0",
+            "uid": uid,
+            "type": cot_type,
+            "how": "m-g",
+            "time": now_text,
+            "start": now_text,
+            "stale": stale_text,
+        },
+    )
+    ET.SubElement(
+        root,
+        "point",
+        {
+            "lat": f"{lat:.7f}",
+            "lon": f"{lon:.7f}",
+            "hae": "9999999.0",
+            "ce": "9999999.0",
+            "le": "9999999.0",
+        },
+    )
+    detail = ET.SubElement(root, "detail")
+    route_el = ET.SubElement(detail, "route")
+    for index, coordinate in enumerate(route.get("geometry", {}).get("coordinates", [])):
+        ET.SubElement(
+            route_el,
+            "point",
+            {
+                "lat": f"{float(coordinate[1]):.7f}",
+                "lon": f"{float(coordinate[0]):.7f}",
+                "index": str(index),
+            },
+        )
+    return ET.tostring(root, encoding="unicode")
+
+
+def _sign_cot_xml(
+    *,
+    uid: str,
+    lat: float,
+    lon: float,
+    route: dict[str, Any],
+    rationale: str,
+    mission_type: str,
+    cot_xml: str,
+) -> tuple[str, dict[str, Any]]:
+    try:
+        from crypto.cot_signer import CotRoute, embed_signature_in_cot_xml, sign_cot
+
+        signed = sign_cot(
+            CotRoute(
+                uid=uid,
+                lat=lat,
+                lon=lon,
+                route_geojson=route,
+                rationale=rationale,
+                mission_type=mission_type,
+            )
+        )
+        return embed_signature_in_cot_xml(cot_xml, signed), signed
+    except ImportError:
+        pass
+
+    try:
+        from crypto.ml_dsa_signer import create_signer
+    except ImportError as error:
+        raise HTTPException(status_code=503, detail="TERA signing modules are unavailable.") from error
+
+    payload = {
+        "uid": uid,
+        "lat": lat,
+        "lon": lon,
+        "route_hash": hashlib.sha256(json.dumps(route, sort_keys=True).encode()).hexdigest(),
+        "rationale": rationale,
+        "mission_type": mission_type,
+    }
+    try:
+        signed = create_signer(os.getenv("WAYFINDER_KEY_ID", "wayfinder-device-001")).sign(payload).to_dict()
+    except RuntimeError as error:
+        dev_key = os.getenv("WAYFINDER_HMAC_KEY", "").encode("utf-8")
+        if not dev_key:
+            raise HTTPException(status_code=503, detail="TERA signing dependencies are unavailable.") from error
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        signed = {
+            "payload": payload,
+            "signature": hmac.new(dev_key, canonical, hashlib.sha256).hexdigest(),
+            "key_id": os.getenv("WAYFINDER_KEY_ID", "wayfinder-device-001"),
+            "algorithm": "HMAC-SHA256-dev-fallback",
+            "timestamp": datetime.now(timezone.utc).timestamp(),
+            "payload_hash": hashlib.sha256(canonical).hexdigest(),
+        }
+    root = ET.fromstring(cot_xml)
+    detail = root.find("detail")
+    if detail is None:
+        detail = ET.SubElement(root, "detail")
+    for old in detail.findall("wayfinder"):
+        detail.remove(old)
+    wayfinder = ET.SubElement(detail, "wayfinder")
+    ET.SubElement(wayfinder, "signature").text = signed["signature"]
+    ET.SubElement(wayfinder, "key_id").text = signed["key_id"]
+    ET.SubElement(wayfinder, "algorithm").text = signed["algorithm"]
+    ET.SubElement(wayfinder, "timestamp").text = str(signed["timestamp"])
+    ET.SubElement(wayfinder, "payload_hash").text = signed["payload_hash"]
+    ET.SubElement(wayfinder, "payload_json").text = json.dumps(
+        signed["payload"],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return ET.tostring(root, encoding="unicode"), signed
+
+
 def _normalize_for_match(text: str) -> str:
     expanded = text.lower()
     for canonical, aliases in KEYWORD_EXPANSIONS.items():
@@ -1090,8 +4704,15 @@ def _infer_source_recommendation(
     questions: list[str] = []
     rationale: list[str] = []
 
-    _append_unique(optional_ids, "esri_world_imagery", "osm_basemap")
-    rationale.append("Esri imagery and OSM basemap stay as lightweight preview/context layers.")
+    _append_unique(required_ids, "naip" if is_us_context else "sentinel_2")
+    _append_unique(optional_ids, "cesium_world_imagery", "osm_basemap")
+    if is_us_context:
+        _append_unique(optional_ids, "usgs_imagery_only", "nrl_naip_conus")
+    rationale.append(
+        "NAIP is the high-detail U.S. imagery default when the AO is in the U.S.; "
+        "Sentinel-2 remains the global free imagery fallback. Cesium imagery stays "
+        "as a token-backed preview stream."
+    )
 
     needs_routing = _text_has_any(
         prompt_text,
@@ -1113,6 +4734,7 @@ def _infer_source_recommendation(
         prompt_text,
         ("terrain", "slope", "ridge", "mountain", "valley", "steep", "exposed", "viewshed"),
     )
+    needs_dted = _text_has_any(prompt_text, ("dted", "dt2", "earth explorer", "earthexplorer"))
     needs_water = _text_has_any(
         prompt_text, ("water", "stream", "river", "spring", "lake", "potable", "hydrate")
     )
@@ -1135,18 +4757,39 @@ def _infer_source_recommendation(
     needs_current_imagery = _text_has_any(
         prompt_text, ("current", "recent", "latest", "flood", "burn", "changed", "cloud")
     )
+    needs_cesium_archive = "cesium" in prompt_text and _text_has_any(
+        prompt_text, ("download", "offline", "archive", "export", "jetson", "local")
+    )
+
+    if needs_cesium_archive:
+        _append_unique(required_ids, "cesium_ion_archive")
+        rationale.append(
+            "Cesium offline use is handled through ion archive/export downloads "
+            "to the Jetson, not by scraping Cesium World stream tiles."
+        )
 
     if needs_routing:
         _append_unique(required_ids, "osm_extract")
         rationale.append("OSM PBF is required for the local routable graph and POI/feature lookup.")
 
     if needs_terrain:
-        _append_unique(required_ids, "usgs_3dep" if is_us_context else "copernicus_dem")
-        _append_unique(required_ids, "esri_world_elevation")
+        _append_unique(required_ids, "copernicus_dem")
+        if is_us_context:
+            _append_unique(optional_ids, "dted_earth_explorer", "usgs_3dep")
+        else:
+            _append_unique(optional_ids, "dted_earth_explorer")
         _append_unique(optional_ids, "cesium_world_terrain")
         rationale.append(
-            "An analysis DEM plus queryable Esri terrain fallback is required "
-            "for slope, exposure, hydrology, and cost surfaces."
+            "Copernicus GLO-30 COGs are the no-account terrain default for slope, "
+            "exposure, hydrology, and cost surfaces; staged EarthExplorer DTED "
+            "supplements it when available."
+        )
+
+    if needs_dted:
+        _append_unique(required_ids, "dted_earth_explorer")
+        rationale.append(
+            "DTED was explicitly requested, so staged EarthExplorer DTED import is "
+            "included; set DTED_SOURCE_DIR on the Jetson before executing the package."
         )
 
     if needs_landcover:
@@ -1160,7 +4803,6 @@ def _infer_source_recommendation(
         _append_unique(required_ids, "usgs_3dhp" if is_us_context else "hydrosheds")
         if is_us_context:
             _append_unique(optional_ids, "nwis")
-        _append_unique(optional_ids, "sentinel_2")
         rationale.append(
             "Hydrography is required for water-source and drainage queries; "
             "imagery/observations are optional confidence boosters."
@@ -1198,12 +4840,13 @@ def _infer_source_recommendation(
         _append_unique(required_ids, "viewshed_surfaces")
         _append_unique(optional_ids, "fcc_towers" if is_us_context else "osm_towers", "osm_towers")
         if not needs_terrain:
-            _append_unique(required_ids, "usgs_3dep" if is_us_context else "copernicus_dem")
-            _append_unique(required_ids, "esri_world_elevation")
+            _append_unique(required_ids, "copernicus_dem")
+            if is_us_context:
+                _append_unique(optional_ids, "dted_earth_explorer", "usgs_3dep")
         rationale.append("Signal planning requires DEM-derived viewsheds plus tower/high-ground candidates.")
 
     if needs_current_imagery and not needs_water and not needs_hazards:
-        _append_unique(optional_ids, "sentinel_2", "landsat_collection_2")
+        _append_unique(optional_ids, "landsat_collection_2")
         if is_us_context:
             _append_unique(optional_ids, "naip")
         rationale.append(
@@ -1275,7 +4918,7 @@ def _infer_source_recommendation(
     selected_ids = []
     preview_ids = [
         source_id
-        for source_id in ("esri_world_imagery", "osm_basemap")
+        for source_id in ("cesium_world_imagery", "usgs_imagery_only", "osm_basemap")
         if source_id in optional_ids
     ]
     _append_unique(selected_ids, *required_ids, *preview_ids)
@@ -1893,8 +5536,21 @@ def _normalize_claude_model(model: str | None) -> str:
     return CLAUDE_MODEL_ALIASES.get(compact, CLAUDE_MODEL_ALIASES.get(candidate.lower(), candidate))
 
 
-def _build_claude_payload(request: PromptRequest) -> tuple[str, dict[str, object]]:
-    model = _normalize_claude_model(request.cloud_model or request.model or CLAUDE_MODEL)
+def _claude_model_candidates(preferred_model: str | None) -> list[str]:
+    candidates = [
+        _normalize_claude_model(preferred_model),
+        *CLAUDE_MODEL_FALLBACKS,
+    ]
+    deduped: list[str] = []
+    for candidate in candidates:
+        if candidate and candidate not in deduped:
+            deduped.append(candidate)
+    return deduped
+
+
+def _build_claude_payload_for_model(
+    request: PromptRequest, model: str
+) -> dict[str, object]:
     payload: dict[str, object] = {
         "model": model,
         "max_tokens": 900,
@@ -1912,7 +5568,12 @@ def _build_claude_payload(request: PromptRequest) -> tuple[str, dict[str, object
             }
         ],
     }
-    return model, payload
+    return payload
+
+
+def _build_claude_payload(request: PromptRequest) -> tuple[str, dict[str, object]]:
+    model = _normalize_claude_model(request.cloud_model or request.model or CLAUDE_MODEL)
+    return model, _build_claude_payload_for_model(request, model)
 
 
 def _extract_claude_response_text(data: dict[str, object]) -> str:
@@ -1940,53 +5601,64 @@ async def _post_claude_message(request: PromptRequest) -> PromptResponse:
             ),
         )
 
-    model, payload = _build_claude_payload(request)
+    requested_model = _normalize_claude_model(
+        request.cloud_model or request.model or CLAUDE_MODEL
+    )
     timeout = httpx.Timeout(REQUEST_TIMEOUT_S, connect=10.0)
     headers = {
         "anthropic-version": ANTHROPIC_VERSION,
         "content-type": "application/json",
         "x-api-key": api_key,
     }
+    model_errors: list[str] = []
 
-    try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.post(ANTHROPIC_API_URL, headers=headers, json=payload)
-            response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        body = exc.response.text[:500]
-        log.error(
-            "claude_http_error",
-            status_code=exc.response.status_code,
-            body=body,
-            model=model,
-        )
-        if exc.response.status_code in {401, 403}:
-            detail = (
-                f"Claude API rejected the key or account access for {model}. "
-                "Check the key in Model Provider or set ANTHROPIC_API_KEY on the server."
+    for model in _claude_model_candidates(requested_model):
+        payload = _build_claude_payload_for_model(request, model)
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.post(
+                    ANTHROPIC_API_URL, headers=headers, json=payload
+                )
+                response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            body = exc.response.text[:500]
+            log.error(
+                "claude_http_error",
+                status_code=exc.response.status_code,
+                body=body,
+                model=model,
             )
-        elif exc.response.status_code == 400 and "model" in body.lower():
-            detail = (
-                f"Claude API rejected model {model}. Select Claude Sonnet 4.6 "
-                "or another listed model in Model Provider."
-            )
-        else:
+            if exc.response.status_code in {401, 403}:
+                detail = (
+                    f"Claude API rejected the key or account access for {model}. "
+                    "Check the key in Model Provider or set ANTHROPIC_API_KEY on the server."
+                )
+                raise HTTPException(status_code=502, detail=detail) from exc
+            if exc.response.status_code == 400 and "model" in body.lower():
+                model_errors.append(f"{model}: {body}")
+                continue
             detail = f"Claude API returned {exc.response.status_code}: {body}"
-        raise HTTPException(status_code=502, detail=detail) from exc
-    except httpx.HTTPError as exc:
-        log.error("claude_connection_error", error=str(exc), model=model)
-        raise HTTPException(
-            status_code=502,
-            detail=(
-                "Could not reach Claude API. Check internet connectivity, proxy/firewall "
-                "settings, and the Anthropic API endpoint."
-            ),
-        ) from exc
+            raise HTTPException(status_code=502, detail=detail) from exc
+        except httpx.HTTPError as exc:
+            log.error("claude_connection_error", error=str(exc), model=model)
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    "Could not reach Claude API. Check internet connectivity, "
+                    "proxy/firewall settings, and the Anthropic API endpoint."
+                ),
+            ) from exc
 
-    text = _extract_claude_response_text(response.json())
-    if not text:
-        raise HTTPException(status_code=502, detail="Claude returned an empty response.")
-    return PromptResponse(model=model, response=text)
+        text = _extract_claude_response_text(response.json())
+        if not text:
+            raise HTTPException(status_code=502, detail="Claude returned an empty response.")
+        return PromptResponse(model=model, response=text)
+
+    detail = (
+        "Claude API rejected every configured model candidate. "
+        + " | ".join(model_errors)
+    )
+    raise HTTPException(status_code=502, detail=detail)
 
 
 def _sse_event(payload: dict[str, object]) -> str:
@@ -2605,6 +6277,7 @@ async def health() -> dict[str, str]:
 async def runtime_config() -> RuntimeConfigResponse:
     return RuntimeConfigResponse(
         cesium_ion_token=CESIUM_ION_TOKEN,
+        esri_token_configured=ESRI_TOKEN_CONFIGURED,
         default_model=OLLAMA_MODEL,
         claude_default_model=_normalize_claude_model(CLAUDE_MODEL),
         anthropic_api_key_configured=bool(os.getenv("ANTHROPIC_API_KEY", "").strip()),
@@ -2813,6 +6486,11 @@ async def recommend_source_package(
     return _infer_source_recommendation(request.mission_text, request.map_context)
 
 
+@app.get("/api/storage", response_model=StorageInfoResponse)
+async def get_storage_info() -> StorageInfoResponse:
+    return _storage_info()
+
+
 def _build_package_manifest(
     *,
     package_id: str,
@@ -2821,6 +6499,16 @@ def _build_package_manifest(
     sources: list[SourceOption],
 ) -> dict[str, object]:
     selected_ids = [source.id for source in sources]
+    bounds = _manifest_bounds_from_context(request.map_context)
+    download_operations = _build_source_download_operations(
+        package_id=package_id,
+        sources=sources,
+        bounds=bounds,
+    )
+    jetson_query_contracts = _build_jetson_query_contracts(
+        package_id=package_id,
+        sources=sources,
+    )
     return {
         "package_id": package_id,
         "package_name": package_name,
@@ -2840,21 +6528,40 @@ def _build_package_manifest(
                 "stream_layer": source.stream_layer,
                 "analysis_role": source.analysis_role,
                 "derived_layers": source.derived_layers,
+                "source_url": source.source_url,
+                "license_or_terms": source.license_or_terms,
+                "download_methods": [
+                    method.model_dump(exclude_none=True) for method in source.download_methods
+                ],
+                "jetson_query_formats": [
+                    query_format.model_dump(exclude_none=True)
+                    for query_format in source.jetson_query_formats
+                ],
                 "notes": source.notes,
             }
             for source in sources
         ],
+        "download_operations": download_operations,
+        "jetson_query_contracts": jetson_query_contracts,
+        "deterministic_algorithms": algorithm_catalog(),
         "server_ingest_plan": {
             "store_raw_sources": [
                 source.id
                 for source in sources
-                if source.download_status in {"download-required", "cache-feed"}
+                if source.download_status
+                in {
+                    "download-required",
+                    "cache-feed",
+                    "export-tiles-with-account",
+                }
+                or source.download_methods
             ],
             "cache_display_tiles": [
                 source.id
                 for source in sources
-                if source.download_status == "cache-via-cesium-pipeline"
-                or source.stream_status.startswith("streamable")
+                if source.download_status in {"cache-tiles", "export-tiles-with-account"}
+                or any(method.id.endswith("_tile_cache") for method in source.download_methods)
+                or source.id == "cesium_ion_archive"
             ],
             "generate_derived_layers": sorted(
                 {
@@ -2872,7 +6579,17 @@ def _build_package_manifest(
                 source.id
                 for source in sources
                 if source.category
-                in {"terrain", "land-cover", "imagery-analysis", "hazards", "terrain-display"}
+                in {
+                    "terrain",
+                    "land-cover",
+                    "imagery-analysis",
+                    "hazards",
+                    "terrain-display",
+                    "imagery-terrain-archive",
+                }
+            ],
+            "jetson_queryable_artifacts": [
+                contract["local_path"] for contract in jetson_query_contracts
             ],
         },
         "offline_metadata_required": [
@@ -2910,11 +6627,73 @@ def _download_plan_warnings(
         warnings.append("No AO bounds were provided; downloads must be clipped before ingest.")
     if not any(source.id == "osm_extract" for source in sources):
         warnings.append("OSM PBF extract is not selected, so server-side routable graph work is blocked.")
+    elif shutil.which("osmium") is None:
+        warnings.append(
+            "OSM Geofabrik PBF will download, but osmium is not installed; AO clipping "
+            "will be marked pending and the regional PBF will be registered."
+        )
     if not any(source.category == "terrain" for source in sources):
         warnings.append("No analysis DEM is selected; slope, hydrology, and viewshed queries are blocked.")
+    if any(source.id == "naip" for source in sources):
+        warnings.append(
+            "NAIP AWS prefixes can be large. The manifest caps downloads with NAIP_MAX_FILES "
+            "and the Jetson storage check runs before execution."
+        )
+        if not _env_path("NAIP_EARTHEXPLORER_DIR"):
+            warnings.append(
+                "NAIP_EARTHEXPLORER_DIR is not configured, so EarthExplorer NAIP GeoTIFF "
+                "import is skipped and the AWS public S3 prefix method is used."
+            )
+    if any(source.id == "dted_earth_explorer" for source in sources):
+        if not _env_path("DTED_SOURCE_DIR"):
+            warnings.append(
+                "DTED_SOURCE_DIR is not configured; EarthExplorer DTED import is skipped. "
+                "Use Copernicus DEM GLO-30 for no-account terrain downloads."
+            )
+        elif shutil.which("gdal_translate") is None:
+            warnings.append(
+                "DTED files will be imported, but gdal_translate is not installed; "
+                "raw DTED will be registered without GeoTIFF conversion."
+            )
+    if any(source.id in {"esri_world_imagery", "esri_world_elevation"} for source in sources):
+        if not ESRI_TOKEN_CONFIGURED:
+            warnings.append(
+                "Esri export operations require ESRI_ARCGIS_TOKEN at download time; "
+                "the manifest uses an environment placeholder and does not store secrets."
+            )
+    if any(source.id == "cesium_ion_archive" for source in sources):
+        has_archive_id = bool(_get_cesium_archive_id())
+        has_asset_ids = bool(
+            (
+                os.getenv("CESIUM_ION_ASSET_IDS")
+                or os.getenv("CESIUM_ASSET_IDS")
+                or os.getenv("CESIUM_ION_ASSET_ID")
+                or ""
+            ).strip()
+        )
+        if not _get_cesium_token():
+            warnings.append(
+                "Cesium archive downloads require CESIUM_ION_TOKEN on the Jetson."
+            )
+        if not (has_archive_id or has_asset_ids):
+            warnings.append(
+                "Cesium archive source selected, but no CESIUM_ION_ARCHIVE_ID or "
+                "CESIUM_ION_ASSET_IDS is configured; no Cesium download operation "
+                "will be created."
+            )
+        else:
+            warnings.append(
+                "Cesium downloads use ion archive/export APIs only. The planner will "
+                "not scrape World Imagery or World Terrain stream tiles."
+            )
     if any(source.stream_status.startswith("streamable") for source in sources):
         warnings.append(
             "Streamable layers still need cached tiles or analytical companions for disconnected use."
+        )
+    if any(source.id == "esri_world_imagery" for source in sources):
+        warnings.append(
+            "Esri World Imagery must be exported through the export-enabled service "
+            "for offline use; do not scrape individual streaming tiles."
         )
     return warnings
 
@@ -2935,6 +6714,11 @@ async def plan_source_package(request: DownloadPlanRequest) -> DownloadPlanRespo
         sources=sources,
     )
     PACKAGE_MANIFESTS[package_id] = manifest
+    estimated_bytes = _estimate_manifest_bytes(manifest)
+    storage = _storage_info(package_id)
+    storage_warning = _storage_warning(estimated_bytes, storage)
+    _persist_package_manifest(package_id, manifest)
+    _save_package_status(package_id, _initial_package_status(package_id, manifest))
     return DownloadPlanResponse(
         package_id=package_id,
         package_name=package_name,
@@ -2943,12 +6727,19 @@ async def plan_source_package(request: DownloadPlanRequest) -> DownloadPlanRespo
         manifest=manifest,
         warnings=_download_plan_warnings(request, sources),
         download_url=f"/api/source-package/{package_id}/download",
+        execute_url=f"/api/source-package/{package_id}/execute",
+        status_url=f"/api/source-package/{package_id}/status",
+        artifacts_url=f"/api/source-package/{package_id}/artifacts",
+        estimated_bytes=estimated_bytes,
+        storage_fit=storage_warning is None,
+        storage=storage,
+        storage_warning=storage_warning,
     )
 
 
 @app.get("/api/source-package/{package_id}/download")
 async def download_source_manifest(package_id: str) -> StreamingResponse:
-    manifest = PACKAGE_MANIFESTS.get(package_id)
+    manifest = _load_package_manifest(package_id)
     if manifest is None:
         raise HTTPException(status_code=404, detail="Source package manifest not found.")
 
@@ -2963,6 +6754,335 @@ async def download_source_manifest(package_id: str) -> StreamingResponse:
             "Cache-Control": "no-store",
         },
     )
+
+
+@app.post("/api/source-package/{package_id}/execute", response_model=PackageExecuteResponse)
+async def execute_source_package(package_id: str) -> PackageExecuteResponse:
+    package_id = _safe_package_id(package_id)
+    manifest = _load_package_manifest(package_id)
+    if manifest is None:
+        raise HTTPException(status_code=404, detail="Source package manifest not found.")
+
+    estimated_bytes = _estimate_manifest_bytes(manifest)
+    storage = _storage_info(package_id)
+    storage_warning = _storage_warning(estimated_bytes, storage)
+    if storage_warning is not None:
+        raise HTTPException(status_code=507, detail=storage_warning)
+
+    existing_task = PACKAGE_TASKS.get(package_id)
+    if existing_task is not None and not existing_task.done():
+        status = _load_package_status(package_id)
+        return PackageExecuteResponse(
+            package_id=package_id,
+            state=str(status.get("state", "running")),
+            status_url=f"/api/source-package/{package_id}/status",
+            artifacts_url=f"/api/source-package/{package_id}/artifacts",
+            storage=storage,
+            message="Package download is already running on the Jetson.",
+        )
+
+    status = _load_package_status(package_id)
+    if status.get("state") == "succeeded":
+        return PackageExecuteResponse(
+            package_id=package_id,
+            state="succeeded",
+            status_url=f"/api/source-package/{package_id}/status",
+            artifacts_url=f"/api/source-package/{package_id}/artifacts",
+            storage=storage,
+            message="Package is already downloaded on the Jetson.",
+        )
+
+    task = asyncio.create_task(_execute_package_job(package_id, manifest))
+    PACKAGE_TASKS[package_id] = task
+    status["state"] = "queued"
+    status["message"] = "Package download queued on the Jetson."
+    _save_package_status(package_id, status)
+    return PackageExecuteResponse(
+        package_id=package_id,
+        state="queued",
+        status_url=f"/api/source-package/{package_id}/status",
+        artifacts_url=f"/api/source-package/{package_id}/artifacts",
+        storage=storage,
+        message="Package download queued on the Jetson.",
+    )
+
+
+@app.get("/api/source-package/{package_id}/status")
+async def get_source_package_status(package_id: str) -> dict[str, object]:
+    package_id = _safe_package_id(package_id)
+    status = _load_package_status(package_id)
+    status["storage"] = _storage_info(package_id).model_dump()
+    return status
+
+
+@app.get("/api/source-package/{package_id}/artifacts")
+async def get_source_package_artifacts(package_id: str) -> dict[str, object]:
+    package_id = _safe_package_id(package_id)
+    if _load_package_manifest(package_id) is None:
+        raise HTTPException(status_code=404, detail="Source package manifest not found.")
+    registry = _load_artifact_registry(package_id)
+    registry["storage"] = _storage_info(package_id).model_dump()
+    return registry
+
+
+@app.get("/api/source-package/{package_id}/query/imagery")
+async def query_package_imagery(package_id: str) -> dict[str, object]:
+    package_id = _safe_package_id(package_id)
+    if _load_package_manifest(package_id) is None:
+        raise HTTPException(status_code=404, detail="Source package manifest not found.")
+    artifacts = _registry_artifacts_by_prefix(
+        package_id,
+        source_ids={"naip", "sentinel_2", "usgs_imagery_only", "nrl_naip_conus"},
+    )
+    indexes: list[dict[str, object]] = []
+    for artifact in artifacts:
+        if str(artifact.get("artifact_type") or "").endswith("_index"):
+            index = _read_json(_artifact_file(package_id, artifact))
+            if index:
+                indexes.append(index)
+    return {
+        "package_id": package_id,
+        "artifacts": artifacts,
+        "indexes": indexes,
+        "query_interfaces": [
+            "GET /api/source-package/{package_id}/query/imagery",
+            "GET /api/source-package/{package_id}/query/imagery/files/{relative_path}",
+        ],
+        "storage": _storage_info(package_id).model_dump(),
+    }
+
+
+@app.get("/api/source-package/{package_id}/query/imagery/files/{relative_path:path}")
+async def get_package_imagery_file(package_id: str, relative_path: str) -> FileResponse:
+    return _package_file_response(package_id, relative_path, allowed_roots=("imagery", "tiles"))
+
+
+@app.get("/api/source-package/{package_id}/query/osm")
+async def query_package_osm(package_id: str) -> dict[str, object]:
+    package_id = _safe_package_id(package_id)
+    if _load_package_manifest(package_id) is None:
+        raise HTTPException(status_code=404, detail="Source package manifest not found.")
+    artifacts = _registry_artifacts_by_prefix(package_id, source_ids={"osm_extract"})
+    indexes: list[dict[str, object]] = []
+    for artifact in artifacts:
+        if str(artifact.get("artifact_type") or "").endswith("_index"):
+            index = _read_json(_artifact_file(package_id, artifact))
+            if index:
+                indexes.append(index)
+    return {
+        "package_id": package_id,
+        "artifacts": artifacts,
+        "indexes": indexes,
+        "query_interfaces": [
+            "osmium tags-filter",
+            "pyosmium scan",
+            "valhalla_build_tiles",
+            "GET /api/source-package/{package_id}/query/osm/files/{relative_path}",
+        ],
+        "storage": _storage_info(package_id).model_dump(),
+    }
+
+
+@app.get("/api/source-package/{package_id}/query/osm/files/{relative_path:path}")
+async def get_package_osm_file(package_id: str, relative_path: str) -> FileResponse:
+    return _package_file_response(package_id, relative_path, allowed_roots=("vectors/osm",))
+
+
+@app.get("/api/source-package/{package_id}/query/cesium")
+async def query_package_cesium(package_id: str) -> dict[str, object]:
+    package_id = _safe_package_id(package_id)
+    if _load_package_manifest(package_id) is None:
+        raise HTTPException(status_code=404, detail="Source package manifest not found.")
+    index_path = _package_dir(package_id) / "cesium" / "archive" / "cesium_archive_index.json"
+    index = _read_json(index_path)
+    if index is None:
+        raise HTTPException(status_code=404, detail="Cesium archive index not found for this package.")
+    registry = _load_artifact_registry(package_id)
+    artifacts = [
+        artifact
+        for artifact in registry.get("artifacts", [])
+        if isinstance(artifact, dict)
+        and str(artifact.get("artifact_type") or "").startswith("cesium_")
+    ]
+    return {
+        "package_id": package_id,
+        "index": index,
+        "artifacts": artifacts,
+        "storage": _storage_info(package_id).model_dump(),
+    }
+
+
+@app.get("/api/source-package/{package_id}/query/cesium/files/{relative_path:path}")
+async def get_package_cesium_file(package_id: str, relative_path: str) -> FileResponse:
+    return _package_file_response(package_id, relative_path, allowed_roots=("cesium",))
+
+
+@app.post("/api/source-package/{package_id}/query/terrain")
+async def query_package_terrain(
+    package_id: str,
+    request: TerrainQueryRequest,
+) -> dict[str, object]:
+    package_id = _safe_package_id(package_id)
+    grid, bbox, cell_size, artifact = _load_package_terrain_grid(
+        package_id,
+        max_cells=request.max_cells,
+    )
+    rows = len(grid)
+    cols = len(grid[0]) if rows else 0
+    if request.query_type == "sample":
+        if request.lat is None or request.lon is None:
+            raise HTTPException(status_code=422, detail="lat and lon are required for sample queries.")
+        row, col = _coord_to_cell(request.lat, request.lon, bbox, rows, cols)
+        return {
+            "package_id": package_id,
+            "query_type": "sample",
+            "artifact": artifact.get("relative_path"),
+            "lat": request.lat,
+            "lon": request.lon,
+            "row": row,
+            "col": col,
+            "elevation_m": grid[row][col],
+            "bbox": bbox,
+            "cell_size_m": cell_size,
+        }
+    if request.query_type == "window":
+        window_bbox = request.bbox
+        if window_bbox is None:
+            raise HTTPException(status_code=422, detail="bbox is required for window queries.")
+        north_west = _coord_to_cell(window_bbox.north, window_bbox.west, bbox, rows, cols)
+        south_east = _coord_to_cell(window_bbox.south, window_bbox.east, bbox, rows, cols)
+        row_min, row_max = sorted((north_west[0], south_east[0]))
+        col_min, col_max = sorted((north_west[1], south_east[1]))
+        window = [row[col_min : col_max + 1] for row in grid[row_min : row_max + 1]]
+        cell_count = len(window) * (len(window[0]) if window else 0)
+        if cell_count > request.max_cells:
+            raise HTTPException(status_code=413, detail="Terrain window exceeds max_cells.")
+        return {
+            "package_id": package_id,
+            "query_type": "window",
+            "artifact": artifact.get("relative_path"),
+            "bbox": window_bbox.model_dump(),
+            "row_range": [row_min, row_max],
+            "col_range": [col_min, col_max],
+            "elevation_grid": window,
+            "cell_size_m": cell_size,
+        }
+
+    values = [
+        float(value)
+        for row in grid
+        for value in row
+        if isinstance(value, (int, float)) and math.isfinite(float(value))
+    ]
+    return {
+        "package_id": package_id,
+        "query_type": "summary",
+        "artifact": artifact.get("relative_path"),
+        "bbox": bbox,
+        "rows": rows,
+        "cols": cols,
+        "cell_size_m": cell_size,
+        "min_elevation_m": min(values) if values else None,
+        "max_elevation_m": max(values) if values else None,
+        "mean_elevation_m": sum(values) / len(values) if values else None,
+    }
+
+
+@app.get("/api/source-package/{package_id}/query/terrain/files/{relative_path:path}")
+async def get_package_terrain_file(package_id: str, relative_path: str) -> FileResponse:
+    return _package_file_response(package_id, relative_path, allowed_roots=("rasters", "samples"))
+
+
+@app.post("/api/source-package/{package_id}/algorithm")
+async def run_package_algorithm(
+    package_id: str,
+    request: AlgorithmRequest,
+) -> dict[str, object]:
+    package_id = _safe_package_id(package_id)
+    if _load_package_manifest(package_id) is None:
+        raise HTTPException(status_code=404, detail="Source package manifest not found.")
+    return _run_algorithm(package_id, request)
+
+
+@app.post("/api/source-package/{package_id}/route")
+async def create_package_route(
+    package_id: str,
+    request: PackageRouteRequest,
+) -> dict[str, object]:
+    package_id = _safe_package_id(package_id)
+    if _load_package_manifest(package_id) is None:
+        raise HTTPException(status_code=404, detail="Source package manifest not found.")
+    return _build_route_from_package(package_id, request)
+
+
+@app.post("/api/source-package/{package_id}/cot")
+async def create_package_cot(
+    package_id: str,
+    request: PackageCotRequest,
+) -> dict[str, object]:
+    package_id = _safe_package_id(package_id)
+    route_artifact = _load_route_artifact(package_id, request.route_id) if request.route_id else None
+    route = request.route or (route_artifact or {}).get("route")
+    if not isinstance(route, dict):
+        raise HTTPException(status_code=422, detail="route or route_id is required.")
+    route_id = request.route_id or str(route.get("properties", {}).get("route_id") or f"TERA-{uuid4().hex[:10]}")
+    rationale = request.rationale
+    if route_artifact and isinstance(route_artifact.get("rationale"), str):
+        rationale = str(route_artifact["rationale"])
+    coordinates = route.get("geometry", {}).get("coordinates", [])
+    if not coordinates:
+        raise HTTPException(status_code=422, detail="Route geometry must contain coordinates.")
+
+    events: list[dict[str, object]] = []
+    cot_type_code = "b-m-r" if request.cot_type == "route" else "a-f-G-U-C"
+    event_coords = [coordinates[-1]] if request.cot_type == "route" else coordinates
+    for index, coordinate in enumerate(event_coords):
+        lon = float(coordinate[0])
+        lat = float(coordinate[1])
+        uid = route_id if request.cot_type == "route" else f"{route_id}-track-{index:03d}"
+        cot_xml = _build_cot_xml(
+            uid=uid,
+            cot_type=cot_type_code,
+            lat=lat,
+            lon=lon,
+            route=route,
+        )
+        signed_xml, signed = _sign_cot_xml(
+            uid=uid,
+            lat=lat,
+            lon=lon,
+            route=route,
+            rationale=rationale,
+            mission_type=request.mission_type,
+            cot_xml=cot_xml,
+        )
+        cot_path = _cot_dir(package_id) / f"{_safe_package_id(uid)}.cot.xml"
+        cot_path.parent.mkdir(parents=True, exist_ok=True)
+        cot_path.write_text(signed_xml, encoding="utf-8")
+        events.append(
+            {
+                "uid": uid,
+                "cot_type": cot_type_code,
+                "path": str(cot_path),
+                "relative_path": cot_path.relative_to(_package_dir(package_id)).as_posix(),
+                "signed": True,
+                "signature_scheme": signed.get("algorithm"),
+                "key_id": signed.get("key_id"),
+                "cot_xml": signed_xml,
+            }
+        )
+
+    response = {
+        "package_id": package_id,
+        "route_id": route_id,
+        "route_hash": _route_hash(route),
+        "cot_type": request.cot_type,
+        "approval_state": "provisional",
+        "atak_display": "Suggested Route - Needs Review",
+        "events": events,
+    }
+    _write_json(_cot_dir(package_id) / f"{_safe_package_id(route_id)}-{request.cot_type}.json", response)
+    return response
 
 
 @app.post("/api/prompt", response_model=PromptResponse)

--- a/llm_dev_kmh/app.py
+++ b/llm_dev_kmh/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 from difflib import SequenceMatcher
@@ -37,11 +38,17 @@ LOCATION_SEARCH_TIMEOUT_S = float(os.getenv("LOCATION_SEARCH_TIMEOUT_S", "4"))
 LOCATION_SEARCH_URL = os.getenv(
     "LOCATION_SEARCH_URL", "https://nominatim.openstreetmap.org/search"
 )
+LOCATION_INTENT_PREFIX_RE = re.compile(
+    r"^(?:go to|goto|navigate to|take me to|move map to|move to|search for|"
+    r"find|show me|zoom to|center on|focus on|look up|open)\s+",
+    re.IGNORECASE,
+)
 CESIUM_ION_TOKEN = os.getenv("CESIUM_ION_TOKEN", "")
 DEFAULT_LAT = float(os.getenv("DEFAULT_LAT", "37.7749"))
 DEFAULT_LON = float(os.getenv("DEFAULT_LON", "-122.4194"))
 DEFAULT_HEIGHT_M = float(os.getenv("DEFAULT_HEIGHT_M", "14000"))
 ACTIVE_OLLAMA_BASE_URL: str | None = None
+ACTIVE_OLLAMA_MODEL: str | None = None
 
 app = FastAPI(title="TERA Source Planner", version="0.2.0")
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
@@ -99,6 +106,7 @@ class LocationSuggestion(BaseModel):
     lon: float
     height_m: float = 12000
     source: str
+    score: float = 0
 
 
 class LocationSearchResponse(BaseModel):
@@ -707,6 +715,71 @@ US_CONTEXT_TERMS = (
 )
 
 LOCAL_LOCATION_GAZETTEER: tuple[dict[str, object], ...] = (
+    {
+        "name": "Cascade Range, WA/OR/BC",
+        "detail": (
+            "Pacific Northwest mountain range, national forests, volcanoes, "
+            "SAR and terrain-routing context."
+        ),
+        "lat": 45.6500,
+        "lon": -121.7000,
+        "height_m": 26000,
+        "aliases": (
+            "cascades",
+            "the cascades",
+            "cascade mountains",
+            "cascade range",
+            "pnw cascades",
+        ),
+    },
+    {
+        "name": "North Cascades National Park, WA",
+        "detail": "High alpine terrain, glaciers, steep valleys, trails, and SAR access constraints.",
+        "lat": 48.7718,
+        "lon": -121.2985,
+        "height_m": 22000,
+        "aliases": ("north cascades", "north cascades np", "cascades national park", "noca"),
+    },
+    {
+        "name": "Olympic National Park, WA",
+        "detail": "Dense forest, mountains, river valleys, coastline, and SAR mission terrain.",
+        "lat": 47.8021,
+        "lon": -123.6044,
+        "height_m": 22000,
+        "aliases": ("olympic", "olympics", "olympic peninsula", "olympic national park"),
+    },
+    {
+        "name": "Mount Rainier National Park, WA",
+        "detail": "Volcanic alpine terrain, glaciers, roads, trails, and high-risk weather.",
+        "lat": 46.8523,
+        "lon": -121.7603,
+        "height_m": 20000,
+        "aliases": ("rainier", "mount rainier", "mt rainier", "rainier national park"),
+    },
+    {
+        "name": "Sierra Nevada, CA/NV",
+        "detail": "Mountain range with alpine terrain, forest roads, trails, water, and winter hazards.",
+        "lat": 38.9000,
+        "lon": -120.0000,
+        "height_m": 26000,
+        "aliases": ("sierra", "sierras", "sierra nevada", "eastern sierra"),
+    },
+    {
+        "name": "Rocky Mountains, CO/WY/MT",
+        "detail": "Western mountain terrain, high elevation, passes, ridges, and SAR context.",
+        "lat": 40.3772,
+        "lon": -105.5250,
+        "height_m": 30000,
+        "aliases": ("rockies", "rocky mountains", "front range"),
+    },
+    {
+        "name": "Appalachian Trail",
+        "detail": "Long-distance eastern trail corridor with forest, ridges, road crossings, and shelters.",
+        "lat": 39.0000,
+        "lon": -77.9000,
+        "height_m": 26000,
+        "aliases": ("appalachian", "appalachians", "appalachian trail", "at trail"),
+    },
     {
         "name": "Joshua Tree National Park, CA",
         "detail": "Desert terrain, trails, dry washes, roads, climbing areas, and water scarcity.",
@@ -1709,7 +1782,7 @@ def _build_system_prompt(request: PromptRequest) -> str:
 
 
 def _build_ollama_payload(request: PromptRequest, *, stream: bool) -> tuple[str, dict[str, object]]:
-    model = request.model or OLLAMA_MODEL
+    model = request.model or ACTIVE_OLLAMA_MODEL or OLLAMA_MODEL
     payload: dict[str, object] = {
         "model": model,
         "stream": stream,
@@ -1852,8 +1925,71 @@ async def _fetch_ollama_models_from(base_url: str) -> list[str]:
     ]
 
 
+def _score_ollama_model_for_default(model: str, configured_model: str) -> int:
+    normalized = model.lower()
+    score = 0
+    if model == configured_model:
+        score += 500
+    if "gemma" in normalized:
+        score += 300
+    if "gemma4" in normalized or "gemma-4" in normalized:
+        score += 80
+    elif "gemma3" in normalized or "gemma-3" in normalized:
+        score += 60
+    elif "gemma2" in normalized or "gemma-2" in normalized:
+        score += 20
+    if "e4b" in normalized:
+        score += 50
+    if "/gemma" in normalized or normalized.startswith("hf.co/"):
+        score -= 20
+    return score
+
+
+def _select_ollama_default_model(models: list[str]) -> str:
+    if not models:
+        return OLLAMA_MODEL
+    if OLLAMA_MODEL in models:
+        return OLLAMA_MODEL
+    return max(
+        models,
+        key=lambda model: (_score_ollama_model_for_default(model, OLLAMA_MODEL), -len(model)),
+    )
+
+
+def _clean_location_query(query: str) -> str:
+    cleaned = re.sub(r"\s+", " ", query.strip())
+    previous = None
+    while cleaned and cleaned != previous:
+        previous = cleaned
+        cleaned = LOCATION_INTENT_PREFIX_RE.sub("", cleaned).strip()
+    return cleaned
+
+
+def _distance_km(lat_a: float, lon_a: float, lat_b: float, lon_b: float) -> float:
+    radius_km = 6371.0088
+    lat1 = math.radians(lat_a)
+    lat2 = math.radians(lat_b)
+    delta_lat = math.radians(lat_b - lat_a)
+    delta_lon = math.radians(lon_b - lon_a)
+    sin_lat = math.sin(delta_lat / 2)
+    sin_lon = math.sin(delta_lon / 2)
+    a = sin_lat * sin_lat + math.cos(lat1) * math.cos(lat2) * sin_lon * sin_lon
+    return radius_km * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _safe_float(value: object, default: float = 0) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    if math.isfinite(number):
+        return number
+    return default
+
+
 def _score_local_location(query: str, item: dict[str, object]) -> int:
-    query_tokens = _tokens_for_match(query)
+    cleaned_query = _clean_location_query(query)
+    query_tokens = _tokens_for_match(cleaned_query)
     if not query_tokens:
         return 0
     haystack = " ".join(
@@ -1868,13 +2004,58 @@ def _score_local_location(query: str, item: dict[str, object]) -> int:
     for query_token in query_tokens:
         if any(_token_matches(token, query_token) for token in haystack_tokens):
             score += 20
-    normalized_query = _normalize_for_match(query)
+    normalized_query = _normalize_for_match(cleaned_query)
     normalized_name = _normalize_for_match(str(item.get("name", "")))
+    normalized_aliases = [
+        _normalize_for_match(str(alias)) for alias in item.get("aliases", ())
+    ]
     if normalized_name.startswith(normalized_query):
         score += 60
     elif normalized_query in normalized_name:
         score += 40
+    for alias in normalized_aliases:
+        if alias == normalized_query:
+            score += 130
+        elif alias.startswith(normalized_query):
+            score += 65
+        elif normalized_query in alias:
+            score += 45
     return score
+
+
+def _score_online_location(
+    query: str,
+    suggestion: LocationSuggestion,
+    *,
+    center_lat: float | None = None,
+    center_lon: float | None = None,
+    importance: float = 0,
+    category: str = "",
+    place_type: str = "",
+) -> float:
+    item = {
+        "name": suggestion.name,
+        "detail": suggestion.detail,
+        "aliases": (),
+    }
+    score = float(_score_local_location(query, item))
+    score += max(0, min(1, importance)) * 65
+
+    category_type = f"{category}/{place_type}".lower()
+    if any(token in category_type for token in ("city", "town", "village", "hamlet")):
+        score += 8
+    if any(token in category_type for token in ("national_park", "protected_area", "park")):
+        score += 24
+    if any(token in category_type for token in ("mountain", "peak", "natural", "water")):
+        score += 18
+    if "administrative" in category_type:
+        score -= 8
+
+    if center_lat is not None and center_lon is not None:
+        distance = _distance_km(center_lat, center_lon, suggestion.lat, suggestion.lon)
+        score += max(0, 35 - min(distance / 125, 35))
+
+    return round(score, 3)
 
 
 def _local_location_suggestions(query: str) -> list[LocationSuggestion]:
@@ -1894,9 +2075,10 @@ def _local_location_suggestions(query: str) -> list[LocationSuggestion]:
                 lon=float(item["lon"]),
                 height_m=float(item.get("height_m", 12000)),
                 source="local-gazetteer",
+                score=float(score + 120),
             )
         )
-    return suggestions[:5]
+    return suggestions[:8]
 
 
 @app.get("/")
@@ -1923,17 +2105,24 @@ async def runtime_config() -> RuntimeConfigResponse:
 
 @app.get("/api/models", response_model=ModelsResponse)
 async def list_ollama_models() -> ModelsResponse:
-    global ACTIVE_OLLAMA_BASE_URL
+    global ACTIVE_OLLAMA_BASE_URL, ACTIVE_OLLAMA_MODEL
     errors: list[str] = []
     for base_url in _ollama_base_url_candidates():
         try:
             models = await _fetch_ollama_models_from(base_url)
+            default_model = _select_ollama_default_model(models)
             ACTIVE_OLLAMA_BASE_URL = base_url
+            ACTIVE_OLLAMA_MODEL = default_model
             return ModelsResponse(
-                default_model=OLLAMA_MODEL,
+                default_model=default_model,
                 models=models,
                 online=True,
                 base_url=base_url,
+                detail=(
+                    f"Auto-detected installed Gemma model {default_model}."
+                    if default_model != OLLAMA_MODEL
+                    else None
+                ),
             )
         except httpx.HTTPStatusError as exc:
             body = exc.response.text[:300]
@@ -1955,46 +2144,73 @@ async def list_ollama_models() -> ModelsResponse:
 @app.get("/api/location-search", response_model=LocationSearchResponse)
 async def search_locations(
     q: str = Query(min_length=2, max_length=200),
+    lat: float | None = Query(default=None, ge=-90, le=90),
+    lon: float | None = Query(default=None, ge=-180, le=180),
+    west: float | None = Query(default=None, ge=-180, le=180),
+    south: float | None = Query(default=None, ge=-90, le=90),
+    east: float | None = Query(default=None, ge=-180, le=180),
+    north: float | None = Query(default=None, ge=-90, le=90),
 ) -> LocationSearchResponse:
-    query = q.strip()
+    query = _clean_location_query(q)
+    if len(query) < 2:
+        raise HTTPException(status_code=422, detail="Location query is too short.")
+
     suggestions = _local_location_suggestions(query)
     online = False
     detail: str | None = None
 
     try:
+        params: dict[str, object] = {
+            "q": query,
+            "format": "jsonv2",
+            "limit": 10,
+            "addressdetails": 1,
+            "extratags": 1,
+            "namedetails": 1,
+            "dedupe": 1,
+        }
+        if None not in (west, south, east, north):
+            params["viewbox"] = f"{west},{north},{east},{south}"
+
         timeout = httpx.Timeout(LOCATION_SEARCH_TIMEOUT_S, connect=2.0)
         async with httpx.AsyncClient(timeout=timeout) as client:
             response = await client.get(
                 LOCATION_SEARCH_URL,
-                params={
-                    "q": query,
-                    "format": "jsonv2",
-                    "limit": 6,
-                    "addressdetails": 1,
-                },
+                params=params,
                 headers={
-                    "User-Agent": "TERA Source Planner local web app; optional online geocode"
+                    "Accept-Language": "en",
+                    "User-Agent": "TERA Source Planner local web app; optional online geocode",
                 },
             )
             response.raise_for_status()
         online = True
         for item in response.json():
-            lat = item.get("lat")
-            lon = item.get("lon")
-            if lat is None or lon is None:
+            item_lat = item.get("lat")
+            item_lon = item.get("lon")
+            if item_lat is None or item_lon is None:
                 continue
             display_name = str(item.get("display_name") or item.get("name") or query)
             category = str(item.get("category") or "online geocoder")
             place_type = str(item.get("type") or "place")
+            suggestion = LocationSuggestion(
+                name=display_name.split(",")[0],
+                detail=f"{category}/{place_type} - {display_name}",
+                lat=float(item_lat),
+                lon=float(item_lon),
+                height_m=12000,
+                source="online-geocoder",
+            )
+            suggestion.score = _score_online_location(
+                query,
+                suggestion,
+                center_lat=lat if lat is not None else None,
+                center_lon=lon if lon is not None else None,
+                importance=_safe_float(item.get("importance")),
+                category=category,
+                place_type=place_type,
+            )
             suggestions.append(
-                LocationSuggestion(
-                    name=display_name.split(",")[0],
-                    detail=f"{category}/{place_type} - {display_name}",
-                    lat=float(lat),
-                    lon=float(lon),
-                    height_m=12000,
-                    source="online-geocoder",
-                )
+                suggestion
             )
     except (httpx.HTTPError, ValueError) as exc:
         detail = f"Online location lookup unavailable: {exc}"
@@ -2011,6 +2227,7 @@ async def search_locations(
             continue
         seen.add(key)
         deduped.append(suggestion)
+    deduped.sort(key=lambda suggestion: suggestion.score, reverse=True)
 
     return LocationSearchResponse(
         query=query,

--- a/llm_dev_kmh/app.py
+++ b/llm_dev_kmh/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
+from difflib import SequenceMatcher
 from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import dedent
@@ -10,7 +11,7 @@ from uuid import uuid4
 
 import httpx
 import structlog
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
@@ -24,13 +25,23 @@ IMAGERY_SOURCING_PROMPT_FILE = (
 )
 INDEX_FILE = BASE_DIR / "static" / "index.html"
 STATIC_DIR = BASE_DIR / "static"
-OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://host.docker.internal:11434")
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
 OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "gemma2:2b")
+ANTHROPIC_API_URL = os.getenv(
+    "ANTHROPIC_API_URL", "https://api.anthropic.com/v1/messages"
+)
+ANTHROPIC_VERSION = os.getenv("ANTHROPIC_VERSION", "2023-06-01")
+CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "claude-sonnet-4-20250514")
 REQUEST_TIMEOUT_S = float(os.getenv("REQUEST_TIMEOUT_S", "120"))
+LOCATION_SEARCH_TIMEOUT_S = float(os.getenv("LOCATION_SEARCH_TIMEOUT_S", "4"))
+LOCATION_SEARCH_URL = os.getenv(
+    "LOCATION_SEARCH_URL", "https://nominatim.openstreetmap.org/search"
+)
 CESIUM_ION_TOKEN = os.getenv("CESIUM_ION_TOKEN", "")
 DEFAULT_LAT = float(os.getenv("DEFAULT_LAT", "37.7749"))
 DEFAULT_LON = float(os.getenv("DEFAULT_LON", "-122.4194"))
 DEFAULT_HEIGHT_M = float(os.getenv("DEFAULT_HEIGHT_M", "14000"))
+ACTIVE_OLLAMA_BASE_URL: str | None = None
 
 app = FastAPI(title="TERA Source Planner", version="0.2.0")
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
@@ -51,6 +62,9 @@ class PromptRequest(BaseModel):
     prompt: str = Field(min_length=1, max_length=12000)
     system: str | None = Field(default=None, max_length=4000)
     model: str | None = Field(default=None, max_length=200)
+    llm_provider: str | None = Field(default="ollama", max_length=40)
+    cloud_model: str | None = Field(default=None, max_length=200)
+    cloud_api_key: str | None = Field(default=None, max_length=500)
     agent_profile: str | None = Field(default="imagery-sourcing", max_length=80)
     map_context: "MapContext | None" = None
     source_context: SourceContext | None = None
@@ -64,14 +78,34 @@ class PromptResponse(BaseModel):
 class ModelsResponse(BaseModel):
     default_model: str
     models: list[str]
+    online: bool = True
+    base_url: str | None = None
+    detail: str | None = None
 
 
 class RuntimeConfigResponse(BaseModel):
     cesium_ion_token: str
     default_model: str
+    claude_default_model: str
     default_lat: float
     default_lon: float
     default_height_m: float
+
+
+class LocationSuggestion(BaseModel):
+    name: str
+    detail: str = ""
+    lat: float
+    lon: float
+    height_m: float = 12000
+    source: str
+
+
+class LocationSearchResponse(BaseModel):
+    query: str
+    suggestions: list[LocationSuggestion]
+    online: bool
+    detail: str | None = None
 
 
 class MapPoint(BaseModel):
@@ -95,6 +129,9 @@ class MapContext(BaseModel):
     view_bounds: ViewBounds | None = None
     imagery_source: str | None = Field(default=None, max_length=200)
     terrain_source: str | None = Field(default=None, max_length=200)
+    location_focus_label: str | None = Field(default=None, max_length=200)
+    location_focus_source: str | None = Field(default=None, max_length=80)
+    location_confirmed: bool = False
 
 
 class SourceOption(BaseModel):
@@ -233,6 +270,42 @@ SOURCE_CATALOG: list[SourceOption] = [
         recommended_for=["terrain-routing", "signal-planning", "imagery-preview"],
         derived_layers=["cached_terrain_tiles"],
         notes="Good for visualization, not a substitute for indexed DEM rasters.",
+    ),
+    SourceOption(
+        id="esri_world_elevation",
+        name="Esri World Elevation Terrain",
+        provider="Esri ArcGIS Online / Living Atlas",
+        category="terrain",
+        purpose=(
+            "Queryable online elevation terrain source for AO sampling and DEM "
+            "fallback when authoritative DEM downloads are unavailable."
+        ),
+        useful_for=[
+            "elevation sampling",
+            "slope fallback",
+            "hillshade",
+            "viewshed preflight",
+            "terrain sanity checks",
+        ],
+        analysis_role=(
+            "Download or cache clipped AO elevation tiles/samples so the server "
+            "database can answer terrain queries offline when primary DEMs are "
+            "missing or delayed."
+        ),
+        stream_status="queryable-online",
+        download_status="download-required",
+        required_for=["terrain-routing", "signal-planning"],
+        recommended_for=["water-access", "sar-planning", "evacuation"],
+        derived_layers=[
+            "elevation_samples",
+            "slope_degrees",
+            "hillshade",
+            "viewshed_surfaces",
+        ],
+        notes=(
+            "Treat as a queryable fallback or validation layer; prefer USGS 3DEP "
+            "or Copernicus DEM when available for authoritative analysis."
+        ),
     ),
     SourceOption(
         id="osm_basemap",
@@ -633,6 +706,59 @@ US_CONTEXT_TERMS = (
     "usfs",
 )
 
+LOCAL_LOCATION_GAZETTEER: tuple[dict[str, object], ...] = (
+    {
+        "name": "Joshua Tree National Park, CA",
+        "detail": "Desert terrain, trails, dry washes, roads, climbing areas, and water scarcity.",
+        "lat": 33.8734,
+        "lon": -115.9010,
+        "height_m": 18000,
+        "aliases": ("joshua tree", "joshua tree np", "jtnp", "joshu tree", "joshua"),
+    },
+    {
+        "name": "San Francisco, CA",
+        "detail": "City center and Bay Area mission staging reference.",
+        "lat": 37.7749,
+        "lon": -122.4194,
+        "height_m": 14000,
+        "aliases": ("sf", "san fran", "bay area"),
+    },
+    {
+        "name": "Fort Irwin / National Training Center, CA",
+        "detail": "Desert maneuver terrain, dry washes, roads, and range constraints.",
+        "lat": 35.2627,
+        "lon": -116.6848,
+        "height_m": 26000,
+        "aliases": ("fort irwin", "ntc", "national training center"),
+    },
+)
+
+KEYWORD_EXPANSIONS: dict[str, tuple[str, ...]] = {
+    "route": ("route", "routing", "navigate", "navigation", "path", "corridor", "approach"),
+    "patrol": ("patrol", "movement", "move", "walk", "team", "operator"),
+    "water": (
+        "water",
+        "hydration",
+        "hydrate",
+        "stream",
+        "river",
+        "spring",
+        "creek",
+        "wash",
+        "well",
+        "source",
+        "watter",
+    ),
+    "terrain": ("terrain", "terain", "topography", "elevation", "ground", "landform"),
+    "slope": ("slope", "steep", "grade", "incline", "cliff", "exposed", "exposure"),
+    "cover": ("cover", "concealment", "conceal", "canopy", "shade", "vegetation", "brush"),
+    "hazard": ("hazard", "hazzard", "risk", "danger", "closure", "blocked", "unsafe"),
+    "signal": ("signal", "comms", "communications", "radio", "relay", "antenna", "line of sight", "los"),
+    "imagery": ("imagery", "image", "satellite", "satelite", "aerial", "visual", "photo"),
+    "sar": ("sar", "search", "rescue", "missing", "lost", "hasty"),
+    "access": ("access", "private", "restricted", "boundary", "parcel", "permission", "legal"),
+}
+
 
 def _get_source_options_by_ids(source_ids: list[str]) -> list[SourceOption]:
     seen: set[str] = set()
@@ -683,14 +809,14 @@ def _format_source_context(source_context: SourceContext | None) -> str:
             for source_id in source_context.required_source_ids
             if source_id in SOURCE_BY_ID
         ]
-        lines.append(f"- Required sources inferred: {', '.join(required_names)}")
+        lines.append(f"- Required sources planned: {', '.join(required_names)}")
     if source_context.optional_source_ids:
         optional_names = [
             SOURCE_BY_ID[source_id].name
             for source_id in source_context.optional_source_ids
             if source_id in SOURCE_BY_ID
         ]
-        lines.append(f"- Optional sources inferred: {', '.join(optional_names)}")
+        lines.append(f"- Optional sources planned: {', '.join(optional_names)}")
     if source_context.clarifying_questions:
         lines.append(
             "- Socratic questions to ask next: "
@@ -715,14 +841,64 @@ def _format_manifest_bounds(map_context: MapContext | None) -> dict[str, float |
     }
 
 
+def _normalize_for_match(text: str) -> str:
+    expanded = text.lower()
+    for canonical, aliases in KEYWORD_EXPANSIONS.items():
+        for alias in aliases:
+            expanded = re.sub(rf"\b{re.escape(alias)}\b", canonical, expanded)
+    return re.sub(r"[^a-z0-9]+", " ", expanded).strip()
+
+
+def _tokens_for_match(text: str) -> list[str]:
+    return [token for token in _normalize_for_match(text).split() if token]
+
+
+def _token_matches(candidate: str, target: str) -> bool:
+    if candidate == target:
+        return True
+    if len(candidate) >= 4 and len(target) >= 4:
+        if candidate.startswith(target) or target.startswith(candidate):
+            return True
+        return SequenceMatcher(None, candidate, target).ratio() >= 0.82
+    return False
+
+
+def _phrase_matches(text_tokens: list[str], term_tokens: list[str]) -> bool:
+    if not term_tokens:
+        return False
+    if len(term_tokens) == 1:
+        return any(_token_matches(token, term_tokens[0]) for token in text_tokens)
+    if len(text_tokens) < len(term_tokens):
+        return False
+    for index in range(0, len(text_tokens) - len(term_tokens) + 1):
+        window = text_tokens[index : index + len(term_tokens)]
+        if all(_token_matches(token, term) for token, term in zip(window, term_tokens)):
+            return True
+    return False
+
+
 def _text_has_any(text: str, terms: tuple[str, ...]) -> bool:
-    return any(term in text for term in terms)
+    normalized_text = _normalize_for_match(text)
+    text_tokens = normalized_text.split()
+    for term in terms:
+        expanded_terms = (term, *KEYWORD_EXPANSIONS.get(term, ()))
+        for expanded_term in expanded_terms:
+            normalized_term = _normalize_for_match(expanded_term)
+            if not normalized_term:
+                continue
+            if f" {normalized_term} " in f" {normalized_text} ":
+                return True
+            if _phrase_matches(text_tokens, normalized_term.split()):
+                return True
+    return False
 
 
 def _infer_is_us_context(prompt_text: str, map_context: MapContext | None) -> bool:
     if _text_has_any(prompt_text, US_CONTEXT_TERMS):
         return True
-    bounds = (map_context.selected_area or map_context.view_bounds) if map_context else None
+    bounds = None
+    if map_context and (map_context.location_confirmed or map_context.selected_area):
+        bounds = map_context.selected_area or map_context.view_bounds
     if bounds and bounds.center_lat is not None and bounds.center_lon is not None:
         return 18.0 <= bounds.center_lat <= 72.0 and -170.0 <= bounds.center_lon <= -50.0
     return False
@@ -731,7 +907,7 @@ def _infer_is_us_context(prompt_text: str, map_context: MapContext | None) -> bo
 def _infer_mission_focus(prompt_text: str) -> str:
     scores: dict[str, int] = {}
     for focus, keywords in FOCUS_KEYWORDS:
-        score = sum(1 for keyword in keywords if keyword in prompt_text)
+        score = sum(1 for keyword in keywords if _text_has_any(prompt_text, (keyword,)))
         if score:
             scores[focus] = score
     if not scores:
@@ -814,8 +990,12 @@ def _infer_source_recommendation(
 
     if needs_terrain:
         _append_unique(required_ids, "usgs_3dep" if is_us_context else "copernicus_dem")
+        _append_unique(required_ids, "esri_world_elevation")
         _append_unique(optional_ids, "cesium_world_terrain")
-        rationale.append("An analysis DEM is required for slope, exposure, hydrology, and cost surfaces.")
+        rationale.append(
+            "An analysis DEM plus queryable Esri terrain fallback is required "
+            "for slope, exposure, hydrology, and cost surfaces."
+        )
 
     if needs_landcover:
         _append_unique(required_ids, "nlcd" if is_us_context else "esa_worldcover")
@@ -844,9 +1024,9 @@ def _infer_source_recommendation(
 
     if needs_hazards:
         _append_unique(optional_ids, "noaa_alerts")
-        if "fire" in prompt_text or "wildfire" in prompt_text:
+        if _text_has_any(prompt_text, ("fire", "wildfire")):
             _append_unique(required_ids, "nasa_firms")
-        if "flood" in prompt_text:
+        if _text_has_any(prompt_text, ("flood",)):
             _append_unique(required_ids, "fema_flood" if is_us_context else "sentinel_1_sar")
         rationale.append(
             "Hazard feeds are included only when the mission says current "
@@ -867,6 +1047,7 @@ def _infer_source_recommendation(
         _append_unique(optional_ids, "fcc_towers" if is_us_context else "osm_towers", "osm_towers")
         if not needs_terrain:
             _append_unique(required_ids, "usgs_3dep" if is_us_context else "copernicus_dem")
+            _append_unique(required_ids, "esri_world_elevation")
         rationale.append("Signal planning requires DEM-derived viewsheds plus tower/high-ground candidates.")
 
     if needs_current_imagery and not needs_water and not needs_hazards:
@@ -878,6 +1059,14 @@ def _infer_source_recommendation(
             "depends on recent conditions."
         )
 
+    if map_context is None or not (map_context.location_confirmed or map_context.selected_area):
+        questions.append(
+            "Move the map to the mission AO with search, KML/KMZ import, or AO "
+            "drawing and confirm that view before final source selection. The "
+            "AO decides clipping bounds and whether U.S. authoritative or global "
+            "open layers are the right defaults."
+        )
+
     if not required_ids:
         questions.append(
             "Which mission outcome must the database answer first: routing, "
@@ -885,7 +1074,7 @@ def _infer_source_recommendation(
             "control? This decides the required source family."
         )
         rationale.append(
-            "No deterministic analytical layer was inferred yet, so the "
+            "No deterministic analytical layer was identified yet, so the "
             "package stays in preview mode."
         )
 
@@ -923,7 +1112,9 @@ def _infer_source_recommendation(
             "or only support terrain movement? Enforcing access adds parcels, "
             "protected areas, or land-management boundaries."
         )
-    if map_context is None or (map_context.selected_area is None and map_context.view_bounds is None):
+    if map_context is None or (
+        map_context.selected_area is None and not map_context.location_confirmed
+    ):
         questions.append(
             "Is this AO inside the U.S. or outside it? That choice switches "
             "between U.S.-authoritative layers and global open layers."
@@ -1425,6 +1616,14 @@ def _build_system_prompt(request: PromptRequest) -> str:
         _format_view_bounds(map_context.selected_area if map_context else None).replace(
             "Visible map bounds", "Selected AO bounds"
         ),
+        (
+            "- Planner-confirmed mission map focus: "
+            + (
+                f"{map_context.location_focus_label or 'selected AO'} via {map_context.location_focus_source or 'map'}"
+                if map_context and (map_context.location_confirmed or map_context.selected_area)
+                else "not confirmed"
+            )
+        ),
         _format_point("Camera position", map_context.camera if map_context else None),
         _format_view_bounds(map_context.view_bounds if map_context else None),
         f"- Imagery source: {(map_context.imagery_source if map_context else None) or 'unknown'}",
@@ -1467,6 +1666,16 @@ def _build_system_prompt(request: PromptRequest) -> str:
                         "- Do not recommend the full catalog. Optimize for the smallest "
                         "package that enables the mission and explain what would be missing "
                         "if a source is omitted."
+                    ),
+                    (
+                        "- Drive source planning to mission scope in the fewest useful turns: "
+                        "combine missing AO, objective, movement mode, time horizon, and "
+                        "constraints into one ranked scope pass when possible."
+                    ),
+                    (
+                        "- If the planner-confirmed mission map focus is not confirmed, "
+                        "tell the planner to move the map with location search, import a "
+                        "KML/KMZ overlay, or draw an AO before final source confirmation."
                     ),
                     (
                         "- Ask no more than three clarifying questions, and only ask "
@@ -1515,8 +1724,179 @@ def _build_ollama_payload(request: PromptRequest, *, stream: bool) -> tuple[str,
     return model, payload
 
 
+def _request_llm_provider(request: PromptRequest) -> str:
+    provider = (request.llm_provider or "ollama").strip().lower()
+    if provider in {"claude", "anthropic"}:
+        return "claude"
+    return "ollama"
+
+
+def _build_claude_payload(request: PromptRequest) -> tuple[str, dict[str, object]]:
+    model = request.cloud_model or request.model or CLAUDE_MODEL
+    payload: dict[str, object] = {
+        "model": model,
+        "max_tokens": 900,
+        "temperature": 0.1,
+        "system": _build_system_prompt(request),
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": request.prompt,
+                    }
+                ],
+            }
+        ],
+    }
+    return model, payload
+
+
+def _extract_claude_response_text(data: dict[str, object]) -> str:
+    content = data.get("content")
+    if not isinstance(content, list):
+        return ""
+
+    chunks: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text":
+            chunks.append(str(block.get("text", "")))
+    return "\n".join(chunk for chunk in chunks if chunk).strip()
+
+
+async def _post_claude_message(request: PromptRequest) -> PromptResponse:
+    api_key = (request.cloud_api_key or os.getenv("ANTHROPIC_API_KEY", "")).strip()
+    if not api_key:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Claude API key required. Open Model Provider, choose Claude API, "
+                "and add a key for this browser session."
+            ),
+        )
+
+    model, payload = _build_claude_payload(request)
+    timeout = httpx.Timeout(REQUEST_TIMEOUT_S, connect=10.0)
+    headers = {
+        "anthropic-version": ANTHROPIC_VERSION,
+        "content-type": "application/json",
+        "x-api-key": api_key,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(ANTHROPIC_API_URL, headers=headers, json=payload)
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        body = exc.response.text[:500]
+        log.error(
+            "claude_http_error",
+            status_code=exc.response.status_code,
+            body=body,
+            model=model,
+        )
+        if exc.response.status_code in {401, 403}:
+            detail = "Claude API rejected the key or account access for this model."
+        else:
+            detail = f"Claude API returned {exc.response.status_code}: {body}"
+        raise HTTPException(status_code=502, detail=detail) from exc
+    except httpx.HTTPError as exc:
+        log.error("claude_connection_error", error=str(exc), model=model)
+        raise HTTPException(
+            status_code=502,
+            detail=f"Could not reach Claude API. {exc}",
+        ) from exc
+
+    text = _extract_claude_response_text(response.json())
+    if not text:
+        raise HTTPException(status_code=502, detail="Claude returned an empty response.")
+    return PromptResponse(model=model, response=text)
+
+
 def _sse_event(payload: dict[str, object]) -> str:
     return f"data: {json.dumps(payload)}\n\n"
+
+
+def _ollama_base_url_candidates() -> list[str]:
+    candidates = [
+        url.strip().rstrip("/")
+        for url in (
+            ACTIVE_OLLAMA_BASE_URL,
+            OLLAMA_BASE_URL,
+            "http://127.0.0.1:11434",
+            "http://localhost:11434",
+            "http://host.docker.internal:11434",
+        )
+        if url and url.strip()
+    ]
+    deduped: list[str] = []
+    for url in candidates:
+        if url not in deduped:
+            deduped.append(url)
+    return deduped
+
+
+async def _fetch_ollama_models_from(base_url: str) -> list[str]:
+    timeout = httpx.Timeout(6.0, connect=2.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.get(f"{base_url}/api/tags")
+        response.raise_for_status()
+    data = response.json()
+    return [
+        str(model.get("name", "")).strip()
+        for model in data.get("models", [])
+        if str(model.get("name", "")).strip()
+    ]
+
+
+def _score_local_location(query: str, item: dict[str, object]) -> int:
+    query_tokens = _tokens_for_match(query)
+    if not query_tokens:
+        return 0
+    haystack = " ".join(
+        [
+            str(item.get("name", "")),
+            str(item.get("detail", "")),
+            " ".join(str(alias) for alias in item.get("aliases", ())),
+        ]
+    )
+    haystack_tokens = _tokens_for_match(haystack)
+    score = 0
+    for query_token in query_tokens:
+        if any(_token_matches(token, query_token) for token in haystack_tokens):
+            score += 20
+    normalized_query = _normalize_for_match(query)
+    normalized_name = _normalize_for_match(str(item.get("name", "")))
+    if normalized_name.startswith(normalized_query):
+        score += 60
+    elif normalized_query in normalized_name:
+        score += 40
+    return score
+
+
+def _local_location_suggestions(query: str) -> list[LocationSuggestion]:
+    scored = [
+        (_score_local_location(query, item), item)
+        for item in LOCAL_LOCATION_GAZETTEER
+    ]
+    suggestions: list[LocationSuggestion] = []
+    for score, item in sorted(scored, key=lambda pair: pair[0], reverse=True):
+        if score <= 0:
+            continue
+        suggestions.append(
+            LocationSuggestion(
+                name=str(item["name"]),
+                detail=str(item.get("detail", "")),
+                lat=float(item["lat"]),
+                lon=float(item["lon"]),
+                height_m=float(item.get("height_m", 12000)),
+                source="local-gazetteer",
+            )
+        )
+    return suggestions[:5]
 
 
 @app.get("/")
@@ -1534,6 +1914,7 @@ async def runtime_config() -> RuntimeConfigResponse:
     return RuntimeConfigResponse(
         cesium_ion_token=CESIUM_ION_TOKEN,
         default_model=OLLAMA_MODEL,
+        claude_default_model=CLAUDE_MODEL,
         default_lat=DEFAULT_LAT,
         default_lon=DEFAULT_LON,
         default_height_m=DEFAULT_HEIGHT_M,
@@ -1542,41 +1923,101 @@ async def runtime_config() -> RuntimeConfigResponse:
 
 @app.get("/api/models", response_model=ModelsResponse)
 async def list_ollama_models() -> ModelsResponse:
-    timeout = httpx.Timeout(30.0, connect=10.0)
+    global ACTIVE_OLLAMA_BASE_URL
+    errors: list[str] = []
+    for base_url in _ollama_base_url_candidates():
+        try:
+            models = await _fetch_ollama_models_from(base_url)
+            ACTIVE_OLLAMA_BASE_URL = base_url
+            return ModelsResponse(
+                default_model=OLLAMA_MODEL,
+                models=models,
+                online=True,
+                base_url=base_url,
+            )
+        except httpx.HTTPStatusError as exc:
+            body = exc.response.text[:300]
+            errors.append(f"{base_url} returned {exc.response.status_code}: {body}")
+        except httpx.HTTPError as exc:
+            errors.append(f"{base_url} unreachable: {exc}")
+
+    detail = " | ".join(errors) if errors else "No Ollama base URLs were configured."
+    log.warning("ollama_models_unavailable", detail=detail)
+    return ModelsResponse(
+        default_model=OLLAMA_MODEL,
+        models=[],
+        online=False,
+        base_url=_ollama_base_url_candidates()[0],
+        detail=f"Local model unavailable. Deterministic source planner is active. {detail}",
+    )
+
+
+@app.get("/api/location-search", response_model=LocationSearchResponse)
+async def search_locations(
+    q: str = Query(min_length=2, max_length=200),
+) -> LocationSearchResponse:
+    query = q.strip()
+    suggestions = _local_location_suggestions(query)
+    online = False
+    detail: str | None = None
 
     try:
+        timeout = httpx.Timeout(LOCATION_SEARCH_TIMEOUT_S, connect=2.0)
         async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.get(f"{OLLAMA_BASE_URL}/api/tags")
+            response = await client.get(
+                LOCATION_SEARCH_URL,
+                params={
+                    "q": query,
+                    "format": "jsonv2",
+                    "limit": 6,
+                    "addressdetails": 1,
+                },
+                headers={
+                    "User-Agent": "TERA Source Planner local web app; optional online geocode"
+                },
+            )
             response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        body = exc.response.text[:500]
-        log.error(
-            "ollama_tags_http_error",
-            status_code=exc.response.status_code,
-            body=body,
-            ollama_base_url=OLLAMA_BASE_URL,
-        )
-        raise HTTPException(
-            status_code=502,
-            detail=f"Could not list models: Ollama returned {exc.response.status_code}: {body}",
-        ) from exc
-    except httpx.HTTPError as exc:
-        log.error("ollama_tags_connection_error", error=str(exc), ollama_base_url=OLLAMA_BASE_URL)
-        raise HTTPException(
-            status_code=502,
-            detail=(
-                "Could not reach Ollama to list models. Confirm it is running and that "
-                f"OLLAMA_BASE_URL={OLLAMA_BASE_URL} is reachable."
-            ),
-        ) from exc
+        online = True
+        for item in response.json():
+            lat = item.get("lat")
+            lon = item.get("lon")
+            if lat is None or lon is None:
+                continue
+            display_name = str(item.get("display_name") or item.get("name") or query)
+            category = str(item.get("category") or "online geocoder")
+            place_type = str(item.get("type") or "place")
+            suggestions.append(
+                LocationSuggestion(
+                    name=display_name.split(",")[0],
+                    detail=f"{category}/{place_type} - {display_name}",
+                    lat=float(lat),
+                    lon=float(lon),
+                    height_m=12000,
+                    source="online-geocoder",
+                )
+            )
+    except (httpx.HTTPError, ValueError) as exc:
+        detail = f"Online location lookup unavailable: {exc}"
 
-    data = response.json()
-    models = [
-        str(model.get("name", "")).strip()
-        for model in data.get("models", [])
-        if str(model.get("name", "")).strip()
-    ]
-    return ModelsResponse(default_model=OLLAMA_MODEL, models=models)
+    deduped: list[LocationSuggestion] = []
+    seen: set[tuple[int, int, str]] = set()
+    for suggestion in suggestions:
+        key = (
+            round(suggestion.lat * 1000),
+            round(suggestion.lon * 1000),
+            suggestion.name.lower(),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(suggestion)
+
+    return LocationSearchResponse(
+        query=query,
+        suggestions=deduped[:8],
+        online=online,
+        detail=detail,
+    )
 
 
 @app.get("/api/data-sources", response_model=SourceCatalogResponse)
@@ -1678,6 +2119,13 @@ def _download_plan_warnings(
         warnings.append(f"Unknown source ids ignored: {', '.join(unknown_ids)}")
     if not sources:
         warnings.append("No sources selected; manifest has no server ingest work.")
+    if request.map_context is None or not (
+        request.map_context.location_confirmed or request.map_context.selected_area
+    ):
+        warnings.append(
+            "Mission map focus is not confirmed; use location search, KML/KMZ import, "
+            "or AO drawing before treating bounds as final."
+        )
     if request.map_context is None or (
         request.map_context.selected_area is None and request.map_context.view_bounds is None
     ):
@@ -1741,35 +2189,37 @@ async def download_source_manifest(package_id: str) -> StreamingResponse:
 
 @app.post("/api/prompt", response_model=PromptResponse)
 async def prompt_ollama(request: PromptRequest) -> PromptResponse:
+    if _request_llm_provider(request) == "claude":
+        return await _post_claude_message(request)
+
     model, payload = _build_ollama_payload(request, stream=False)
 
     timeout = httpx.Timeout(REQUEST_TIMEOUT_S, connect=10.0)
 
-    try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.post(f"{OLLAMA_BASE_URL}/api/generate", json=payload)
-            response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        body = exc.response.text[:500]
-        log.error(
-            "ollama_http_error",
-            status_code=exc.response.status_code,
-            body=body,
-            ollama_base_url=OLLAMA_BASE_URL,
+    errors: list[str] = []
+    for base_url in _ollama_base_url_candidates():
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.post(f"{base_url}/api/generate", json=payload)
+                response.raise_for_status()
+            break
+        except httpx.HTTPStatusError as exc:
+            body = exc.response.text[:500]
+            errors.append(f"{base_url} returned {exc.response.status_code}: {body}")
+            log.error(
+                "ollama_http_error",
+                status_code=exc.response.status_code,
+                body=body,
+                ollama_base_url=base_url,
+            )
+        except httpx.HTTPError as exc:
+            errors.append(f"{base_url} unreachable: {exc}")
+            log.error("ollama_connection_error", error=str(exc), ollama_base_url=base_url)
+    else:
+        raise HTTPException(
+            status_code=502,
+            detail="Could not reach a local Ollama host. " + " | ".join(errors),
         )
-        raise HTTPException(
-            status_code=502,
-            detail=f"Ollama returned {exc.response.status_code}: {body}",
-        ) from exc
-    except httpx.HTTPError as exc:
-        log.error("ollama_connection_error", error=str(exc), ollama_base_url=OLLAMA_BASE_URL)
-        raise HTTPException(
-            status_code=502,
-            detail=(
-                "Could not reach Ollama. Confirm it is running and that "
-                f"OLLAMA_BASE_URL={OLLAMA_BASE_URL} is reachable from the container."
-            ),
-        ) from exc
 
     data = response.json()
     text = str(data.get("response", "")).strip()
@@ -1781,6 +2231,50 @@ async def prompt_ollama(request: PromptRequest) -> PromptResponse:
 
 @app.post("/api/prompt/stream")
 async def prompt_ollama_stream(request: PromptRequest) -> StreamingResponse:
+    if _request_llm_provider(request) == "claude":
+        model, _payload = _build_claude_payload(request)
+
+        async def claude_event_stream():
+            yield _sse_event({"type": "start", "model": model, "provider": "claude"})
+            yield _sse_event(
+                {
+                    "type": "status",
+                    "detail": "Waiting for Claude API response",
+                    "model": model,
+                }
+            )
+            try:
+                result = await _post_claude_message(request)
+            except HTTPException as exc:
+                yield _sse_event(
+                    {
+                        "type": "error",
+                        "detail": str(exc.detail),
+                        "model": model,
+                        "provider": "claude",
+                    }
+                )
+                return
+            yield _sse_event(
+                {
+                    "type": "token",
+                    "text": result.response,
+                    "model": result.model,
+                    "provider": "claude",
+                }
+            )
+            yield _sse_event({"type": "done", "model": result.model, "provider": "claude"})
+
+        return StreamingResponse(
+            claude_event_stream(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
     model, payload = _build_ollama_payload(request, stream=True)
     timeout = httpx.Timeout(REQUEST_TIMEOUT_S, connect=10.0)
 
@@ -1789,59 +2283,58 @@ async def prompt_ollama_stream(request: PromptRequest) -> StreamingResponse:
         yield _sse_event(
             {"type": "status", "detail": "Waiting for local model tokens", "model": model}
         )
-        try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                async with client.stream(
-                    "POST", f"{OLLAMA_BASE_URL}/api/generate", json=payload
-                ) as response:
-                    if response.status_code >= 400:
-                        body = (await response.aread()).decode("utf-8", errors="replace")[:500]
-                        log.error(
-                            "ollama_stream_http_error",
-                            status_code=response.status_code,
-                            body=body,
-                            ollama_base_url=OLLAMA_BASE_URL,
-                        )
-                        yield _sse_event(
-                            {
-                                "type": "error",
-                                "detail": f"Ollama returned {response.status_code}: {body}",
-                                "model": model,
-                            }
-                        )
-                        return
-
-                    async for line in response.aiter_lines():
-                        if not line:
-                            continue
-                        try:
-                            chunk = json.loads(line)
-                        except json.JSONDecodeError:
+        errors: list[str] = []
+        for base_url in _ollama_base_url_candidates():
+            try:
+                async with httpx.AsyncClient(timeout=timeout) as client:
+                    async with client.stream(
+                        "POST", f"{base_url}/api/generate", json=payload
+                    ) as response:
+                        if response.status_code >= 400:
+                            body = (await response.aread()).decode(
+                                "utf-8", errors="replace"
+                            )[:500]
+                            errors.append(
+                                f"{base_url} returned {response.status_code}: {body}"
+                            )
+                            log.error(
+                                "ollama_stream_http_error",
+                                status_code=response.status_code,
+                                body=body,
+                                ollama_base_url=base_url,
+                            )
                             continue
 
-                        text = str(chunk.get("response", ""))
-                        if text:
-                            yield _sse_event({"type": "token", "text": text, "model": model})
+                        async for line in response.aiter_lines():
+                            if not line:
+                                continue
+                            try:
+                                chunk = json.loads(line)
+                            except json.JSONDecodeError:
+                                continue
 
-                        if chunk.get("done"):
-                            yield _sse_event({"type": "done", "model": model})
-                            return
-        except httpx.HTTPError as exc:
-            log.error(
-                "ollama_stream_connection_error",
-                error=str(exc),
-                ollama_base_url=OLLAMA_BASE_URL,
-            )
-            yield _sse_event(
-                {
-                    "type": "error",
-                    "detail": (
-                        "Could not reach Ollama. Confirm it is running and that "
-                        f"OLLAMA_BASE_URL={OLLAMA_BASE_URL} is reachable."
-                    ),
-                    "model": model,
-                }
-            )
+                            text = str(chunk.get("response", ""))
+                            if text:
+                                yield _sse_event({"type": "token", "text": text, "model": model})
+
+                            if chunk.get("done"):
+                                yield _sse_event({"type": "done", "model": model})
+                                return
+            except httpx.HTTPError as exc:
+                errors.append(f"{base_url} unreachable: {exc}")
+                log.error(
+                    "ollama_stream_connection_error",
+                    error=str(exc),
+                    ollama_base_url=base_url,
+                )
+
+        yield _sse_event(
+            {
+                "type": "error",
+                "detail": "Could not reach a local Ollama host. " + " | ".join(errors),
+                "model": model,
+            }
+        )
 
     return StreamingResponse(
         event_stream(),

--- a/llm_dev_kmh/app.py
+++ b/llm_dev_kmh/app.py
@@ -26,6 +26,43 @@ IMAGERY_SOURCING_PROMPT_FILE = (
 )
 INDEX_FILE = BASE_DIR / "static" / "index.html"
 STATIC_DIR = BASE_DIR / "static"
+
+
+def _load_dotenv_file(path: Path) -> None:
+    if not path.exists():
+        return
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        key, separator, value = line.partition("=")
+        if not separator:
+            continue
+        key = key.strip()
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+            continue
+        if key in os.environ:
+            continue
+        value = value.strip()
+        if (
+            len(value) >= 2
+            and value[0] == value[-1]
+            and value[0] in {'"', "'"}
+        ):
+            value = value[1:-1]
+        os.environ[key] = value
+
+
+_load_dotenv_file(BASE_DIR.parent / ".env")
+_load_dotenv_file(BASE_DIR.parent / ".env.local")
+
 OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
 OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "gemma2:2b")
 ANTHROPIC_API_URL = os.getenv(
@@ -78,7 +115,13 @@ GOOGLE_MAPS_COORD_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"@(?P<lat>[+-]?\d+(?:\.\d+)?),(?P<lon>[+-]?\d+(?:\.\d+)?)", re.IGNORECASE),
     re.compile(r"[?&](?:q|ll|center)=(?P<lat>[+-]?\d+(?:\.\d+)?),(?P<lon>[+-]?\d+(?:\.\d+)?)", re.IGNORECASE),
 )
-CESIUM_ION_TOKEN = os.getenv("CESIUM_ION_TOKEN", "")
+CESIUM_ION_TOKEN = (
+    os.getenv("CESIUM_ION_TOKEN")
+    or os.getenv("CESIUM_TOKEN")
+    or os.getenv("CESIUM_ACCESS_TOKEN")
+    or os.getenv("CESIUM_ION_ACCESS_TOKEN")
+    or ""
+).strip()
 DEFAULT_LAT = float(os.getenv("DEFAULT_LAT", "37.7749"))
 DEFAULT_LON = float(os.getenv("DEFAULT_LON", "-122.4194"))
 DEFAULT_HEIGHT_M = float(os.getenv("DEFAULT_HEIGHT_M", "14000"))

--- a/llm_dev_kmh/docker-compose.yml
+++ b/llm_dev_kmh/docker-compose.yml
@@ -6,7 +6,13 @@ services:
       - "8080:8080"
     environment:
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
-      OLLAMA_MODEL: ${OLLAMA_MODEL:-gemma2:2b}
+      OLLAMA_MODEL: ${OLLAMA_MODEL:-gemma3:4b}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      CLAUDE_MODEL: ${CLAUDE_MODEL:-claude-sonnet-4-6}
+      TERA_ATAK_MODEL: ${TERA_ATAK_MODEL:-gemma3:4b}
+      TERA_ATAK_AGENT_PROFILE: ${TERA_ATAK_AGENT_PROFILE:-tera-atak-live}
+      TERA_ATAK_DEVICE_URL: ${TERA_ATAK_DEVICE_URL:-}
+      TERA_ATAK_AGENT_COMMAND: ${TERA_ATAK_AGENT_COMMAND:-}
       REQUEST_TIMEOUT_S: ${REQUEST_TIMEOUT_S:-120}
       CESIUM_ION_TOKEN: ${CESIUM_ION_TOKEN:-}
     extra_hosts:

--- a/llm_dev_kmh/geo_algorithms.py
+++ b/llm_dev_kmh/geo_algorithms.py
@@ -1,0 +1,748 @@
+from __future__ import annotations
+
+import heapq
+import math
+from collections import deque
+from dataclasses import dataclass
+from itertools import count
+from typing import Callable, Hashable, Iterable, Mapping, Sequence
+
+Node = Hashable
+Graph = Mapping[Node, Sequence[tuple[Node, float]]]
+GridPoint = tuple[int, int]
+Grid = Sequence[Sequence[float | int | None]]
+
+
+@dataclass(frozen=True)
+class RasterCostResult:
+    distance: list[list[float]]
+    predecessor: dict[GridPoint, GridPoint]
+    sources: tuple[GridPoint, ...]
+
+
+def reconstruct_path(
+    predecessor: Mapping[Node, Node],
+    start: Node,
+    goal: Node,
+) -> list[Node]:
+    if start == goal:
+        return [start]
+    if goal not in predecessor:
+        return []
+
+    path = [goal]
+    cursor = goal
+    while cursor != start:
+        cursor = predecessor[cursor]
+        path.append(cursor)
+    path.reverse()
+    return path
+
+
+def dijkstra(
+    graph: Graph,
+    start: Node,
+    goal: Node | None = None,
+) -> tuple[dict[Node, float], dict[Node, Node]]:
+    distances: dict[Node, float] = {start: 0.0}
+    predecessor: dict[Node, Node] = {}
+    heap: list[tuple[float, int, Node]] = []
+    tie = count()
+    heapq.heappush(heap, (0.0, next(tie), start))
+
+    while heap:
+        current_cost, _index, node = heapq.heappop(heap)
+        if current_cost > distances.get(node, math.inf):
+            continue
+        if goal is not None and node == goal:
+            break
+        for neighbor, edge_cost in graph.get(node, ()):
+            if edge_cost < 0:
+                raise ValueError("Dijkstra requires non-negative edge costs.")
+            next_cost = current_cost + float(edge_cost)
+            if next_cost < distances.get(neighbor, math.inf):
+                distances[neighbor] = next_cost
+                predecessor[neighbor] = node
+                heapq.heappush(heap, (next_cost, next(tie), neighbor))
+
+    return distances, predecessor
+
+
+def astar(
+    graph: Graph,
+    start: Node,
+    goal: Node,
+    heuristic: Callable[[Node, Node], float] | None = None,
+) -> tuple[list[Node], float]:
+    estimate = heuristic or (lambda _node, _goal: 0.0)
+    g_score: dict[Node, float] = {start: 0.0}
+    predecessor: dict[Node, Node] = {}
+    heap: list[tuple[float, int, Node]] = []
+    tie = count()
+    heapq.heappush(heap, (estimate(start, goal), next(tie), start))
+
+    while heap:
+        _f_score, _index, node = heapq.heappop(heap)
+        if node == goal:
+            return reconstruct_path(predecessor, start, goal), g_score[node]
+        for neighbor, edge_cost in graph.get(node, ()):
+            if edge_cost < 0:
+                raise ValueError("A* requires non-negative edge costs.")
+            tentative = g_score[node] + float(edge_cost)
+            if tentative < g_score.get(neighbor, math.inf):
+                predecessor[neighbor] = node
+                g_score[neighbor] = tentative
+                heapq.heappush(
+                    heap,
+                    (tentative + estimate(neighbor, goal), next(tie), neighbor),
+                )
+
+    return [], math.inf
+
+
+def multi_source_dijkstra(
+    graph: Graph,
+    sources: Iterable[Node],
+    goals: set[Node] | None = None,
+) -> tuple[dict[Node, float], dict[Node, Node], Node | None]:
+    distances: dict[Node, float] = {}
+    predecessor: dict[Node, Node] = {}
+    heap: list[tuple[float, int, Node]] = []
+    tie = count()
+
+    for source in sources:
+        distances[source] = 0.0
+        heapq.heappush(heap, (0.0, next(tie), source))
+
+    reached_goal: Node | None = None
+    while heap:
+        current_cost, _index, node = heapq.heappop(heap)
+        if current_cost > distances.get(node, math.inf):
+            continue
+        if goals and node in goals:
+            reached_goal = node
+            break
+        for neighbor, edge_cost in graph.get(node, ()):
+            if edge_cost < 0:
+                raise ValueError("Dijkstra requires non-negative edge costs.")
+            next_cost = current_cost + float(edge_cost)
+            if next_cost < distances.get(neighbor, math.inf):
+                distances[neighbor] = next_cost
+                predecessor[neighbor] = node
+                heapq.heappush(heap, (next_cost, next(tie), neighbor))
+
+    return distances, predecessor, reached_goal
+
+
+def path_cost(graph: Graph, path: Sequence[Node]) -> float:
+    if len(path) < 2:
+        return 0.0
+    total = 0.0
+    for left, right in zip(path, path[1:]):
+        for neighbor, edge_cost in graph.get(left, ()):
+            if neighbor == right:
+                total += float(edge_cost)
+                break
+        else:
+            return math.inf
+    return total
+
+
+def yens_k_shortest_paths(
+    graph: Graph,
+    start: Node,
+    goal: Node,
+    k: int,
+    heuristic: Callable[[Node, Node], float] | None = None,
+) -> list[tuple[list[Node], float]]:
+    first_path, first_cost = astar(graph, start, goal, heuristic)
+    if not first_path:
+        return []
+
+    accepted: list[tuple[list[Node], float]] = [(first_path, first_cost)]
+    candidates: list[tuple[float, int, list[Node]]] = []
+    tie = count()
+
+    for kth in range(1, max(1, k)):
+        previous_path = accepted[kth - 1][0]
+        for spur_index in range(len(previous_path) - 1):
+            spur_node = previous_path[spur_index]
+            root_path = previous_path[: spur_index + 1]
+            root_nodes = set(root_path[:-1])
+            removed_edges: set[tuple[Node, Node]] = set()
+
+            for path, _cost in accepted:
+                if len(path) > spur_index and path[: spur_index + 1] == root_path:
+                    removed_edges.add((path[spur_index], path[spur_index + 1]))
+
+            def graph_view(node: Node) -> Sequence[tuple[Node, float]]:
+                edges = []
+                for neighbor, edge_cost in graph.get(node, ()):
+                    if (node, neighbor) in removed_edges:
+                        continue
+                    if neighbor in root_nodes:
+                        continue
+                    edges.append((neighbor, edge_cost))
+                return edges
+
+            spur_graph: Graph = _GraphView(graph_view)
+            spur_path, spur_cost = astar(spur_graph, spur_node, goal, heuristic)
+            if not spur_path:
+                continue
+            total_path = root_path[:-1] + spur_path
+            if any(total_path == path for path, _cost in accepted):
+                continue
+            total_cost = path_cost(graph, root_path) + spur_cost
+            heapq.heappush(candidates, (total_cost, next(tie), total_path))
+
+        if not candidates:
+            break
+        cost, _index, path = heapq.heappop(candidates)
+        accepted.append((path, cost))
+
+    return accepted[:k]
+
+
+class _GraphView(Mapping[Node, Sequence[tuple[Node, float]]]):
+    def __init__(self, getter: Callable[[Node], Sequence[tuple[Node, float]]]) -> None:
+        self._getter = getter
+
+    def __getitem__(self, key: Node) -> Sequence[tuple[Node, float]]:
+        return self._getter(key)
+
+    def __iter__(self):
+        return iter(())
+
+    def __len__(self) -> int:
+        return 0
+
+    def get(self, key: Node, default=None):  # type: ignore[override]
+        return self._getter(key)
+
+
+def raster_cost_distance(
+    cost_grid: Grid,
+    starts: Iterable[GridPoint],
+    *,
+    diagonal: bool = True,
+) -> RasterCostResult:
+    rows = len(cost_grid)
+    cols = len(cost_grid[0]) if rows else 0
+    distances = [[math.inf for _col in range(cols)] for _row in range(rows)]
+    predecessor: dict[GridPoint, GridPoint] = {}
+    heap: list[tuple[float, int, GridPoint]] = []
+    tie = count()
+    source_points = tuple(starts)
+
+    for row, col in source_points:
+        if _is_passable(cost_grid, row, col):
+            distances[row][col] = 0.0
+            heapq.heappush(heap, (0.0, next(tie), (row, col)))
+
+    while heap:
+        current_cost, _index, point = heapq.heappop(heap)
+        row, col = point
+        if current_cost > distances[row][col]:
+            continue
+        for neighbor in _grid_neighbors(row, col, rows, cols, diagonal=diagonal):
+            nr, nc = neighbor
+            if not _is_passable(cost_grid, nr, nc):
+                continue
+            step_distance = math.sqrt(2.0) if nr != row and nc != col else 1.0
+            cell_cost = (float(cost_grid[row][col]) + float(cost_grid[nr][nc])) / 2.0
+            next_cost = current_cost + cell_cost * step_distance
+            if next_cost < distances[nr][nc]:
+                distances[nr][nc] = next_cost
+                predecessor[neighbor] = point
+                heapq.heappush(heap, (next_cost, next(tie), neighbor))
+
+    return RasterCostResult(distances, predecessor, source_points)
+
+
+def backtrack_least_cost_path(
+    result: RasterCostResult,
+    target: GridPoint,
+) -> list[GridPoint]:
+    row, col = target
+    if row < 0 or col < 0 or row >= len(result.distance) or col >= len(result.distance[row]):
+        return []
+    if not math.isfinite(result.distance[row][col]):
+        return []
+
+    path = [target]
+    cursor = target
+    while cursor not in result.sources:
+        if cursor not in result.predecessor:
+            return []
+        cursor = result.predecessor[cursor]
+        path.append(cursor)
+    path.reverse()
+    return path
+
+
+def derive_terrain_layers(
+    elevation_grid: Grid,
+    *,
+    cell_size_m: float,
+) -> dict[str, list[list[float]]]:
+    rows = len(elevation_grid)
+    cols = len(elevation_grid[0]) if rows else 0
+    slope = [[0.0 for _col in range(cols)] for _row in range(rows)]
+    aspect = [[0.0 for _col in range(cols)] for _row in range(rows)]
+    roughness = [[0.0 for _col in range(cols)] for _row in range(rows)]
+    tpi = [[0.0 for _col in range(cols)] for _row in range(rows)]
+    curvature = [[0.0 for _col in range(cols)] for _row in range(rows)]
+
+    for row in range(rows):
+        for col in range(cols):
+            center = _safe_elevation(elevation_grid, row, col)
+            left = _safe_elevation(elevation_grid, row, max(0, col - 1))
+            right = _safe_elevation(elevation_grid, row, min(cols - 1, col + 1))
+            up = _safe_elevation(elevation_grid, max(0, row - 1), col)
+            down = _safe_elevation(elevation_grid, min(rows - 1, row + 1), col)
+            dzdx = (right - left) / (2.0 * cell_size_m)
+            dzdy = (down - up) / (2.0 * cell_size_m)
+            slope[row][col] = math.degrees(math.atan(math.hypot(dzdx, dzdy)))
+            aspect[row][col] = (math.degrees(math.atan2(dzdy, -dzdx)) + 360.0) % 360.0
+
+            neighbors = [
+                _safe_elevation(elevation_grid, nr, nc)
+                for nr in range(max(0, row - 1), min(rows, row + 2))
+                for nc in range(max(0, col - 1), min(cols, col + 2))
+            ]
+            roughness[row][col] = max(neighbors) - min(neighbors)
+            tpi[row][col] = center - (sum(neighbors) / len(neighbors))
+            curvature[row][col] = (left + right + up + down - 4.0 * center) / (
+                cell_size_m**2
+            )
+
+    return {
+        "slope_degrees": slope,
+        "aspect_degrees": aspect,
+        "roughness_m": roughness,
+        "topographic_position_index_m": tpi,
+        "curvature": curvature,
+    }
+
+
+def build_walking_cost_surface(
+    slope_degrees: Grid,
+    *,
+    landcover_grid: Sequence[Sequence[str | int | None]] | None = None,
+    hazard_mask: Sequence[Sequence[bool]] | None = None,
+    max_slope_deg: float = 35.0,
+) -> list[list[float]]:
+    rows = len(slope_degrees)
+    cols = len(slope_degrees[0]) if rows else 0
+    costs = [[math.inf for _col in range(cols)] for _row in range(rows)]
+
+    for row in range(rows):
+        for col in range(cols):
+            slope = float(slope_degrees[row][col] or 0)
+            if hazard_mask and hazard_mask[row][col]:
+                continue
+            if slope > max_slope_deg:
+                continue
+            multiplier = 1.0 + (slope / 22.0) ** 2
+            if landcover_grid:
+                multiplier *= _landcover_multiplier(landcover_grid[row][col])
+            costs[row][col] = multiplier
+    return costs
+
+
+def flow_direction_d8(elevation_grid: Grid, *, cell_size_m: float) -> list[list[GridPoint | None]]:
+    rows = len(elevation_grid)
+    cols = len(elevation_grid[0]) if rows else 0
+    directions: list[list[GridPoint | None]] = [[None for _col in range(cols)] for _row in range(rows)]
+
+    for row in range(rows):
+        for col in range(cols):
+            current = _safe_elevation(elevation_grid, row, col)
+            best_drop = 0.0
+            best_neighbor: GridPoint | None = None
+            for nr, nc in _grid_neighbors(row, col, rows, cols, diagonal=True):
+                distance = math.sqrt(2.0) * cell_size_m if nr != row and nc != col else cell_size_m
+                drop = (current - _safe_elevation(elevation_grid, nr, nc)) / distance
+                if drop > best_drop:
+                    best_drop = drop
+                    best_neighbor = (nr, nc)
+            directions[row][col] = best_neighbor
+    return directions
+
+
+def flow_accumulation_d8(elevation_grid: Grid, *, cell_size_m: float) -> list[list[int]]:
+    directions = flow_direction_d8(elevation_grid, cell_size_m=cell_size_m)
+    rows = len(directions)
+    cols = len(directions[0]) if rows else 0
+    indegree = [[0 for _col in range(cols)] for _row in range(rows)]
+    accumulation = [[1 for _col in range(cols)] for _row in range(rows)]
+
+    for row in range(rows):
+        for col in range(cols):
+            downstream = directions[row][col]
+            if downstream:
+                indegree[downstream[0]][downstream[1]] += 1
+
+    queue: deque[GridPoint] = deque(
+        (row, col)
+        for row in range(rows)
+        for col in range(cols)
+        if indegree[row][col] == 0
+    )
+
+    while queue:
+        row, col = queue.popleft()
+        downstream = directions[row][col]
+        if downstream is None:
+            continue
+        dr, dc = downstream
+        accumulation[dr][dc] += accumulation[row][col]
+        indegree[dr][dc] -= 1
+        if indegree[dr][dc] == 0:
+            queue.append((dr, dc))
+
+    return accumulation
+
+
+def viewshed(
+    elevation_grid: Grid,
+    observer: GridPoint,
+    *,
+    cell_size_m: float,
+    observer_height_m: float = 2.0,
+    target_height_m: float = 1.5,
+    max_radius_cells: int | None = None,
+) -> list[list[bool]]:
+    rows = len(elevation_grid)
+    cols = len(elevation_grid[0]) if rows else 0
+    visible = [[False for _col in range(cols)] for _row in range(rows)]
+    observer_row, observer_col = observer
+    observer_elev = _safe_elevation(elevation_grid, observer_row, observer_col) + observer_height_m
+
+    for row in range(rows):
+        for col in range(cols):
+            radius = max(abs(row - observer_row), abs(col - observer_col))
+            if max_radius_cells is not None and radius > max_radius_cells:
+                continue
+            visible[row][col] = _has_line_of_sight(
+                elevation_grid,
+                (observer_row, observer_col),
+                (row, col),
+                observer_elev,
+                target_height_m,
+            )
+    return visible
+
+
+def isochrone_masks(
+    distance_grid: Sequence[Sequence[float]],
+    thresholds: Sequence[float],
+) -> dict[float, list[list[bool]]]:
+    return {
+        float(threshold): [
+            [math.isfinite(value) and value <= threshold for value in row]
+            for row in distance_grid
+        ]
+        for threshold in thresholds
+    }
+
+
+def radial_sar_sectors(
+    center_lat: float,
+    center_lon: float,
+    radius_m: float,
+    sector_count: int,
+    *,
+    start_bearing_deg: float = 0.0,
+    arc_steps_per_sector: int = 8,
+) -> dict[str, object]:
+    if sector_count <= 0:
+        raise ValueError("sector_count must be positive.")
+
+    features = []
+    width = 360.0 / sector_count
+    for index in range(sector_count):
+        start = start_bearing_deg + index * width
+        end = start + width
+        coordinates = [[center_lon, center_lat]]
+        for step in range(arc_steps_per_sector + 1):
+            bearing = start + (end - start) * (step / arc_steps_per_sector)
+            lat, lon = _destination_point(center_lat, center_lon, bearing, radius_m)
+            coordinates.append([lon, lat])
+        coordinates.append([center_lon, center_lat])
+        features.append(
+            {
+                "type": "Feature",
+                "properties": {
+                    "sector": index + 1,
+                    "bearing_start_deg": start % 360.0,
+                    "bearing_end_deg": end % 360.0,
+                    "radius_m": radius_m,
+                },
+                "geometry": {"type": "Polygon", "coordinates": [coordinates]},
+            }
+        )
+
+    return {"type": "FeatureCollection", "features": features}
+
+
+def sar_probability_surface(
+    rows: int,
+    cols: int,
+    last_known: GridPoint,
+    *,
+    sigma_cells: float = 6.0,
+    travel_cost: Sequence[Sequence[float]] | None = None,
+    attraction_points: Sequence[GridPoint] | None = None,
+) -> list[list[float]]:
+    if rows <= 0 or cols <= 0:
+        return []
+
+    lk_row, lk_col = last_known
+    attraction_points = attraction_points or ()
+    probabilities = [[0.0 for _col in range(cols)] for _row in range(rows)]
+    total = 0.0
+
+    for row in range(rows):
+        for col in range(cols):
+            distance_cells = math.hypot(row - lk_row, col - lk_col)
+            probability = math.exp(-(distance_cells**2) / (2.0 * sigma_cells**2))
+            if travel_cost:
+                cost = travel_cost[row][col]
+                probability *= 0.0 if not math.isfinite(cost) else 1.0 / (1.0 + cost)
+            for point in attraction_points:
+                probability += 0.25 * math.exp(
+                    -(math.hypot(row - point[0], col - point[1]) ** 2)
+                    / (2.0 * (sigma_cells / 2.0) ** 2)
+                )
+            probabilities[row][col] = probability
+            total += probability
+
+    if total <= 0:
+        return probabilities
+    return [[value / total for value in row] for row in probabilities]
+
+
+def score_route(
+    *,
+    normalized_time: float,
+    normalized_energy: float,
+    hazard_exposure: float,
+    data_uncertainty: float,
+    resource_value: float = 0.0,
+    rescue_visibility: float = 0.0,
+    weights: Mapping[str, float] | None = None,
+) -> float:
+    route_weights = {
+        "time": 0.25,
+        "energy": 0.2,
+        "risk": 0.35,
+        "uncertainty": 0.15,
+        "resource": 0.03,
+        "rescue": 0.02,
+    }
+    if weights:
+        route_weights.update(weights)
+    return (
+        route_weights["time"] * normalized_time
+        + route_weights["energy"] * normalized_energy
+        + route_weights["risk"] * hazard_exposure
+        + route_weights["uncertainty"] * data_uncertainty
+        - route_weights["resource"] * resource_value
+        - route_weights["rescue"] * rescue_visibility
+    )
+
+
+def algorithm_catalog() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "graph_dijkstra",
+            "purpose": "Default shortest path on local road/trail graph.",
+            "inputs": ["GeoPackage/SQLite graph edges", "edge_cost"],
+            "outputs": ["least_cost_path", "distance_or_time"],
+        },
+        {
+            "id": "graph_astar",
+            "purpose": "Goal-directed graph routing with admissible distance heuristic.",
+            "inputs": ["graph edges", "node coordinates", "heuristic"],
+            "outputs": ["least_cost_path", "route_cost"],
+        },
+        {
+            "id": "multi_source_dijkstra",
+            "purpose": "Nearest target among water, shelter, road, trail, or signal candidates.",
+            "inputs": ["graph edges", "candidate node set"],
+            "outputs": ["nearest_candidate", "access_path"],
+        },
+        {
+            "id": "yen_k_shortest_paths",
+            "purpose": "Fastest, safest, and easiest alternatives when graph routes differ.",
+            "inputs": ["graph edges", "source/destination", "k"],
+            "outputs": ["ranked_route_alternatives"],
+        },
+        {
+            "id": "raster_cost_distance",
+            "purpose": "Off-road and hybrid movement over slope/landcover/hazard cost rasters.",
+            "inputs": ["COG cost raster", "start cells"],
+            "outputs": ["cumulative_cost_raster", "predecessor_grid"],
+        },
+        {
+            "id": "least_cost_backtrack",
+            "purpose": "Recover least-cost route geometry from cumulative raster output.",
+            "inputs": ["cumulative_cost_raster", "predecessor_grid", "target cell"],
+            "outputs": ["least_cost_cell_path"],
+        },
+        {
+            "id": "terrain_derivatives",
+            "purpose": "Generate slope, aspect, roughness, and TPI from Esri/DEM COGs.",
+            "inputs": ["DEM COG"],
+            "outputs": ["slope_degrees", "aspect_degrees", "roughness", "tpi", "curvature"],
+        },
+        {
+            "id": "flow_accumulation_d8",
+            "purpose": "Drainage and likely water reasoning from DEM cells.",
+            "inputs": ["DEM COG"],
+            "outputs": ["flow_direction", "flow_accumulation"],
+        },
+        {
+            "id": "viewshed",
+            "purpose": "Line-of-sight, signal, open-sky, and observation checks.",
+            "inputs": ["DEM COG", "observer cell", "antenna heights"],
+            "outputs": ["visible_cell_mask"],
+        },
+        {
+            "id": "isochrone_masks",
+            "purpose": "Reachable area masks from travel-time or cost surfaces.",
+            "inputs": ["cumulative_cost_raster", "thresholds"],
+            "outputs": ["reachable_area_masks"],
+        },
+        {
+            "id": "sar_sector_partition",
+            "purpose": "Radial SAR sectors for hasty search planning.",
+            "inputs": ["center", "radius", "sector_count"],
+            "outputs": ["GeoJSON sector polygons"],
+        },
+        {
+            "id": "sar_probability_surface",
+            "purpose": "Normalized probability-of-area grid from last known position and travel cost.",
+            "inputs": ["last_known_cell", "sigma", "travel_cost", "attraction_points"],
+            "outputs": ["probability_grid"],
+        },
+        {
+            "id": "route_score",
+            "purpose": "Separate time, energy, risk, uncertainty, resource, and rescue visibility scoring.",
+            "inputs": ["route metrics", "mission weights"],
+            "outputs": ["comparable route score"],
+        },
+    ]
+
+
+def _grid_neighbors(
+    row: int,
+    col: int,
+    rows: int,
+    cols: int,
+    *,
+    diagonal: bool,
+) -> Iterable[GridPoint]:
+    offsets = (
+        (-1, 0),
+        (1, 0),
+        (0, -1),
+        (0, 1),
+    )
+    if diagonal:
+        offsets = (
+            *offsets,
+            (-1, -1),
+            (-1, 1),
+            (1, -1),
+            (1, 1),
+        )
+    for dr, dc in offsets:
+        nr = row + dr
+        nc = col + dc
+        if 0 <= nr < rows and 0 <= nc < cols:
+            yield nr, nc
+
+
+def _is_passable(grid: Grid, row: int, col: int) -> bool:
+    value = grid[row][col]
+    return value is not None and math.isfinite(float(value)) and float(value) > 0
+
+
+def _safe_elevation(grid: Grid, row: int, col: int) -> float:
+    value = grid[row][col]
+    if value is None:
+        return 0.0
+    return float(value)
+
+
+def _landcover_multiplier(value: str | int | None) -> float:
+    lookup = {
+        "road": 0.5,
+        "trail": 0.6,
+        "open": 1.0,
+        "grass": 1.0,
+        "shrub": 1.4,
+        "forest": 1.6,
+        "dense_brush": 2.8,
+        "wetland": 4.5,
+        "water": math.inf,
+        11: math.inf,
+        21: 0.8,
+        41: 1.6,
+        42: 1.6,
+        43: 1.7,
+        52: 1.4,
+        90: 4.5,
+        95: 4.5,
+    }
+    return float(lookup.get(value, 1.2))
+
+
+def _has_line_of_sight(
+    elevation_grid: Grid,
+    observer: GridPoint,
+    target: GridPoint,
+    observer_elev: float,
+    target_height_m: float,
+) -> bool:
+    if observer == target:
+        return True
+
+    start_row, start_col = observer
+    target_row, target_col = target
+    target_elev = _safe_elevation(elevation_grid, target_row, target_col) + target_height_m
+    steps = max(abs(target_row - start_row), abs(target_col - start_col))
+
+    for step in range(1, steps):
+        fraction = step / steps
+        row = round(start_row + (target_row - start_row) * fraction)
+        col = round(start_col + (target_col - start_col) * fraction)
+        terrain_elev = _safe_elevation(elevation_grid, row, col)
+        line_elev = observer_elev + (target_elev - observer_elev) * fraction
+        if terrain_elev > line_elev:
+            return False
+    return True
+
+
+def _destination_point(
+    lat: float,
+    lon: float,
+    bearing_deg: float,
+    distance_m: float,
+) -> tuple[float, float]:
+    radius_m = 6_371_000.0
+    bearing = math.radians(bearing_deg)
+    lat1 = math.radians(lat)
+    lon1 = math.radians(lon)
+    angular = distance_m / radius_m
+    lat2 = math.asin(
+        math.sin(lat1) * math.cos(angular)
+        + math.cos(lat1) * math.sin(angular) * math.cos(bearing)
+    )
+    lon2 = lon1 + math.atan2(
+        math.sin(bearing) * math.sin(angular) * math.cos(lat1),
+        math.cos(angular) - math.sin(lat1) * math.sin(lat2),
+    )
+    return math.degrees(lat2), ((math.degrees(lon2) + 540.0) % 360.0) - 180.0

--- a/llm_dev_kmh/requirements.txt
+++ b/llm_dev_kmh/requirements.txt
@@ -2,3 +2,6 @@ fastapi>=0.115
 uvicorn[standard]>=0.30
 httpx>=0.27
 structlog>=24.1
+rasterio>=1.3
+cryptography>=43.0
+defusedxml>=0.7

--- a/llm_dev_kmh/static/app.js
+++ b/llm_dev_kmh/static/app.js
@@ -41,7 +41,7 @@ const state = {
   localModelAvailable: false,
   localModelDetail: "",
   serverClaudeKeyAvailable: false,
-  llmProvider: sessionStorage.getItem("teraLlmProvider") || "ollama",
+  llmProvider: sessionStorage.getItem("teraLlmProvider") || "auto",
   claudeApiKey: sessionStorage.getItem("teraClaudeApiKey") || "",
   selectedSourceIds: new Set(),
   packagePlan: null,
@@ -1786,15 +1786,29 @@ function hasClaudeProviderCredential() {
 
 function applyProviderVisibility() {
   const isClaude = state.llmProvider === "claude";
+  const isAuto = state.llmProvider === "auto";
   const hasClaudeKey = hasClaudeProviderCredential();
   els.providerSelect.value = state.llmProvider;
   els.providerLocalModelRow.classList.toggle("hidden", isClaude);
-  els.providerClaudeModelRow.classList.toggle("hidden", !isClaude);
-  els.providerClaudeKeyRow.classList.toggle("hidden", !isClaude);
+  els.providerClaudeModelRow.classList.toggle("hidden", !(isClaude || isAuto));
+  els.providerClaudeKeyRow.classList.toggle("hidden", !(isClaude || isAuto));
   if (state.claudeApiKey) {
     els.claudeApiKeyInput.value = state.claudeApiKey;
   }
-  if (isClaude) {
+  if (isAuto) {
+    const localLabel = els.modelSelect.value || els.topModelSelect.value || state.config?.default_model || "local model";
+    const tone = hasClaudeKey || state.localModelAvailable ? "good" : "warn";
+    setModelProviderButton(hasClaudeKey ? "Auto: Claude primary" : "Auto: local fallback", tone);
+    if (hasClaudeKey && state.localModelAvailable) {
+      els.providerStatus.textContent = `Claude primary; local fallback: ${localLabel}`;
+    } else if (hasClaudeKey) {
+      els.providerStatus.textContent = "Claude primary; local model unavailable";
+    } else if (state.localModelAvailable) {
+      els.providerStatus.textContent = `Claude key missing; using local fallback: ${localLabel}`;
+    } else {
+      els.providerStatus.textContent = "Claude key and local model unavailable; deterministic planner remains active";
+    }
+  } else if (isClaude) {
     setModelProviderButton(`Claude: ${els.claudeModelSelect.value}`, hasClaudeKey ? "good" : "warn");
     els.providerStatus.textContent = state.claudeApiKey
       ? "Claude API key loaded for this browser session"
@@ -1829,7 +1843,7 @@ function applyProviderSelection() {
     sessionStorage.removeItem("teraClaudeApiKey");
   }
 
-  if (state.llmProvider === "ollama") {
+  if (state.llmProvider === "ollama" || state.llmProvider === "auto") {
     els.modelSelect.value = els.topModelSelect.value;
   }
   applyProviderVisibility();
@@ -2729,9 +2743,16 @@ async function loadRuntimeConfig() {
   state.config = await fetchJson("/api/config");
   state.cesiumIonTokenAvailable = hasCesiumIonToken();
   state.serverClaudeKeyAvailable = Boolean(state.config.anthropic_api_key_configured);
+  if (!sessionStorage.getItem("teraLlmProvider")) {
+    state.llmProvider = state.config.default_provider || (state.serverClaudeKeyAvailable ? "auto" : "ollama");
+  }
   setChip(els.tokenChip, "Map stream checking");
+  els.providerSelect.value = state.llmProvider;
   els.claudeModelSelect.value = state.config.claude_default_model || els.claudeModelSelect.value;
-  setModelProviderButton(`Default model: ${state.config.default_model}`, "warn");
+  setModelProviderButton(
+    state.llmProvider === "auto" ? "Auto: Claude primary" : `Default model: ${state.config.default_model}`,
+    state.serverClaudeKeyAvailable ? "good" : "warn",
+  );
   state.imageryMode = "esri";
   state.terrainMode = state.cesiumIonTokenAvailable ? "cesium-world" : "ellipsoid";
   els.imagerySelect.value = state.imageryMode;
@@ -2984,6 +3005,9 @@ async function downloadPackageToJetson() {
 }
 
 function providerDisplayName(provider) {
+  if (provider === "auto") {
+    return "auto provider";
+  }
   return provider === "claude" ? "Claude" : "local Ollama";
 }
 
@@ -3001,7 +3025,8 @@ async function resolveLocalModelForFallback() {
 async function streamAssistantProvider({
   assistantMessage,
   provider,
-  model,
+  localModel,
+  cloudModel,
   finalPrompt,
   system,
   agentProfile,
@@ -3012,13 +3037,20 @@ async function streamAssistantProvider({
   const providerLabel = providerDisplayName(provider);
   const baseMeta = metaPrefix ? `${metaPrefix} | ${providerLabel}` : providerLabel;
   let streamedText = "";
-  let resolvedModel = model || "default model";
+  let resolvedModel = provider === "ollama"
+    ? localModel || "auto-detect"
+    : cloudModel || localModel || "default model";
+  let resolvedProvider = provider;
+  const selectedLocalModel = localModel || "";
+  const selectedCloudModel = cloudModel || "";
 
   setMessagePending(assistantMessage, `${providerLabel} is thinking`);
   ensureMessageMeta(assistantMessage, `provider: ${baseMeta} | model: ${resolvedModel} | streaming`);
   els.requestStatus.textContent = provider === "claude"
     ? "Streaming Claude response..."
-    : "Streaming local Ollama response...";
+    : provider === "auto"
+      ? "Trying Claude, then local model if needed..."
+      : "Streaming local Ollama response...";
 
   const response = await fetch("/api/prompt/stream", {
     method: "POST",
@@ -3026,10 +3058,10 @@ async function streamAssistantProvider({
     body: JSON.stringify({
       prompt: finalPrompt,
       system: system || null,
-      model: provider === "claude" ? null : model || null,
+      model: provider === "claude" ? null : selectedLocalModel || null,
       llm_provider: provider,
-      cloud_model: provider === "claude" ? model || null : null,
-      cloud_api_key: provider === "claude" ? state.claudeApiKey || null : null,
+      cloud_model: provider === "ollama" ? null : selectedCloudModel || null,
+      cloud_api_key: provider === "ollama" ? null : state.claudeApiKey || null,
       agent_profile: agentProfile,
       map_context: mapContext,
       source_context: sourceContext,
@@ -3044,7 +3076,8 @@ async function streamAssistantProvider({
   await readEventStream(response, (eventData) => {
     if (eventData.type === "start") {
       resolvedModel = eventData.model || resolvedModel;
-      ensureMessageMeta(assistantMessage, `provider: ${baseMeta} | model: ${resolvedModel} | streaming`);
+      resolvedProvider = eventData.provider || resolvedProvider;
+      ensureMessageMeta(assistantMessage, `provider: ${providerDisplayName(resolvedProvider)} | model: ${resolvedModel} | streaming`);
       return;
     }
     if (eventData.type === "token") {
@@ -3058,11 +3091,19 @@ async function streamAssistantProvider({
       els.requestStatus.textContent = eventData.detail || `Streaming ${providerLabel} response...`;
       return;
     }
+    if (eventData.type === "fallback") {
+      const reason = eventData.reason ? ` ${eventData.reason}` : "";
+      els.providerStatus.textContent = eventData.detail || "Trying fallback model provider.";
+      els.requestStatus.textContent = eventData.detail || "Trying fallback model provider.";
+      ensureMessageMeta(assistantMessage, `provider: ${baseMeta} | fallback:${reason}`);
+      return;
+    }
     if (eventData.type === "error") {
       throw new Error(eventData.detail || `${providerLabel} request failed.`);
     }
     if (eventData.type === "done") {
-      ensureMessageMeta(assistantMessage, `provider: ${baseMeta} | model: ${eventData.model || resolvedModel}`);
+      resolvedProvider = eventData.provider || resolvedProvider;
+      ensureMessageMeta(assistantMessage, `provider: ${providerDisplayName(resolvedProvider)} | model: ${eventData.model || resolvedModel}`);
     }
   });
 
@@ -3072,13 +3113,13 @@ async function streamAssistantProvider({
       : "The local Ollama model returned an empty streamed response.");
   }
 
-  if (provider === "ollama") {
+  if (resolvedProvider === "ollama") {
     state.localModelAvailable = true;
     state.localModelDetail = "";
     applyProviderVisibility();
   }
 
-  return { provider, model: resolvedModel, text: streamedText };
+  return { provider: resolvedProvider, model: resolvedModel, text: streamedText };
 }
 
 async function submitPrompt(event) {
@@ -3093,12 +3134,14 @@ async function submitPrompt(event) {
   }
   const system = els.systemInput.value.trim();
   const provider = state.llmProvider;
-  const model = provider === "claude"
-    ? els.claudeModelSelect.value.trim()
-    : els.modelSelect.value.trim();
+  const localModel = els.modelSelect.value.trim();
+  const cloudModel = els.claudeModelSelect.value.trim();
+  const model = provider === "ollama" ? localModel : cloudModel || localModel;
   els.requestStatus.textContent = provider === "claude"
     ? "Connecting to Claude API..."
-    : "Connecting to local model...";
+    : provider === "auto"
+      ? "Connecting with Claude primary and local fallback..."
+      : "Connecting to local model...";
   const agentProfile = els.agentProfileSelect.value;
   const finalPrompt = `${prompt}${makeMapContextAppendix()}`;
   const mapContext = els.includeMapContext.checked ? buildMapContext() : null;
@@ -3129,59 +3172,25 @@ async function submitPrompt(event) {
   const assistantMessage = appendMessage(
     "assistant",
     "",
-    provider === "claude"
-      ? `provider: Claude | model: ${model || "default"} | queued`
-      : `provider: local Ollama | model: ${model || "auto-detect"} | queued`,
+    provider === "auto"
+      ? `provider: Auto | Claude: ${cloudModel || "default"} | Local: ${localModel || "auto-detect"} | queued`
+      : provider === "claude"
+        ? `provider: Claude | model: ${cloudModel || "default"} | queued`
+        : `provider: local Ollama | model: ${localModel || "auto-detect"} | queued`,
   );
 
   try {
-    let claudeError = null;
-    let localError = null;
-    let result = null;
-
-    if (provider === "claude") {
-      if (hasClaudeProviderCredential()) {
-        try {
-          result = await streamAssistantProvider({
-            assistantMessage,
-            provider: "claude",
-            model,
-            finalPrompt,
-            system,
-            agentProfile,
-            mapContext,
-            sourceContext,
-          });
-        } catch (error) {
-          claudeError = getErrorMessage(error);
-          console.warn("Claude request failed; trying local Ollama fallback.", claudeError);
-          els.providerStatus.textContent = "Claude request failed; trying detected local Ollama.";
-          els.requestStatus.textContent = "Trying local model fallback...";
-        }
-      } else {
-        claudeError = "Claude API key is not set in this browser session or on the server.";
-        els.providerStatus.textContent = "Claude API key missing";
-        els.requestStatus.textContent = "Trying local model fallback...";
-      }
-    }
-
-    if (!result) {
-      const localModel = await resolveLocalModelForFallback();
-      try {
-        result = await streamAssistantProvider({
-          assistantMessage,
-          provider: "ollama",
-          model: localModel,
-          finalPrompt,
-          system,
-          agentProfile,
-          mapContext,
-          sourceContext,
-        });
-      } catch (error) {
-        localError = getErrorMessage(error);
-      }
-    }
+    const result = await streamAssistantProvider({
+      assistantMessage,
+      provider,
+      localModel,
+      cloudModel,
+      finalPrompt,
+      system,
+      agentProfile,
+      mapContext,
+      sourceContext,
+    });
 
     if (result) {
       els.requestStatus.textContent = result.provider === "claude"
@@ -3189,25 +3198,12 @@ async function submitPrompt(event) {
         : `Completed with local Ollama ${result.model}`;
       return;
     }
-
-    if (localError) {
-      state.localModelAvailable = false;
-      state.localModelDetail = localError;
-      applyProviderVisibility();
-    }
-    const failureSummary = [
-      claudeError ? `Claude: ${claudeError}` : "",
-      localError ? `local Ollama: ${localError}` : "",
-    ].filter(Boolean).join(" | ");
-    if (failureSummary) {
-      console.warn("Model providers unavailable; deterministic planner response shown.", failureSummary);
-    }
-    setMessageBody(assistantMessage, buildDeterministicAdvisorResponse(sourceRecommendation, mapContext));
-    ensureMessageMeta(assistantMessage, "deterministic planner response");
-    els.requestStatus.textContent = "Deterministic planner response shown.";
   } catch (error) {
     const message = getErrorMessage(error);
     console.warn("Prompt request failed; deterministic planner response shown.", message);
+    state.localModelAvailable = false;
+    state.localModelDetail = message;
+    applyProviderVisibility();
     setMessageBody(assistantMessage, buildDeterministicAdvisorResponse(sourceRecommendation, mapContext));
     ensureMessageMeta(assistantMessage, "deterministic planner response");
     els.requestStatus.textContent = "Deterministic planner response shown.";
@@ -4267,14 +4263,14 @@ async function init() {
     els.modelProviderBtn.addEventListener("click", () => {
       const shouldOpen = els.modelProviderMenu.classList.contains("hidden");
       setModelProviderMenuOpen(shouldOpen);
-      if (shouldOpen && state.llmProvider === "ollama") {
+      if (shouldOpen && (state.llmProvider === "ollama" || state.llmProvider === "auto")) {
         void loadModels();
       }
     });
     els.providerSelect.addEventListener("change", (event) => {
       state.llmProvider = event.target.value;
       applyProviderVisibility();
-      if (state.llmProvider === "ollama") {
+      if (state.llmProvider === "ollama" || state.llmProvider === "auto") {
         void loadModels();
       }
     });

--- a/llm_dev_kmh/static/app.js
+++ b/llm_dev_kmh/static/app.js
@@ -37,6 +37,7 @@ const state = {
   mapLocationConfirmed: false,
   locationSearchTimer: null,
   locationSearchRequestId: 0,
+  cesiumIonTokenAvailable: false,
   localModelAvailable: false,
   localModelDetail: "",
   serverClaudeKeyAvailable: false,
@@ -2530,15 +2531,40 @@ function toggleMapMode() {
   setMapMode(state.mapMode === "3d" ? "2d" : "3d");
 }
 
+function hasCesiumIonToken() {
+  return Boolean(state.config?.cesium_ion_token);
+}
+
+function updateMapStreamChip(imagery, terrain, requestedModes = {}) {
+  const requestedIon = requestedModes.imageryMode === "ion-satellite"
+    || requestedModes.terrainMode === "cesium-world";
+  const fallbackReason = [imagery?.fallbackReason, terrain?.fallbackReason]
+    .filter(Boolean)
+    .join("; ");
+
+  if (imagery?.usingIon || terrain?.usingIon) {
+    setChip(els.tokenChip, "Cesium ion stream active", "good");
+    return;
+  }
+
+  if (fallbackReason || (requestedIon && !state.cesiumIonTokenAvailable)) {
+    setChip(els.tokenChip, "Map stream active; ion fallback", "warn");
+    return;
+  }
+
+  const imageryLabel = imagery?.shortLabel || imagery?.label || "imagery";
+  setChip(els.tokenChip, `Map stream: ${imageryLabel}`, "good");
+}
+
 async function loadRuntimeConfig() {
   state.config = await fetchJson("/api/config");
-  const hasToken = Boolean(state.config.cesium_ion_token);
+  state.cesiumIonTokenAvailable = hasCesiumIonToken();
   state.serverClaudeKeyAvailable = Boolean(state.config.anthropic_api_key_configured);
-  setChip(els.tokenChip, hasToken ? "Cesium token detected" : "Cesium token missing", hasToken ? "good" : "warn");
+  setChip(els.tokenChip, "Map stream checking");
   els.claudeModelSelect.value = state.config.claude_default_model || els.claudeModelSelect.value;
   setModelProviderButton(`Default model: ${state.config.default_model}`, "warn");
   state.imageryMode = "esri";
-  state.terrainMode = hasToken ? "cesium-world" : "ellipsoid";
+  state.terrainMode = state.cesiumIonTokenAvailable ? "cesium-world" : "ellipsoid";
   els.imagerySelect.value = state.imageryMode;
   els.terrainSelect.value = state.terrainMode;
 }
@@ -2977,6 +3003,8 @@ async function resolveImageryProvider() {
     return {
       provider: makeUrlTemplateImageryProvider(IMAGERY_FALLBACKS.esri),
       label: IMAGERY_FALLBACKS.esri.label,
+      shortLabel: "Esri imagery",
+      usingIon: false,
     };
   }
 
@@ -2984,15 +3012,20 @@ async function resolveImageryProvider() {
     return {
       provider: makeUrlTemplateImageryProvider(IMAGERY_FALLBACKS.osm),
       label: IMAGERY_FALLBACKS.osm.label,
+      shortLabel: "OSM basemap",
+      usingIon: false,
     };
   }
 
-  if (!state.config.cesium_ion_token) {
+  if (!hasCesiumIonToken()) {
     state.imageryMode = "esri";
     els.imagerySelect.value = "esri";
     return {
       provider: makeUrlTemplateImageryProvider(IMAGERY_FALLBACKS.esri),
       label: IMAGERY_FALLBACKS.esri.label,
+      shortLabel: "Esri imagery",
+      usingIon: false,
+      fallbackReason: "Cesium ion token is not configured for World Imagery.",
     };
   }
 
@@ -3002,6 +3035,8 @@ async function resolveImageryProvider() {
         style: Cesium.IonWorldImageryStyle.AERIAL,
       }),
       label: "Cesium World Imagery",
+      shortLabel: "Cesium imagery",
+      usingIon: true,
     };
   } catch (error) {
     console.warn("Cesium imagery failed; using Esri fallback.", error);
@@ -3010,25 +3045,36 @@ async function resolveImageryProvider() {
     return {
       provider: makeUrlTemplateImageryProvider(IMAGERY_FALLBACKS.esri),
       label: IMAGERY_FALLBACKS.esri.label,
+      shortLabel: "Esri imagery",
+      usingIon: false,
+      fallbackReason: "Cesium World Imagery request failed.",
     };
   }
 }
 
 async function resolveTerrainProvider() {
-  if (state.terrainMode === "ellipsoid" || !state.config.cesium_ion_token) {
-    if (state.terrainMode !== "ellipsoid" && !state.config.cesium_ion_token) {
+  if (state.terrainMode === "ellipsoid" || !hasCesiumIonToken()) {
+    const fallbackReason = state.terrainMode !== "ellipsoid" && !hasCesiumIonToken()
+      ? "Cesium ion token is not configured for World Terrain."
+      : "";
+    if (state.terrainMode !== "ellipsoid" && !hasCesiumIonToken()) {
       state.terrainMode = "ellipsoid";
       els.terrainSelect.value = "ellipsoid";
     }
     return {
       provider: new Cesium.EllipsoidTerrainProvider(),
       label: "Terrain: Ellipsoid only",
+      shortLabel: "ellipsoid terrain",
+      usingIon: false,
+      fallbackReason,
     };
   }
   try {
     return {
       provider: await Cesium.createWorldTerrainAsync(),
       label: "Terrain: Cesium World Terrain",
+      shortLabel: "Cesium terrain",
+      usingIon: true,
     };
   } catch (error) {
     console.warn("Cesium terrain failed; using ellipsoid fallback.", error);
@@ -3037,6 +3083,9 @@ async function resolveTerrainProvider() {
     return {
       provider: new Cesium.EllipsoidTerrainProvider(),
       label: "Terrain: Ellipsoid fallback",
+      shortLabel: "ellipsoid terrain",
+      usingIon: false,
+      fallbackReason: "Cesium World Terrain request failed.",
     };
   }
 }
@@ -3369,7 +3418,7 @@ async function buildViewer() {
     }
   }
 
-  if (state.config.cesium_ion_token) {
+  if (hasCesiumIonToken()) {
     Cesium.Ion.defaultAccessToken = state.config.cesium_ion_token;
   }
 
@@ -3389,12 +3438,17 @@ async function buildViewer() {
   });
   window.__LLM_DEV_VIEWER = state.viewer;
 
+  const requestedModes = {
+    imageryMode: state.imageryMode,
+    terrainMode: state.terrainMode,
+  };
   const imagery = await resolveImageryProvider();
   state.viewer.imageryLayers.removeAll();
   state.viewer.imageryLayers.addImageryProvider(imagery.provider);
 
   const terrain = await resolveTerrainProvider();
   state.viewer.terrainProvider = terrain.provider;
+  updateMapStreamChip(imagery, terrain, requestedModes);
 
   state.viewer.scene.globe.depthTestAgainstTerrain = false;
   applyMapModeCameraControls();
@@ -3914,14 +3968,14 @@ function onPromptInputKeyDown(event) {
 async function streamSelectedSources() {
   if (state.selectedSourceIds.has("esri_world_imagery")) {
     state.imageryMode = "esri";
-  } else if (state.selectedSourceIds.has("cesium_world_imagery") && state.config?.cesium_ion_token) {
+  } else if (state.selectedSourceIds.has("cesium_world_imagery") && hasCesiumIonToken()) {
     state.imageryMode = "ion-satellite";
   } else if (state.selectedSourceIds.has("osm_basemap")) {
     state.imageryMode = "osm";
   }
 
   state.terrainMode = state.selectedSourceIds.has("cesium_world_terrain")
-    && state.config?.cesium_ion_token
+    && hasCesiumIonToken()
     ? "cesium-world"
     : "ellipsoid";
 

--- a/llm_dev_kmh/static/app.js
+++ b/llm_dev_kmh/static/app.js
@@ -110,7 +110,6 @@ const els = {
   workflowStageMeta: document.getElementById("workflowStageMeta"),
   workflowDots: document.getElementById("workflowDots"),
   workflowSlides: Array.from(document.querySelectorAll("[data-workflow-slide]")),
-  clarifyingQuestions: document.getElementById("clarifyingQuestions"),
   sourceList: document.getElementById("sourceList"),
   packageModeChip: document.getElementById("packageModeChip"),
   inferredMission: document.getElementById("inferredMission"),
@@ -135,11 +134,6 @@ const WORKFLOW_STAGES = [
     key: "mission",
     label: "Mission",
     meta: "Review extracted mission",
-  },
-  {
-    key: "questions",
-    label: "Questions",
-    meta: "Broaden or limit scope",
   },
   {
     key: "sources",
@@ -171,6 +165,8 @@ const FALLBACK_PRIMARY_STREAM_SOURCE_IDS = [
   "cesium_world_terrain",
   "osm_basemap",
 ];
+
+const LOCATION_INTENT_PREFIX_PATTERN = /^(go to|goto|navigate to|take me to|move map to|move to|search for|find|show me|zoom to|center on|focus on)\s+/i;
 
 const LOCATION_GAZETTEER = [
   {
@@ -236,6 +232,38 @@ const LOCATION_GAZETTEER = [
     lon: -120.0324,
     heightM: 18000,
     aliases: ["tahoe", "south lake tahoe"],
+  },
+  {
+    name: "Cascade Range, WA/OR/BC",
+    detail: "Pacific Northwest mountain range, national forests, volcanoes, SAR and terrain-routing context",
+    lat: 45.6500,
+    lon: -121.7000,
+    heightM: 26000,
+    aliases: ["cascades", "the cascades", "cascade mountains", "cascade range", "pnw cascades"],
+  },
+  {
+    name: "North Cascades National Park, WA",
+    detail: "High alpine terrain, glaciers, steep valleys, trails, and SAR access constraints",
+    lat: 48.7718,
+    lon: -121.2985,
+    heightM: 22000,
+    aliases: ["north cascades", "north cascades np", "noca"],
+  },
+  {
+    name: "Olympic National Park, WA",
+    detail: "Dense forest, mountains, river valleys, coastline, and SAR mission terrain",
+    lat: 47.8021,
+    lon: -123.6044,
+    heightM: 22000,
+    aliases: ["olympic", "olympic peninsula", "olympics"],
+  },
+  {
+    name: "Mount Rainier National Park, WA",
+    detail: "Volcanic alpine terrain, glaciers, roads, trails, and high-risk weather",
+    lat: 46.8523,
+    lon: -121.7603,
+    heightM: 20000,
+    aliases: ["rainier", "mount rainier", "mt rainier"],
   },
   {
     name: "Joshua Tree National Park, CA",
@@ -344,6 +372,12 @@ const LOCATION_GAZETTEER = [
 ];
 
 const LOCATION_SEARCH_LIMIT = 6;
+const LOCATION_SOURCE_PRIORITY = {
+  "coordinate-query": 500,
+  gazetteer: 180,
+  "local-gazetteer": 180,
+  "online-geocoder": 0,
+};
 const UTM_LATITUDE_BANDS = "CDEFGHJKLMNPQRSTUVWXX";
 const MGRS_COLUMN_LETTER_SETS = ["ABCDEFGH", "JKLMNPQR", "STUVWXYZ"];
 const MGRS_ROW_LETTER_SETS = ["ABCDEFGHJKLMNPQRSTUV", "FGHJKLMNPQRSTUVABCDE"];
@@ -650,8 +684,18 @@ function tokenLooksLike(token, target) {
   return distance <= Math.max(1, Math.floor(Math.max(token.length, target.length) * 0.28));
 }
 
+function cleanLocationSearchQuery(query) {
+  let cleaned = query.trim().replace(/\s+/g, " ");
+  let previous = "";
+  while (cleaned && cleaned !== previous) {
+    previous = cleaned;
+    cleaned = cleaned.replace(LOCATION_INTENT_PREFIX_PATTERN, "").trim();
+  }
+  return cleaned;
+}
+
 function parseCoordinateQuery(query) {
-  const trimmed = query.trim();
+  const trimmed = cleanLocationSearchQuery(query);
   if (!trimmed) {
     return null;
   }
@@ -698,7 +742,7 @@ function parseCoordinateQuery(query) {
 }
 
 function scoreLocationCandidate(candidate, query) {
-  const normalizedQuery = normalizeSearchText(query);
+  const normalizedQuery = normalizeSearchText(cleanLocationSearchQuery(query));
   if (!normalizedQuery) {
     return 0;
   }
@@ -718,7 +762,7 @@ function scoreLocationCandidate(candidate, query) {
 
   for (const alias of aliases) {
     if (alias === normalizedQuery) {
-      score += 110;
+      score += 145;
     } else if (alias.startsWith(normalizedQuery)) {
       score += 85;
     } else if (alias.includes(normalizedQuery)) {
@@ -747,13 +791,17 @@ function scoreLocationCandidate(candidate, query) {
 }
 
 function getLocationSearchSuggestions(query) {
-  const coordinate = parseCoordinateQuery(query);
+  const cleanedQuery = cleanLocationSearchQuery(query);
+  const coordinate = parseCoordinateQuery(cleanedQuery);
   const scored = LOCATION_GAZETTEER
-    .map((candidate) => ({
-      ...candidate,
-      source: "gazetteer",
-      score: scoreLocationCandidate(candidate, query),
-    }))
+    .map((candidate) => {
+      const matchScore = scoreLocationCandidate(candidate, cleanedQuery);
+      return {
+        ...candidate,
+        source: "gazetteer",
+        score: matchScore > 0 ? matchScore + LOCATION_SOURCE_PRIORITY.gazetteer : 0,
+      };
+    })
     .filter((candidate) => candidate.score > 0)
     .sort((a, b) => b.score - a.score)
     .slice(0, LOCATION_SEARCH_LIMIT);
@@ -765,6 +813,7 @@ function getLocationSearchSuggestions(query) {
 }
 
 function normalizeServerLocationSuggestion(suggestion) {
+  const serverScore = Number(suggestion.score);
   return {
     name: suggestion.name,
     detail: suggestion.detail || `${Number(suggestion.lat).toFixed(5)}, ${Number(suggestion.lon).toFixed(5)}`,
@@ -772,10 +821,20 @@ function normalizeServerLocationSuggestion(suggestion) {
     lon: Number(suggestion.lon),
     heightM: Number(suggestion.height_m || suggestion.heightM || 12000),
     source: suggestion.source || "online-geocoder",
+    score: Number.isFinite(serverScore) ? serverScore : 0,
   };
 }
 
-function mergeLocationSuggestions(primaryMatches, incomingMatches) {
+function scoreMergedLocation(match, query) {
+  const providedScore = Number(match.score);
+  if (Number.isFinite(providedScore) && providedScore > 0) {
+    return providedScore;
+  }
+  return scoreLocationCandidate(match, query)
+    + (LOCATION_SOURCE_PRIORITY[match.source] || 0);
+}
+
+function mergeLocationSuggestions(primaryMatches, incomingMatches, query = "") {
   const merged = [];
   const seen = new Set();
   for (const match of [...primaryMatches, ...incomingMatches]) {
@@ -787,25 +846,67 @@ function mergeLocationSuggestions(primaryMatches, incomingMatches) {
       continue;
     }
     seen.add(key);
-    merged.push(match);
+    merged.push({
+      ...match,
+      score: scoreMergedLocation(match, query),
+    });
   }
-  return merged.slice(0, LOCATION_SEARCH_LIMIT);
+  return merged
+    .sort((a, b) => {
+      const scoreDelta = scoreMergedLocation(b, query) - scoreMergedLocation(a, query);
+      if (scoreDelta !== 0) {
+        return scoreDelta;
+      }
+      return (LOCATION_SOURCE_PRIORITY[b.source] || 0) - (LOCATION_SOURCE_PRIORITY[a.source] || 0);
+    })
+    .slice(0, LOCATION_SEARCH_LIMIT);
+}
+
+function buildLocationSearchUrl(query) {
+  const params = new URLSearchParams({ q: cleanLocationSearchQuery(query) });
+  const center = getMapCenterPoint();
+  if (center) {
+    params.set("lat", center.lat.toFixed(6));
+    params.set("lon", center.lon.toFixed(6));
+  }
+
+  const bounds = buildMapContext().view_bounds;
+  if (bounds) {
+    params.set("west", bounds.west.toFixed(6));
+    params.set("south", bounds.south.toFixed(6));
+    params.set("east", bounds.east.toFixed(6));
+    params.set("north", bounds.north.toFixed(6));
+  }
+  return `/api/location-search?${params.toString()}`;
+}
+
+async function fetchLocationSearchSuggestions(query) {
+  const cleanedQuery = cleanLocationSearchQuery(query);
+  if (cleanedQuery.length < 2) {
+    return [];
+  }
+  const data = await fetchJson(buildLocationSearchUrl(cleanedQuery));
+  return Array.isArray(data.suggestions)
+    ? data.suggestions.map(normalizeServerLocationSuggestion)
+    : [];
 }
 
 async function refreshOnlineLocationSuggestions(query, requestId, localMatches) {
   try {
-    const data = await fetchJson(`/api/location-search?q=${encodeURIComponent(query)}`);
+    const cleanedQuery = cleanLocationSearchQuery(query);
+    const serverMatches = await fetchLocationSearchSuggestions(cleanedQuery);
     if (requestId !== state.locationSearchRequestId) {
       return;
     }
-    const serverMatches = Array.isArray(data.suggestions)
-      ? data.suggestions.map(normalizeServerLocationSuggestion)
-      : [];
-    state.locationSearchMatches = mergeLocationSuggestions(localMatches, serverMatches);
-    renderLocationSearchSuggestions();
+    state.locationSearchMatches = mergeLocationSuggestions(localMatches, serverMatches, cleanedQuery);
+    if (state.locationSearchMatches.length) {
+      renderLocationSearchSuggestions();
+    } else {
+      renderLocationSearchEmpty(cleanedQuery);
+    }
   } catch (_error) {
     if (requestId === state.locationSearchRequestId && !state.locationSearchMatches.length) {
-      setLocationSearchOpen(false);
+      renderLocationSearchEmpty(query);
     }
   }
 }
@@ -826,6 +927,29 @@ function setActiveLocationSuggestion(index) {
     option.classList.toggle("active", isActive);
     option.setAttribute("aria-selected", String(isActive));
   });
+}
+
+function renderLocationSearchStatus(message) {
+  els.locationSearchSuggestions.replaceChildren();
+  const status = document.createElement("div");
+  status.className = "location-suggestion-status";
+  status.textContent = message;
+  els.locationSearchSuggestions.appendChild(status);
+  setLocationSearchOpen(true);
+}
+
+function renderLocationSearchLoading(query) {
+  const cleanedQuery = cleanLocationSearchQuery(query);
+  renderLocationSearchStatus(`Searching ${cleanedQuery}...`);
+}
+
+function renderLocationSearchEmpty(query) {
+  const cleanedQuery = cleanLocationSearchQuery(query);
+  renderLocationSearchStatus(
+    cleanedQuery
+      ? `No location match for "${cleanedQuery}". Try a more specific place, coordinates, or KML/KMZ.`
+      : "Enter a mission location, coordinates, or KML/KMZ overlay.",
+  );
 }
 
 function renderLocationSearchSuggestions() {
@@ -854,7 +978,7 @@ function renderLocationSearchSuggestions() {
     button.addEventListener("pointerenter", () => setActiveLocationSuggestion(index));
     button.addEventListener("click", () => {
       state.activeLocationSearchIndex = index;
-      void commitLocationSearch();
+      flyToLocationSuggestion(match);
     });
 
     els.locationSearchSuggestions.appendChild(button);
@@ -893,35 +1017,64 @@ function flyToLocationSuggestion(suggestion) {
 }
 
 async function commitLocationSearch() {
-  const query = els.locationSearchInput.value.trim();
-  let matches = state.locationSearchMatches.length
-    ? state.locationSearchMatches
-    : getLocationSearchSuggestions(query);
-  const index = state.activeLocationSearchIndex >= 0 ? state.activeLocationSearchIndex : 0;
-  let suggestion = matches[index] || matches[0];
-  if (!suggestion && query.length >= 2) {
-    try {
-      const data = await fetchJson(`/api/location-search?q=${encodeURIComponent(query)}`);
-      const serverMatches = Array.isArray(data.suggestions)
-        ? data.suggestions.map(normalizeServerLocationSuggestion)
-        : [];
-      matches = mergeLocationSuggestions([], serverMatches);
-      state.locationSearchMatches = matches;
-      suggestion = matches[0];
-    } catch (_error) {
-      suggestion = null;
-    }
-  }
-  if (!suggestion) {
-    els.requestStatus.textContent = "No local match. Paste decimal coordinates or import a KML/KMZ overlay.";
-    setLocationSearchOpen(false);
+  const query = cleanLocationSearchQuery(els.locationSearchInput.value);
+  window.clearTimeout(state.locationSearchTimer);
+  state.locationSearchRequestId += 1;
+
+  const coordinate = parseCoordinateQuery(query);
+  if (coordinate) {
+    flyToLocationSuggestion(coordinate);
     return;
+  }
+
+  if (query.length < 2) {
+    renderLocationSearchEmpty(query);
+    return;
+  }
+
+  const localMatches = getLocationSearchSuggestions(query);
+  const selectedBeforeFetch = state.activeLocationSearchIndex > 0
+    ? state.locationSearchMatches[state.activeLocationSearchIndex]
+    : null;
+  if (localMatches.length) {
+    state.locationSearchMatches = localMatches;
+    renderLocationSearchSuggestions();
+  } else {
+    renderLocationSearchLoading(query);
+  }
+
+  let serverMatches = [];
+  try {
+    serverMatches = await fetchLocationSearchSuggestions(query);
+  } catch (_error) {
+    serverMatches = [];
+  }
+
+  const matches = mergeLocationSuggestions(localMatches, serverMatches, query);
+  state.locationSearchMatches = matches;
+  const selectedKey = selectedBeforeFetch
+    ? `${Math.round(selectedBeforeFetch.lat * 1000)}:${Math.round(selectedBeforeFetch.lon * 1000)}:${selectedBeforeFetch.name.toLowerCase()}`
+    : "";
+  const suggestion = selectedKey
+    ? matches.find((match) => (
+      `${Math.round(match.lat * 1000)}:${Math.round(match.lon * 1000)}:${match.name.toLowerCase()}`
+    ) === selectedKey) || selectedBeforeFetch
+    : matches[0];
+
+  if (!suggestion) {
+    els.requestStatus.textContent = "Location not resolved. Try a more specific place, coordinates, or KML/KMZ.";
+    renderLocationSearchEmpty(query);
+    return;
+  }
+
+  if (matches.length) {
+    renderLocationSearchSuggestions();
   }
   flyToLocationSuggestion(suggestion);
 }
 
 function onLocationSearchInput() {
-  const query = els.locationSearchInput.value.trim();
+  const query = cleanLocationSearchQuery(els.locationSearchInput.value);
   window.clearTimeout(state.locationSearchTimer);
   state.locationSearchRequestId += 1;
   if (query.length < 2) {
@@ -931,11 +1084,15 @@ function onLocationSearchInput() {
   }
   const localMatches = getLocationSearchSuggestions(query);
   state.locationSearchMatches = localMatches;
-  renderLocationSearchSuggestions();
+  if (localMatches.length) {
+    renderLocationSearchSuggestions();
+  } else {
+    renderLocationSearchLoading(query);
+  }
   const requestId = state.locationSearchRequestId;
   state.locationSearchTimer = window.setTimeout(() => {
     void refreshOnlineLocationSuggestions(query, requestId, localMatches);
-  }, 240);
+  }, 180);
 }
 
 function onLocationSearchKeyDown(event) {
@@ -1437,7 +1594,7 @@ function applyProviderVisibility() {
     const tone = state.localModelAvailable ? "good" : "warn";
     setModelProviderButton(state.localModelAvailable ? `Local: ${label}` : "Local model offline; rules active", tone);
     els.providerStatus.textContent = state.localModelAvailable
-      ? "Local Ollama available"
+      ? `Using detected local model: ${label}`
       : "Local model offline; deterministic planner remains active";
   }
 }
@@ -1487,26 +1644,6 @@ function renderWorkflowDots() {
     dot.title = stage.label;
     els.workflowDots.appendChild(dot);
   });
-}
-
-function renderClarifyingQuestions() {
-  els.clarifyingQuestions.replaceChildren();
-  const questions = state.sourceInference?.clarifying_questions || [];
-
-  if (!questions.length) {
-    const item = document.createElement("li");
-    item.textContent = state.sourceInference
-      ? "No additional Socratic question is needed. Review the working sources or describe a constraint in chat."
-      : "Socratic source questions will appear after the first mission description.";
-    els.clarifyingQuestions.appendChild(item);
-    return;
-  }
-
-  for (const question of questions) {
-    const item = document.createElement("li");
-    item.textContent = question;
-    els.clarifyingQuestions.appendChild(item);
-  }
 }
 
 function ensureClarifyingQuestions(recommendation) {
@@ -1561,7 +1698,6 @@ function updateWorkflowPanel() {
   els.buildPackageBtn.disabled = selectedCount === 0 || !state.sourceConfirmed;
   els.streamSelectedBtn.disabled = selectedCount === 0;
 
-  renderClarifyingQuestions();
   renderWorkflowDots();
 }
 
@@ -1919,7 +2055,7 @@ function applySourceRecommendation(data, missionText, mode = "server", statusMes
   const fallbackText = mode === "fallback"
     ? ` Browser fallback used because the planner API is unavailable (${statusMessage}).`
     : "";
-  els.packageStatus.textContent = `Drafted ${state.selectedSourceIds.size} working sources.${fallbackText} Use Questions to scope, then confirm sources.`;
+  els.packageStatus.textContent = `Drafted ${state.selectedSourceIds.size} working sources.${fallbackText} Use the advisor response to scope, then confirm sources.`;
   updateWorkflowPanel();
 }
 
@@ -2165,7 +2301,7 @@ function confirmSources() {
   }
   state.sourceConfirmed = true;
   hidePackageOutput();
-  setWorkflowStage(3);
+  setWorkflowStage(2);
   els.packageStatus.textContent = "Sources confirmed. Draw or adjust the AO rectangle for the data package.";
 }
 
@@ -2303,7 +2439,7 @@ async function loadModels() {
       els.modelsList.appendChild(item);
       els.modelsStatus.textContent = "Local model offline; deterministic planner active";
       applyProviderVisibility();
-      return;
+      return data;
     }
 
     if (!Array.isArray(data.models) || data.models.length === 0) {
@@ -2318,7 +2454,7 @@ async function loadModels() {
       els.modelsStatus.textContent = `Default model: ${data.default_model}`;
       syncModelSelects(els.modelSelect, els.topModelSelect);
       applyProviderVisibility();
-      return;
+      return data;
     }
 
     for (const model of data.models) {
@@ -2341,9 +2477,10 @@ async function loadModels() {
       els.modelSelect.appendChild(option);
     }
 
-    els.modelsStatus.textContent = `${data.models.length} model${data.models.length === 1 ? "" : "s"} available`;
+    els.modelsStatus.textContent = `Detected local model: ${data.default_model}`;
     syncModelSelects(els.modelSelect, els.topModelSelect);
     applyProviderVisibility();
+    return data;
   } catch (error) {
     state.localModelAvailable = false;
     state.localModelDetail = error instanceof Error ? error.message : String(error);
@@ -2359,6 +2496,7 @@ async function loadModels() {
     els.modelsStatus.textContent = "Local model offline; deterministic planner active";
     syncModelSelects(els.modelSelect, els.topModelSelect);
     applyProviderVisibility();
+    return null;
   }
 }
 
@@ -2407,7 +2545,7 @@ async function planSourcesFromMission(missionText, mapContext) {
 async function buildSourcePackage() {
   if (!state.sourceConfirmed) {
     els.packageStatus.textContent = "Confirm the recommended source list before building the manifest.";
-    setWorkflowStage(2);
+    setWorkflowStage(1);
     return;
   }
 
@@ -2444,6 +2582,104 @@ async function buildSourcePackage() {
   }
 }
 
+function providerDisplayName(provider) {
+  return provider === "claude" ? "Claude" : "local Ollama";
+}
+
+async function resolveLocalModelForFallback() {
+  const modelData = await loadModels();
+  return (
+    els.modelSelect.value.trim()
+    || els.topModelSelect.value.trim()
+    || modelData?.default_model
+    || state.config?.default_model
+    || ""
+  );
+}
+
+async function streamAssistantProvider({
+  assistantMessage,
+  provider,
+  model,
+  finalPrompt,
+  system,
+  agentProfile,
+  mapContext,
+  sourceContext,
+  metaPrefix = "",
+}) {
+  const providerLabel = providerDisplayName(provider);
+  const baseMeta = metaPrefix ? `${metaPrefix} | ${providerLabel}` : providerLabel;
+  let streamedText = "";
+  let resolvedModel = model || "default model";
+
+  setMessagePending(assistantMessage, `${providerLabel} is thinking`);
+  ensureMessageMeta(assistantMessage, `provider: ${baseMeta} | model: ${resolvedModel} | streaming`);
+  els.requestStatus.textContent = provider === "claude"
+    ? "Streaming Claude response..."
+    : "Streaming local Ollama response...";
+
+  const response = await fetch("/api/prompt/stream", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      prompt: finalPrompt,
+      system: system || null,
+      model: provider === "claude" ? null : model || null,
+      llm_provider: provider,
+      cloud_model: provider === "claude" ? model || null : null,
+      cloud_api_key: provider === "claude" ? state.claudeApiKey || null : null,
+      agent_profile: agentProfile,
+      map_context: mapContext,
+      source_context: sourceContext,
+    }),
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.detail || `${response.status} ${response.statusText}`);
+  }
+
+  await readEventStream(response, (eventData) => {
+    if (eventData.type === "start") {
+      resolvedModel = eventData.model || resolvedModel;
+      ensureMessageMeta(assistantMessage, `provider: ${baseMeta} | model: ${resolvedModel} | streaming`);
+      return;
+    }
+    if (eventData.type === "token") {
+      streamedText += eventData.text || "";
+      const shouldFollowStream = isChatPinnedToBottom();
+      setMessageBody(assistantMessage, streamedText);
+      maybeScrollChatToBottom(shouldFollowStream);
+      return;
+    }
+    if (eventData.type === "status") {
+      els.requestStatus.textContent = eventData.detail || `Streaming ${providerLabel} response...`;
+      return;
+    }
+    if (eventData.type === "error") {
+      throw new Error(eventData.detail || `${providerLabel} request failed.`);
+    }
+    if (eventData.type === "done") {
+      ensureMessageMeta(assistantMessage, `provider: ${baseMeta} | model: ${eventData.model || resolvedModel}`);
+    }
+  });
+
+  if (!streamedText.trim()) {
+    throw new Error(provider === "claude"
+      ? "Claude returned an empty response."
+      : "The local Ollama model returned an empty streamed response.");
+  }
+
+  if (provider === "ollama") {
+    state.localModelAvailable = true;
+    state.localModelDetail = "";
+    applyProviderVisibility();
+  }
+
+  return { provider, model: resolvedModel, text: streamedText };
+}
+
 async function submitPrompt(event) {
   event.preventDefault();
   els.submitBtn.disabled = true;
@@ -2462,17 +2698,10 @@ async function submitPrompt(event) {
   els.requestStatus.textContent = provider === "claude"
     ? "Connecting to Claude API..."
     : "Connecting to local model...";
-  if (provider === "claude" && !state.claudeApiKey) {
-    els.submitBtn.disabled = false;
-    els.requestStatus.textContent = "Claude API key required";
-    els.providerStatus.textContent = "Enter a Claude API key to use cloud inference";
-    setModelProviderMenuOpen(true);
-    els.claudeApiKeyInput.focus();
-    return;
-  }
   const agentProfile = els.agentProfileSelect.value;
   const finalPrompt = `${prompt}${makeMapContextAppendix()}`;
   const mapContext = els.includeMapContext.checked ? buildMapContext() : null;
+  els.promptInput.value = "";
   els.requestStatus.textContent = "Planning source package...";
   try {
     await planSourcesFromMission(prompt, mapContext);
@@ -2496,112 +2725,87 @@ async function submitPrompt(event) {
     ].join(" | "),
   );
 
-  let activeAssistantMessage = null;
-
-  if (provider === "ollama" && !state.localModelAvailable) {
-    appendMessage(
-      "assistant",
-      buildDeterministicAdvisorResponse(sourceRecommendation, mapContext),
-      "deterministic source advisor | local model offline",
-    );
-    els.requestStatus.textContent = "Local model offline; deterministic advisor response shown";
-    els.promptInput.value = "";
-    els.submitBtn.disabled = false;
-    return;
-  }
+  const assistantMessage = appendMessage(
+    "assistant",
+    "",
+    provider === "claude"
+      ? `provider: Claude | model: ${model || "default"} | queued`
+      : `provider: local Ollama | model: ${model || "auto-detect"} | queued`,
+  );
 
   try {
-    const assistantMessage = appendMessage(
-      "assistant",
-      "",
-      model ? `model: ${model} | streaming` : "streaming",
-    );
-    activeAssistantMessage = assistantMessage;
-    setMessagePending(assistantMessage);
-    const response = await fetch("/api/prompt/stream", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        prompt: finalPrompt,
-        system: system || null,
-        model: model || null,
-        llm_provider: provider,
-        cloud_model: provider === "claude" ? model : null,
-        cloud_api_key: provider === "claude" ? state.claudeApiKey || null : null,
-        agent_profile: agentProfile,
-        map_context: mapContext,
-        source_context: sourceContext,
-      }),
-    });
+    let claudeError = null;
+    let localError = null;
+    let result = null;
 
-    if (!response.ok) {
-      const data = await response.json().catch(() => ({}));
-      throw new Error(data.detail || `${response.status} ${response.statusText}`);
+    if (provider === "claude") {
+      if (state.claudeApiKey) {
+        try {
+          result = await streamAssistantProvider({
+            assistantMessage,
+            provider: "claude",
+            model,
+            finalPrompt,
+            system,
+            agentProfile,
+            mapContext,
+            sourceContext,
+          });
+        } catch (error) {
+          claudeError = getErrorMessage(error);
+          els.providerStatus.textContent = `Claude request failed: ${claudeError}`;
+          els.requestStatus.textContent = "Claude failed; trying local Ollama fallback...";
+        }
+      } else {
+        claudeError = "Claude API key is not set for this browser session.";
+        els.providerStatus.textContent = "Claude API key missing; trying local Ollama fallback";
+        els.requestStatus.textContent = "Claude key missing; trying local Ollama fallback...";
+      }
     }
 
-    let streamedText = "";
-    let resolvedModel = model || "default model";
-
-    els.requestStatus.textContent = "Streaming response...";
-
-    await readEventStream(response, (eventData) => {
-      if (eventData.type === "start") {
-        resolvedModel = eventData.model || resolvedModel;
-        ensureMessageMeta(assistantMessage, `model: ${resolvedModel} | streaming`);
-        return;
+    if (!result) {
+      const localModel = await resolveLocalModelForFallback();
+      try {
+        result = await streamAssistantProvider({
+          assistantMessage,
+          provider: "ollama",
+          model: localModel,
+          finalPrompt,
+          system,
+          agentProfile,
+          mapContext,
+          sourceContext,
+          metaPrefix: provider === "claude" ? "local fallback after Claude failure" : "",
+        });
+      } catch (error) {
+        localError = getErrorMessage(error);
       }
-      if (eventData.type === "token") {
-        streamedText += eventData.text || "";
-        const shouldFollowStream = isChatPinnedToBottom();
-        setMessageBody(assistantMessage, streamedText);
-        maybeScrollChatToBottom(shouldFollowStream);
-        return;
-      }
-      if (eventData.type === "status") {
-        els.requestStatus.textContent = eventData.detail || "Streaming response...";
-        return;
-      }
-      if (eventData.type === "error") {
-        throw new Error(eventData.detail || "Streaming request failed.");
-      }
-      if (eventData.type === "done") {
-        ensureMessageMeta(assistantMessage, `model: ${eventData.model || resolvedModel}`);
-      }
-    });
-
-    if (!streamedText.trim()) {
-      throw new Error(provider === "claude"
-        ? "Claude returned an empty response."
-        : "The local model returned an empty streamed response.");
     }
 
-    els.requestStatus.textContent = `Completed with ${resolvedModel}`;
-    els.promptInput.value = "";
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (provider === "ollama") {
+    if (result) {
+      els.requestStatus.textContent = result.provider === "claude"
+        ? `Completed with Claude ${result.model}`
+        : `Completed with local Ollama ${result.model}`;
+      return;
+    }
+
+    if (localError) {
       state.localModelAvailable = false;
-      state.localModelDetail = message;
+      state.localModelDetail = localError;
       applyProviderVisibility();
-    } else {
-      els.providerStatus.textContent = `Claude request failed: ${message}`;
     }
-    const fallbackMeta = provider === "claude"
-      ? "deterministic fallback | Claude request failed"
-      : "deterministic fallback | local model unavailable";
-    if (activeAssistantMessage) {
-      setMessageBody(activeAssistantMessage, buildDeterministicAdvisorResponse(sourceRecommendation, mapContext));
-      ensureMessageMeta(activeAssistantMessage, fallbackMeta);
-    } else {
-      appendMessage(
-        "assistant",
-        buildDeterministicAdvisorResponse(sourceRecommendation, mapContext),
-        fallbackMeta,
-      );
-    }
-    els.requestStatus.textContent = provider === "claude"
-      ? `Claude request failed; deterministic advisor response shown (${message})`
-      : `Local model unavailable; deterministic advisor response shown (${message})`;
+    const failureSummary = [
+      claudeError ? `Claude: ${claudeError}` : "",
+      localError ? `local Ollama: ${localError}` : "",
+    ].filter(Boolean).join(" | ");
+    setMessageBody(assistantMessage, buildDeterministicAdvisorResponse(sourceRecommendation, mapContext));
+    ensureMessageMeta(assistantMessage, `deterministic fallback | ${failureSummary || "model providers unavailable"}`);
+    els.requestStatus.textContent = `Model providers unavailable; deterministic advisor response shown (${failureSummary})`;
+  } catch (error) {
+    const message = getErrorMessage(error);
+    setMessageBody(assistantMessage, buildDeterministicAdvisorResponse(sourceRecommendation, mapContext));
+    ensureMessageMeta(assistantMessage, `deterministic fallback | ${message}`);
+    els.requestStatus.textContent = `Deterministic advisor response shown (${message})`;
   } finally {
     els.submitBtn.disabled = false;
   }
@@ -2876,7 +3080,7 @@ function clearSelectedArea() {
 function setAreaSelectMode(active) {
   if (active && !state.sourceConfirmed) {
     els.packageStatus.textContent = "Confirm the recommended source list before drawing AO coverage.";
-    setWorkflowStage(2);
+    setWorkflowStage(1);
     return;
   }
   state.areaSelectActive = active;
@@ -3328,11 +3532,18 @@ async function init() {
     els.locationSearchInput.addEventListener("input", onLocationSearchInput);
     els.locationSearchInput.addEventListener("keydown", onLocationSearchKeyDown);
     els.modelProviderBtn.addEventListener("click", () => {
-      setModelProviderMenuOpen(els.modelProviderMenu.classList.contains("hidden"));
+      const shouldOpen = els.modelProviderMenu.classList.contains("hidden");
+      setModelProviderMenuOpen(shouldOpen);
+      if (shouldOpen && state.llmProvider === "ollama") {
+        void loadModels();
+      }
     });
     els.providerSelect.addEventListener("change", (event) => {
       state.llmProvider = event.target.value;
       applyProviderVisibility();
+      if (state.llmProvider === "ollama") {
+        void loadModels();
+      }
     });
     els.topModelSelect.addEventListener("change", () => {
       els.modelSelect.value = els.topModelSelect.value;

--- a/llm_dev_kmh/static/app.js
+++ b/llm_dev_kmh/static/app.js
@@ -15,6 +15,7 @@ const state = {
   chatCount: 0,
   imageryMode: "esri",
   terrainMode: "cesium-world",
+  mapMode: "2d",
   panelWidth: 520,
   panelCollapsed: false,
   dragState: null,
@@ -27,7 +28,9 @@ const state = {
   sourcePlannerMessage: "",
   overlayDataSource: null,
   overlayFileName: "",
+  overlayFeatureCount: 0,
   locationSearchMatches: [],
+  locationSearchDetail: "",
   activeLocationSearchIndex: -1,
   mapFocusLabel: "",
   mapFocusSource: "",
@@ -36,6 +39,7 @@ const state = {
   locationSearchRequestId: 0,
   localModelAvailable: false,
   localModelDetail: "",
+  serverClaudeKeyAvailable: false,
   llmProvider: sessionStorage.getItem("teraLlmProvider") || "ollama",
   claudeApiKey: sessionStorage.getItem("teraClaudeApiKey") || "",
   selectedSourceIds: new Set(),
@@ -75,6 +79,7 @@ const els = {
   sourcePanel: document.getElementById("sourcePanel"),
   mapStage: document.querySelector(".map-stage"),
   mapResetViewBtn: document.getElementById("mapResetViewBtn"),
+  mapModeToggleBtn: document.getElementById("mapModeToggleBtn"),
   locationSearchPanel: document.getElementById("locationSearchPanel"),
   locationSearchForm: document.getElementById("locationSearchForm"),
   locationSearchInput: document.getElementById("locationSearchInput"),
@@ -374,6 +379,7 @@ const LOCATION_GAZETTEER = [
 const LOCATION_SEARCH_LIMIT = 6;
 const LOCATION_SOURCE_PRIORITY = {
   "coordinate-query": 500,
+  "google-places": 260,
   gazetteer: 180,
   "local-gazetteer": 180,
   "online-geocoder": 0,
@@ -694,9 +700,46 @@ function cleanLocationSearchQuery(query) {
   return cleaned;
 }
 
+function parseGoogleMapsCoordinateQuery(query) {
+  const patterns = [
+    /!3d([+-]?\d+(?:\.\d+)?)!4d([+-]?\d+(?:\.\d+)?)/i,
+    /@([+-]?\d+(?:\.\d+)?),([+-]?\d+(?:\.\d+)?)/i,
+    /[?&](?:q|ll|center)=([+-]?\d+(?:\.\d+)?),([+-]?\d+(?:\.\d+)?)/i,
+  ];
+  for (const pattern of patterns) {
+    const match = query.match(pattern);
+    if (!match) {
+      continue;
+    }
+    const lat = Number(match[1]);
+    const lon = Number(match[2]);
+    if (Number.isFinite(lat) && Number.isFinite(lon) && Math.abs(lat) <= 90 && Math.abs(lon) <= 180) {
+      return {
+        name: `Coordinates ${lat.toFixed(5)}, ${lon.toFixed(5)}`,
+        detail: "Parsed from Google Maps link or coordinate query",
+        lat,
+        lon,
+        heightM: 12000,
+        source: "coordinate-query",
+        score: LOCATION_SOURCE_PRIORITY["coordinate-query"],
+      };
+    }
+  }
+  return null;
+}
+
 function parseCoordinateQuery(query) {
   const trimmed = cleanLocationSearchQuery(query);
   if (!trimmed) {
+    return null;
+  }
+
+  const googleMapsCoordinate = parseGoogleMapsCoordinateQuery(trimmed);
+  if (googleMapsCoordinate) {
+    return googleMapsCoordinate;
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
     return null;
   }
 
@@ -880,33 +923,44 @@ function buildLocationSearchUrl(query) {
   return `/api/location-search?${params.toString()}`;
 }
 
+function googleMapsSearchUrl(query) {
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(cleanLocationSearchQuery(query))}`;
+}
+
 async function fetchLocationSearchSuggestions(query) {
   const cleanedQuery = cleanLocationSearchQuery(query);
-  if (cleanedQuery.length < 2) {
-    return [];
+  if (cleanedQuery.length < 1) {
+    return { suggestions: [], detail: "" };
   }
   const data = await fetchJson(buildLocationSearchUrl(cleanedQuery));
-  return Array.isArray(data.suggestions)
-    ? data.suggestions.map(normalizeServerLocationSuggestion)
-    : [];
+  return {
+    suggestions: Array.isArray(data.suggestions)
+      ? data.suggestions.map(normalizeServerLocationSuggestion)
+      : [],
+    detail: data.detail || "",
+    online: Boolean(data.online),
+  };
 }
 
 async function refreshOnlineLocationSuggestions(query, requestId, localMatches) {
   try {
     const cleanedQuery = cleanLocationSearchQuery(query);
-    const serverMatches = await fetchLocationSearchSuggestions(cleanedQuery);
+    const result = await fetchLocationSearchSuggestions(cleanedQuery);
     if (requestId !== state.locationSearchRequestId) {
       return;
     }
+    state.locationSearchDetail = result.detail || "";
+    const serverMatches = result.suggestions || [];
     state.locationSearchMatches = mergeLocationSuggestions(localMatches, serverMatches, cleanedQuery);
     if (state.locationSearchMatches.length) {
       renderLocationSearchSuggestions();
     } else {
-      renderLocationSearchEmpty(cleanedQuery);
+      renderLocationSearchEmpty(cleanedQuery, state.locationSearchDetail);
     }
   } catch (_error) {
     if (requestId === state.locationSearchRequestId && !state.locationSearchMatches.length) {
-      renderLocationSearchEmpty(query);
+      state.locationSearchDetail = getErrorMessage(_error);
+      renderLocationSearchEmpty(query, state.locationSearchDetail);
     }
   }
 }
@@ -929,26 +983,40 @@ function setActiveLocationSuggestion(index) {
   });
 }
 
-function renderLocationSearchStatus(message) {
+function renderLocationSearchStatus(message, query = "") {
   els.locationSearchSuggestions.replaceChildren();
   const status = document.createElement("div");
   status.className = "location-suggestion-status";
-  status.textContent = message;
+  const text = document.createElement("span");
+  text.textContent = message;
+  status.appendChild(text);
+  const cleanedQuery = cleanLocationSearchQuery(query);
+  if (cleanedQuery) {
+    const externalLink = document.createElement("a");
+    externalLink.className = "location-suggestion-external";
+    externalLink.href = googleMapsSearchUrl(cleanedQuery);
+    externalLink.target = "_blank";
+    externalLink.rel = "noreferrer";
+    externalLink.textContent = "Open Google Maps search";
+    status.appendChild(externalLink);
+  }
   els.locationSearchSuggestions.appendChild(status);
   setLocationSearchOpen(true);
 }
 
 function renderLocationSearchLoading(query) {
   const cleanedQuery = cleanLocationSearchQuery(query);
-  renderLocationSearchStatus(`Searching ${cleanedQuery}...`);
+  renderLocationSearchStatus(`Searching ${cleanedQuery}...`, cleanedQuery);
 }
 
-function renderLocationSearchEmpty(query) {
+function renderLocationSearchEmpty(query, detail = "") {
   const cleanedQuery = cleanLocationSearchQuery(query);
+  const detailText = detail ? ` ${detail}` : "";
   renderLocationSearchStatus(
     cleanedQuery
-      ? `No location match for "${cleanedQuery}". Try a more specific place, coordinates, or KML/KMZ.`
+      ? `No in-map coordinate match for "${cleanedQuery}".${detailText}`
       : "Enter a mission location, coordinates, or KML/KMZ overlay.",
+    cleanedQuery,
   );
 }
 
@@ -1020,6 +1088,7 @@ async function commitLocationSearch() {
   const query = cleanLocationSearchQuery(els.locationSearchInput.value);
   window.clearTimeout(state.locationSearchTimer);
   state.locationSearchRequestId += 1;
+  state.locationSearchDetail = "";
 
   const coordinate = parseCoordinateQuery(query);
   if (coordinate) {
@@ -1027,13 +1096,13 @@ async function commitLocationSearch() {
     return;
   }
 
-  if (query.length < 2) {
+  if (query.length < 1) {
     renderLocationSearchEmpty(query);
     return;
   }
 
   const localMatches = getLocationSearchSuggestions(query);
-  const selectedBeforeFetch = state.activeLocationSearchIndex > 0
+  const selectedBeforeFetch = state.activeLocationSearchIndex >= 0
     ? state.locationSearchMatches[state.activeLocationSearchIndex]
     : null;
   if (localMatches.length) {
@@ -1045,9 +1114,12 @@ async function commitLocationSearch() {
 
   let serverMatches = [];
   try {
-    serverMatches = await fetchLocationSearchSuggestions(query);
-  } catch (_error) {
+    const result = await fetchLocationSearchSuggestions(query);
+    serverMatches = result.suggestions || [];
+    state.locationSearchDetail = result.detail || "";
+  } catch (error) {
     serverMatches = [];
+    state.locationSearchDetail = getErrorMessage(error);
   }
 
   const matches = mergeLocationSuggestions(localMatches, serverMatches, query);
@@ -1063,7 +1135,7 @@ async function commitLocationSearch() {
 
   if (!suggestion) {
     els.requestStatus.textContent = "Location not resolved. Try a more specific place, coordinates, or KML/KMZ.";
-    renderLocationSearchEmpty(query);
+    renderLocationSearchEmpty(query, state.locationSearchDetail);
     return;
   }
 
@@ -1077,7 +1149,8 @@ function onLocationSearchInput() {
   const query = cleanLocationSearchQuery(els.locationSearchInput.value);
   window.clearTimeout(state.locationSearchTimer);
   state.locationSearchRequestId += 1;
-  if (query.length < 2) {
+  state.locationSearchDetail = "";
+  if (query.length < 1) {
     state.locationSearchMatches = [];
     setLocationSearchOpen(false);
     return;
@@ -1579,6 +1652,7 @@ function syncModelSelects(sourceSelect, targetSelect) {
 
 function applyProviderVisibility() {
   const isClaude = state.llmProvider === "claude";
+  const hasClaudeKey = Boolean(state.claudeApiKey || state.serverClaudeKeyAvailable);
   els.providerSelect.value = state.llmProvider;
   els.providerLocalModelRow.classList.toggle("hidden", isClaude);
   els.providerClaudeModelRow.classList.toggle("hidden", !isClaude);
@@ -1587,8 +1661,12 @@ function applyProviderVisibility() {
     els.claudeApiKeyInput.value = state.claudeApiKey;
   }
   if (isClaude) {
-    setModelProviderButton(`Claude: ${els.claudeModelSelect.value}`, state.claudeApiKey ? "good" : "warn");
-    els.providerStatus.textContent = state.claudeApiKey ? "Claude API key loaded for this session" : "Claude key required";
+    setModelProviderButton(`Claude: ${els.claudeModelSelect.value}`, hasClaudeKey ? "good" : "warn");
+    els.providerStatus.textContent = state.claudeApiKey
+      ? "Claude API key loaded for this browser session"
+      : state.serverClaudeKeyAvailable
+        ? "Server ANTHROPIC_API_KEY will be used"
+        : "Claude key required";
   } else {
     const label = els.modelSelect.value || els.topModelSelect.value || state.config?.default_model || "local model";
     const tone = state.localModelAvailable ? "good" : "warn";
@@ -1602,9 +1680,9 @@ function applyProviderVisibility() {
 function applyProviderSelection() {
   state.llmProvider = els.providerSelect.value;
   state.claudeApiKey = els.claudeApiKeyInput.value.trim();
-  if (state.llmProvider === "claude" && !state.claudeApiKey) {
+  if (state.llmProvider === "claude" && !state.claudeApiKey && !state.serverClaudeKeyAvailable) {
     applyProviderVisibility();
-    els.providerStatus.textContent = "Claude API key required before switching providers";
+    els.providerStatus.textContent = "Claude API key required here or ANTHROPIC_API_KEY on the server";
     setModelProviderMenuOpen(true);
     els.claudeApiKeyInput.focus();
     return;
@@ -2055,7 +2133,7 @@ function applySourceRecommendation(data, missionText, mode = "server", statusMes
   const fallbackText = mode === "fallback"
     ? ` Browser fallback used because the planner API is unavailable (${statusMessage}).`
     : "";
-  els.packageStatus.textContent = `Drafted ${state.selectedSourceIds.size} working sources.${fallbackText} Use the advisor response to scope, then confirm sources.`;
+  els.packageStatus.textContent = `Drafted ${state.selectedSourceIds.size} working sources.${fallbackText} Confirm sources when ready.`;
   updateWorkflowPanel();
 }
 
@@ -2406,9 +2484,56 @@ function updateCameraText() {
   updateCenterGrid();
 }
 
+function updateMapModeControl() {
+  if (!els.mapModeToggleBtn) {
+    return;
+  }
+  const is3d = state.mapMode === "3d";
+  els.mapModeToggleBtn.textContent = is3d ? "2D View" : "3D View";
+  els.mapModeToggleBtn.setAttribute("aria-pressed", String(is3d));
+}
+
+function applyMapModeCameraControls() {
+  if (!state.viewer) {
+    return;
+  }
+  const controller = state.viewer.scene.screenSpaceCameraController;
+  const is3d = state.mapMode === "3d";
+  controller.enableTranslate = true;
+  controller.enableZoom = true;
+  controller.enableRotate = is3d;
+  controller.enableTilt = is3d;
+  controller.enableLook = is3d;
+  controller.enableCollisionDetection = true;
+  updateMapModeControl();
+}
+
+function setMapMode(mode, { animate = true } = {}) {
+  if (!state.viewer) {
+    state.mapMode = mode;
+    updateMapModeControl();
+    return;
+  }
+  const nextMode = mode === "3d" ? "3d" : "2d";
+  state.mapMode = nextMode;
+  const duration = animate ? 0.45 : 0;
+  if (nextMode === "3d") {
+    state.viewer.scene.morphTo3D(duration);
+  } else {
+    state.viewer.scene.morphTo2D(duration);
+  }
+  applyMapModeCameraControls();
+  state.viewer.scene.requestRender();
+}
+
+function toggleMapMode() {
+  setMapMode(state.mapMode === "3d" ? "2d" : "3d");
+}
+
 async function loadRuntimeConfig() {
   state.config = await fetchJson("/api/config");
   const hasToken = Boolean(state.config.cesium_ion_token);
+  state.serverClaudeKeyAvailable = Boolean(state.config.anthropic_api_key_configured);
   setChip(els.tokenChip, hasToken ? "Cesium token detected" : "Cesium token missing", hasToken ? "good" : "warn");
   els.claudeModelSelect.value = state.config.claude_default_model || els.claudeModelSelect.value;
   setModelProviderButton(`Default model: ${state.config.default_model}`, "warn");
@@ -2753,13 +2878,14 @@ async function submitPrompt(event) {
           });
         } catch (error) {
           claudeError = getErrorMessage(error);
-          els.providerStatus.textContent = `Claude request failed: ${claudeError}`;
-          els.requestStatus.textContent = "Claude failed; trying local Ollama fallback...";
+          console.warn("Claude request failed; trying local Ollama fallback.", claudeError);
+          els.providerStatus.textContent = "Claude request failed. Check key, model access, or network.";
+          els.requestStatus.textContent = "Trying local model fallback...";
         }
       } else {
-        claudeError = "Claude API key is not set for this browser session.";
-        els.providerStatus.textContent = "Claude API key missing; trying local Ollama fallback";
-        els.requestStatus.textContent = "Claude key missing; trying local Ollama fallback...";
+        claudeError = "Claude API key is not set in this browser session or on the server.";
+        els.providerStatus.textContent = "Claude API key missing";
+        els.requestStatus.textContent = "Trying local model fallback...";
       }
     }
 
@@ -2775,7 +2901,6 @@ async function submitPrompt(event) {
           agentProfile,
           mapContext,
           sourceContext,
-          metaPrefix: provider === "claude" ? "local fallback after Claude failure" : "",
         });
       } catch (error) {
         localError = getErrorMessage(error);
@@ -2798,14 +2923,18 @@ async function submitPrompt(event) {
       claudeError ? `Claude: ${claudeError}` : "",
       localError ? `local Ollama: ${localError}` : "",
     ].filter(Boolean).join(" | ");
+    if (failureSummary) {
+      console.warn("Model providers unavailable; deterministic planner response shown.", failureSummary);
+    }
     setMessageBody(assistantMessage, buildDeterministicAdvisorResponse(sourceRecommendation, mapContext));
-    ensureMessageMeta(assistantMessage, `deterministic fallback | ${failureSummary || "model providers unavailable"}`);
-    els.requestStatus.textContent = `Model providers unavailable; deterministic advisor response shown (${failureSummary})`;
+    ensureMessageMeta(assistantMessage, "deterministic planner response");
+    els.requestStatus.textContent = "Deterministic planner response shown.";
   } catch (error) {
     const message = getErrorMessage(error);
+    console.warn("Prompt request failed; deterministic planner response shown.", message);
     setMessageBody(assistantMessage, buildDeterministicAdvisorResponse(sourceRecommendation, mapContext));
-    ensureMessageMeta(assistantMessage, `deterministic fallback | ${message}`);
-    els.requestStatus.textContent = `Deterministic advisor response shown (${message})`;
+    ensureMessageMeta(assistantMessage, "deterministic planner response");
+    els.requestStatus.textContent = "Deterministic planner response shown.";
   } finally {
     els.submitBtn.disabled = false;
   }
@@ -3094,10 +3223,11 @@ function setCameraDragEnabled(enabled) {
     return;
   }
   const controller = state.viewer.scene.screenSpaceCameraController;
-  controller.enableRotate = enabled;
   controller.enableTranslate = enabled;
-  controller.enableTilt = enabled;
-  controller.enableLook = enabled;
+  controller.enableZoom = true;
+  controller.enableRotate = enabled && state.mapMode === "3d";
+  controller.enableTilt = enabled && state.mapMode === "3d";
+  controller.enableLook = enabled && state.mapMode === "3d";
 }
 
 function finishAreaResize(position) {
@@ -3210,6 +3340,13 @@ function wireMapInteraction() {
     finishAreaDrawing(movement.position);
   }, Cesium.ScreenSpaceEventType.LEFT_UP);
 
+  handler.setInputAction(() => {
+    if (state.areaDrawing || state.areaResizeHandle) {
+      return;
+    }
+    setMapMode("3d");
+  }, Cesium.ScreenSpaceEventType.MIDDLE_DOWN);
+
   state.viewer.camera.changed.addEventListener(updateCameraText);
   updateCameraText();
 }
@@ -3226,6 +3363,7 @@ async function buildViewer() {
     state.areaHandleEntities = [];
     state.overlayDataSource = null;
     state.overlayFileName = "";
+    state.overlayFeatureCount = 0;
     if (state.mapFocusSource === "kml-kmz-import") {
       clearMapLocationFocus();
     }
@@ -3243,6 +3381,7 @@ async function buildViewer() {
     homeButton: false,
     infoBox: false,
     navigationHelpButton: false,
+    sceneMode: Cesium.SceneMode.SCENE2D,
     sceneModePicker: false,
     selectionIndicator: false,
     terrainProvider: new Cesium.EllipsoidTerrainProvider(),
@@ -3258,8 +3397,12 @@ async function buildViewer() {
   state.viewer.terrainProvider = terrain.provider;
 
   state.viewer.scene.globe.depthTestAgainstTerrain = false;
-  state.viewer.scene.screenSpaceCameraController.enableCollisionDetection = true;
+  applyMapModeCameraControls();
   state.viewer.camera.percentageChanged = 0.01;
+  state.viewer.scene.morphComplete.addEventListener(() => {
+    applyMapModeCameraControls();
+    updateCameraText();
+  });
 
   const target = state.lastCamera || {
     lat: state.config.default_lat,
@@ -3278,6 +3421,7 @@ async function buildViewer() {
   state.viewer.resize();
   state.viewer.scene.requestRender();
   wireMapInteraction();
+  setMapMode(state.mapMode, { animate: false });
   if (state.selectedArea) {
     setAreaEntityBounds(state.selectedArea);
   }
@@ -3302,6 +3446,276 @@ function resetView() {
   els.requestStatus.textContent = "Map reset. Search or import the mission location before source confirmation.";
 }
 
+function kmlDescendants(root, localName) {
+  return Array.from(root.getElementsByTagName("*")).filter((node) => node.localName === localName);
+}
+
+function firstKmlDescendant(root, localName) {
+  return kmlDescendants(root, localName)[0] || null;
+}
+
+function readKmlText(root, localName) {
+  const node = firstKmlDescendant(root, localName);
+  return node?.textContent?.trim() || "";
+}
+
+function parseKmlCoordinateText(text) {
+  return String(text || "")
+    .trim()
+    .split(/\s+/)
+    .map((tuple) => tuple.split(",").map((value) => Number.parseFloat(value)))
+    .filter(([lon, lat]) => Number.isFinite(lon) && Number.isFinite(lat))
+    .map(([lon, lat, height]) => (
+      Number.isFinite(height) ? [lon, lat, height] : [lon, lat]
+    ));
+}
+
+function parseKmlGxCoordinateText(text) {
+  return String(text || "")
+    .trim()
+    .split(/\s+/)
+    .map((value) => Number.parseFloat(value))
+    .filter((value) => Number.isFinite(value));
+}
+
+function closeLinearRing(points) {
+  if (points.length < 3) {
+    return points;
+  }
+  const first = points[0];
+  const last = points[points.length - 1];
+  if (first[0] === last[0] && first[1] === last[1]) {
+    return points;
+  }
+  return [...points, [...first]];
+}
+
+function parseKmlPointGeometry(node) {
+  const coordinates = parseKmlCoordinateText(readKmlText(node, "coordinates"))[0];
+  return coordinates ? { type: "Point", coordinates } : null;
+}
+
+function parseKmlLineGeometry(node) {
+  const coordinates = parseKmlCoordinateText(readKmlText(node, "coordinates"));
+  return coordinates.length >= 2 ? { type: "LineString", coordinates } : null;
+}
+
+function parseKmlTrackGeometry(node) {
+  const coordinates = kmlDescendants(node, "coord")
+    .map((coordNode) => parseKmlGxCoordinateText(coordNode.textContent))
+    .filter(([lon, lat]) => Number.isFinite(lon) && Number.isFinite(lat))
+    .map(([lon, lat, height]) => (
+      Number.isFinite(height) ? [lon, lat, height] : [lon, lat]
+    ));
+  return coordinates.length >= 2 ? { type: "LineString", coordinates } : null;
+}
+
+function parseKmlPolygonGeometry(node) {
+  const outerBoundary = firstKmlDescendant(node, "outerBoundaryIs") || node;
+  const outerRing = firstKmlDescendant(outerBoundary, "LinearRing");
+  const outerCoordinates = closeLinearRing(parseKmlCoordinateText(readKmlText(outerRing || outerBoundary, "coordinates")));
+  if (outerCoordinates.length < 4) {
+    return null;
+  }
+
+  const innerCoordinates = kmlDescendants(node, "innerBoundaryIs")
+    .map((innerBoundary) => {
+      const innerRing = firstKmlDescendant(innerBoundary, "LinearRing");
+      return closeLinearRing(parseKmlCoordinateText(readKmlText(innerRing || innerBoundary, "coordinates")));
+    })
+    .filter((ring) => ring.length >= 4);
+
+  return { type: "Polygon", coordinates: [outerCoordinates, ...innerCoordinates] };
+}
+
+function extractKmlGeometries(root) {
+  const geometries = [];
+  for (const node of kmlDescendants(root, "Point")) {
+    const geometry = parseKmlPointGeometry(node);
+    if (geometry) {
+      geometries.push(geometry);
+    }
+  }
+  for (const node of kmlDescendants(root, "LineString")) {
+    const geometry = parseKmlLineGeometry(node);
+    if (geometry) {
+      geometries.push(geometry);
+    }
+  }
+  for (const node of kmlDescendants(root, "Track")) {
+    const geometry = parseKmlTrackGeometry(node);
+    if (geometry) {
+      geometries.push(geometry);
+    }
+  }
+  for (const node of kmlDescendants(root, "Polygon")) {
+    const geometry = parseKmlPolygonGeometry(node);
+    if (geometry) {
+      geometries.push(geometry);
+    }
+  }
+  return geometries;
+}
+
+function parseKmlToGeoJson(kmlText, sourceName) {
+  const xml = new DOMParser().parseFromString(kmlText, "application/xml");
+  if (xml.querySelector("parsererror")) {
+    throw new Error(`${sourceName} is not valid KML XML.`);
+  }
+
+  const placemarks = kmlDescendants(xml, "Placemark");
+  const features = [];
+  const roots = placemarks.length ? placemarks : [xml.documentElement];
+
+  roots.forEach((root, index) => {
+    const name = readKmlText(root, "name") || `${sourceName} feature ${index + 1}`;
+    const description = readKmlText(root, "description");
+    for (const geometry of extractKmlGeometries(root)) {
+      features.push({
+        type: "Feature",
+        properties: {
+          name,
+          description,
+          source: sourceName,
+        },
+        geometry,
+      });
+    }
+  });
+
+  return {
+    type: "FeatureCollection",
+    features,
+  };
+}
+
+function sortKmlArchiveEntries(a, b) {
+  const aName = a.name.toLowerCase();
+  const bName = b.name.toLowerCase();
+  const aDepth = aName.split("/").length;
+  const bDepth = bName.split("/").length;
+  if (aDepth !== bDepth) {
+    return aDepth - bDepth;
+  }
+  if (aName.endsWith("doc.kml") && !bName.endsWith("doc.kml")) {
+    return -1;
+  }
+  if (bName.endsWith("doc.kml") && !aName.endsWith("doc.kml")) {
+    return 1;
+  }
+  return aName.localeCompare(bName);
+}
+
+async function readOverlayFileText(file) {
+  const lowerName = file.name.toLowerCase();
+  if (lowerName.endsWith(".kml")) {
+    return [{ name: file.name, text: await file.text() }];
+  }
+
+  if (!lowerName.endsWith(".kmz")) {
+    throw new Error(`Unsupported overlay format: ${file.name}`);
+  }
+  if (!window.JSZip) {
+    throw new Error("KMZ import requires JSZip to finish loading. Try again after the page is ready.");
+  }
+
+  const zip = await window.JSZip.loadAsync(await file.arrayBuffer());
+  const entries = Object.values(zip.files)
+    .filter((entry) => !entry.dir && entry.name.toLowerCase().endsWith(".kml"))
+    .sort(sortKmlArchiveEntries);
+  if (!entries.length) {
+    throw new Error(`No KML document found inside ${file.name}.`);
+  }
+
+  const texts = [];
+  for (const entry of entries) {
+    texts.push({
+      name: entry.name,
+      text: await entry.async("text"),
+    });
+  }
+  return texts;
+}
+
+async function loadParsedOverlayDataSource(file) {
+  const entries = await readOverlayFileText(file);
+  const features = [];
+  for (const entry of entries) {
+    const collection = parseKmlToGeoJson(entry.text, entry.name);
+    for (const feature of collection.features) {
+      features.push({
+        ...feature,
+        properties: {
+          ...(feature.properties || {}),
+          package: file.name,
+        },
+      });
+    }
+  }
+  if (!features.length) {
+    throw new Error(`No supported point, line, track, or polygon features were found in ${file.name}.`);
+  }
+
+  const dataSource = await Cesium.GeoJsonDataSource.load({
+    type: "FeatureCollection",
+    features,
+  }, {
+    clampToGround: true,
+    markerColor: cesiumCssColor("--color-accent-gold"),
+    stroke: cesiumCssColor("--color-accent-gold"),
+    fill: cesiumCssColor("--color-accent-gold").withAlpha(0.2),
+    strokeWidth: 3,
+  });
+  dataSource.name = file.name;
+  styleOverlayDataSource(dataSource);
+  state.overlayFeatureCount = features.length;
+  return dataSource;
+}
+
+async function loadNativeOverlayDataSource(file) {
+  const dataSource = await Cesium.KmlDataSource.load(file, {
+    camera: state.viewer.scene.camera,
+    canvas: state.viewer.scene.canvas,
+    clampToGround: true,
+    sourceUri: file.name,
+  });
+  state.overlayFeatureCount = dataSource.entities.values.length;
+  return dataSource;
+}
+
+function styleOverlayDataSource(dataSource) {
+  const gold = cesiumCssColor("--color-accent-gold");
+  const background = cesiumCssColor("--color-bg-primary");
+  const fill = gold.withAlpha(0.22);
+
+  for (const entity of dataSource.entities.values) {
+    if (entity.position) {
+      entity.billboard = undefined;
+      entity.point = new Cesium.PointGraphics({
+        pixelSize: 11,
+        color: gold,
+        outlineColor: background,
+        outlineWidth: 2,
+        heightReference: Cesium.HeightReference.CLAMP_TO_GROUND,
+        disableDepthTestDistance: Number.POSITIVE_INFINITY,
+      });
+    }
+    if (entity.polyline) {
+      entity.polyline.width = 3;
+      entity.polyline.material = gold;
+      entity.polyline.depthFailMaterial = gold.withAlpha(0.55);
+      entity.polyline.clampToGround = true;
+    }
+    if (entity.polygon) {
+      entity.polygon.material = fill;
+      entity.polygon.outline = true;
+      entity.polygon.outlineColor = gold;
+      entity.polygon.outlineWidth = 2;
+      entity.polygon.perPositionHeight = false;
+    }
+  }
+}
+
 function isSupportedOverlayFile(file) {
   return /\.(kml|kmz)$/i.test(file.name);
 }
@@ -3310,6 +3724,7 @@ async function removeCurrentOverlay() {
   if (!state.viewer || !state.overlayDataSource) {
     state.overlayDataSource = null;
     state.overlayFileName = "";
+    state.overlayFeatureCount = 0;
     if (state.mapFocusSource === "kml-kmz-import") {
       clearMapLocationFocus();
     }
@@ -3319,6 +3734,7 @@ async function removeCurrentOverlay() {
   await state.viewer.dataSources.remove(state.overlayDataSource, true);
   state.overlayDataSource = null;
   state.overlayFileName = "";
+  state.overlayFeatureCount = 0;
   if (state.mapFocusSource === "kml-kmz-import") {
     clearMapLocationFocus();
   }
@@ -3342,12 +3758,13 @@ async function importMapOverlay(file) {
 
   try {
     await removeCurrentOverlay();
-    const dataSource = await Cesium.KmlDataSource.load(file, {
-      camera: state.viewer.scene.camera,
-      canvas: state.viewer.scene.canvas,
-      clampToGround: true,
-      sourceUri: file.name,
-    });
+    let dataSource;
+    try {
+      dataSource = await loadParsedOverlayDataSource(file);
+    } catch (parseError) {
+      console.warn("Parsed KML/KMZ rendering failed; trying Cesium native loader.", parseError);
+      dataSource = await loadNativeOverlayDataSource(file);
+    }
     state.overlayDataSource = await state.viewer.dataSources.add(dataSource);
     state.overlayFileName = file.name;
     markMapLocationFocused(file.name, "kml-kmz-import");
@@ -3355,7 +3772,7 @@ async function importMapOverlay(file) {
     if (state.overlayDataSource.entities.values.length) {
       await state.viewer.flyTo(state.overlayDataSource, { duration: 1.1 });
       updateCameraText();
-      els.requestStatus.textContent = `Overlay loaded: ${file.name}`;
+      els.requestStatus.textContent = `Overlay loaded: ${file.name} (${state.overlayFeatureCount} features)`;
     } else {
       els.requestStatus.textContent = `Overlay loaded with no visible features: ${file.name}`;
     }
@@ -3526,6 +3943,7 @@ async function init() {
     els.clearChatBtn.addEventListener("click", clearChat);
     els.resetViewBtn.addEventListener("click", resetView);
     els.mapResetViewBtn.addEventListener("click", resetView);
+    els.mapModeToggleBtn.addEventListener("click", toggleMapMode);
     els.importOverlayBtn.addEventListener("click", requestOverlayFile);
     els.overlayFileInput.addEventListener("change", onOverlayFileSelected);
     els.locationSearchForm.addEventListener("submit", onLocationSearchSubmit);

--- a/llm_dev_kmh/static/app.js
+++ b/llm_dev_kmh/static/app.js
@@ -43,6 +43,8 @@ const state = {
   serverClaudeKeyAvailable: false,
   llmProvider: sessionStorage.getItem("teraLlmProvider") || "auto",
   claudeApiKey: sessionStorage.getItem("teraClaudeApiKey") || "",
+  atakAgentActive: false,
+  atakMirrorTimer: null,
   selectedSourceIds: new Set(),
   packagePlan: null,
   packageStatusTimer: null,
@@ -75,6 +77,11 @@ const els = {
   resetViewBtn: document.getElementById("resetViewBtn"),
   importOverlayBtn: document.getElementById("importOverlayBtn"),
   overlayFileInput: document.getElementById("overlayFileInput"),
+  atakAgentBtn: document.getElementById("atakAgentBtn"),
+  atakMirrorPanel: document.getElementById("atakMirrorPanel"),
+  atakMirrorStatus: document.getElementById("atakMirrorStatus"),
+  atakMirrorLog: document.getElementById("atakMirrorLog"),
+  atakMirrorRefreshBtn: document.getElementById("atakMirrorRefreshBtn"),
   panelToggleBtn: document.getElementById("panelToggleBtn"),
   panelResizer: document.getElementById("panelResizer"),
   workspaceShell: document.querySelector(".workspace-shell"),
@@ -694,6 +701,11 @@ function setChip(node, text, tone = "") {
 function setModelProviderButton(text, tone = "") {
   els.modelProviderBtn.textContent = text;
   els.modelProviderBtn.className = `chip chip-button${tone ? ` ${tone}` : ""}`;
+}
+
+function setAtakAgentButton(text, tone = "") {
+  els.atakAgentBtn.textContent = text;
+  els.atakAgentBtn.className = `chip chip-button${tone ? ` ${tone}` : ""}`;
 }
 
 function getErrorMessage(error) {
@@ -2841,6 +2853,140 @@ async function loadModels() {
   }
 }
 
+function ensureLocalModelOption(model) {
+  if (!model) {
+    return;
+  }
+  for (const select of [els.modelSelect, els.topModelSelect]) {
+    const exists = Array.from(select.options).some((option) => option.value === model);
+    if (!exists) {
+      const option = document.createElement("option");
+      option.value = model;
+      option.textContent = `${model} (ATAK local)`;
+      select.appendChild(option);
+    }
+    select.value = model;
+  }
+}
+
+function renderAtakMirror(events = []) {
+  els.atakMirrorLog.innerHTML = "";
+  if (!events.length) {
+    const empty = document.createElement("div");
+    empty.className = "atak-mirror-empty";
+    empty.textContent = "No ATAK plugin conversation mirrored yet.";
+    els.atakMirrorLog.appendChild(empty);
+    return;
+  }
+
+  for (const event of events) {
+    const item = document.createElement("article");
+    item.className = `atak-mirror-event ${event.role === "operator" ? "inbound" : "outbound"}`;
+
+    const header = document.createElement("div");
+    header.className = "atak-mirror-event-header";
+    const source = document.createElement("span");
+    source.textContent = `${event.source || "jetson"} / ${event.role || "event"}`;
+    const stamp = document.createElement("time");
+    stamp.dateTime = event.timestamp || "";
+    stamp.textContent = event.timestamp ? new Date(event.timestamp).toLocaleTimeString() : "";
+    header.append(source, stamp);
+
+    const body = document.createElement("div");
+    body.className = "atak-mirror-event-body";
+    body.textContent = event.text || "";
+
+    const meta = document.createElement("div");
+    meta.className = "message-meta";
+    meta.textContent = [
+      event.direction,
+      event.provider,
+      event.model,
+    ].filter(Boolean).join(" | ");
+
+    item.append(header, body);
+    if (meta.textContent) {
+      item.appendChild(meta);
+    }
+    els.atakMirrorLog.appendChild(item);
+  }
+  els.atakMirrorLog.scrollTop = els.atakMirrorLog.scrollHeight;
+}
+
+function applyAtakAgentStatus(data) {
+  state.atakAgentActive = Boolean(data.active);
+  els.atakMirrorPanel.classList.toggle("hidden", !state.atakAgentActive);
+  if (state.atakAgentActive) {
+    setAtakAgentButton("ATAK Local: active", data.status === "active" ? "good" : "warn");
+    els.atakMirrorStatus.textContent = data.detail || `Mirroring ${data.model || "local model"}`;
+    renderAtakMirror(data.events || []);
+  } else {
+    setAtakAgentButton("ATAK Local", "");
+  }
+}
+
+async function refreshAtakMirror() {
+  const data = await fetchJson("/api/jetson/atak-agent/mirror");
+  applyAtakAgentStatus(data);
+  return data;
+}
+
+function startAtakMirrorPolling() {
+  if (state.atakMirrorTimer) {
+    window.clearInterval(state.atakMirrorTimer);
+  }
+  state.atakMirrorTimer = window.setInterval(() => {
+    refreshAtakMirror().catch((error) => {
+      els.atakMirrorStatus.textContent = getErrorMessage(error);
+      setAtakAgentButton("ATAK mirror error", "bad");
+    });
+  }, 2000);
+}
+
+async function loadAtakAgentStatus() {
+  try {
+    const data = await fetchJson("/api/jetson/atak-agent/status");
+    applyAtakAgentStatus(data);
+    if (data.active) {
+      ensureLocalModelOption(data.model);
+      startAtakMirrorPolling();
+    }
+  } catch (error) {
+    setAtakAgentButton("ATAK status unknown", "warn");
+  }
+}
+
+async function activateAtakLocalAgent() {
+  els.atakAgentBtn.disabled = true;
+  setAtakAgentButton("Switching ATAK...", "warn");
+  try {
+    const data = await fetchJson("/api/jetson/atak-agent/activate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gemma3:4b",
+        agent_profile: "tera-atak-live",
+      }),
+    });
+
+    ensureLocalModelOption(data.model || "gemma3:4b");
+    state.llmProvider = "ollama";
+    sessionStorage.setItem("teraLlmProvider", "ollama");
+    els.providerSelect.value = "ollama";
+    els.agentProfileSelect.value = data.agent_profile || "tera-atak-live";
+    state.localModelAvailable = true;
+    els.modelsStatus.textContent = `ATAK local model: ${data.model}`;
+    applyProviderVisibility();
+    applyAtakAgentStatus(data);
+    startAtakMirrorPolling();
+  } catch (error) {
+    setAtakAgentButton("ATAK switch failed", "bad");
+    els.requestStatus.textContent = getErrorMessage(error);
+  } finally {
+    els.atakAgentBtn.disabled = false;
+  }
+}
+
 function makeMapContextAppendix() {
   if (!els.includeMapContext.checked) {
     return "";
@@ -4257,6 +4403,12 @@ async function init() {
     els.mapModeToggleBtn.addEventListener("click", toggleMapMode);
     els.importOverlayBtn.addEventListener("click", requestOverlayFile);
     els.overlayFileInput.addEventListener("change", onOverlayFileSelected);
+    els.atakAgentBtn.addEventListener("click", activateAtakLocalAgent);
+    els.atakMirrorRefreshBtn.addEventListener("click", () => {
+      refreshAtakMirror().catch((error) => {
+        els.atakMirrorStatus.textContent = getErrorMessage(error);
+      });
+    });
     els.locationSearchForm.addEventListener("submit", onLocationSearchSubmit);
     els.locationSearchInput.addEventListener("input", onLocationSearchInput);
     els.locationSearchInput.addEventListener("keydown", onLocationSearchKeyDown);
@@ -4335,6 +4487,7 @@ async function init() {
 
   await loadRuntimeConfig();
   await loadModels();
+  await loadAtakAgentStatus();
   await loadDataSources();
   await loadJetsonStorage();
   await buildViewer();

--- a/llm_dev_kmh/static/app.js
+++ b/llm_dev_kmh/static/app.js
@@ -13,7 +13,7 @@ const state = {
   areaStartPoint: null,
   cameraText: "",
   chatCount: 0,
-  imageryMode: "esri",
+  imageryMode: "ion-satellite",
   terrainMode: "cesium-world",
   mapMode: "2d",
   panelWidth: 520,
@@ -45,6 +45,8 @@ const state = {
   claudeApiKey: sessionStorage.getItem("teraClaudeApiKey") || "",
   selectedSourceIds: new Set(),
   packagePlan: null,
+  packageStatusTimer: null,
+  jetsonStorage: null,
   sourceInference: null,
   sourceConfirmed: false,
   workflowStageIndex: 0,
@@ -130,6 +132,20 @@ const els = {
   packageStatus: document.getElementById("packageStatus"),
   packageManifest: document.getElementById("packageManifest"),
   downloadManifestLink: document.getElementById("downloadManifestLink"),
+  jetsonStorageCard: document.getElementById("jetsonStorageCard"),
+  storageRoot: document.getElementById("storageRoot"),
+  storageFitChip: document.getElementById("storageFitChip"),
+  storageMeterUsed: document.getElementById("storageMeterUsed"),
+  storageMeterReserve: document.getElementById("storageMeterReserve"),
+  storageFree: document.getElementById("storageFree"),
+  storageUsable: document.getElementById("storageUsable"),
+  storageReserve: document.getElementById("storageReserve"),
+  storageEstimate: document.getElementById("storageEstimate"),
+  packageExecutionActions: document.getElementById("packageExecutionActions"),
+  downloadToJetsonBtn: document.getElementById("downloadToJetsonBtn"),
+  refreshPackageStatusBtn: document.getElementById("refreshPackageStatusBtn"),
+  packageExecutionStatus: document.getElementById("packageExecutionStatus"),
+  packageArtifacts: document.getElementById("packageArtifacts"),
 };
 
 window.__TERA_SOURCE_STATE = state;
@@ -159,6 +175,11 @@ const IMAGERY_FALLBACKS = {
     credit: "Esri World Imagery",
     label: "Esri World Imagery",
   },
+  "usgs-imagery": {
+    url: "https://basemap.nationalmap.gov/ArcGIS/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}",
+    credit: "USGS The National Map",
+    label: "USGS Imagery Only",
+  },
   osm: {
     url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
     credit: "OpenStreetMap contributors",
@@ -167,7 +188,8 @@ const IMAGERY_FALLBACKS = {
 };
 
 const FALLBACK_PRIMARY_STREAM_SOURCE_IDS = [
-  "esri_world_imagery",
+  "cesium_world_imagery",
+  "usgs_imagery_only",
   "cesium_world_terrain",
   "osm_basemap",
 ];
@@ -408,10 +430,57 @@ const FALLBACK_SOURCE_CATALOG = [
     name: "Esri World Imagery",
     provider: "Esri ArcGIS Online",
     category: "imagery",
-    purpose: "Streamable visual basemap for AO inspection and imagery context.",
+    purpose: "Optional licensed imagery stream when an Esri account is available.",
     stream_status: "streamable",
-    download_status: "manifest-only",
+    download_status: "export-tiles-with-account",
     stream_layer: "esri",
+  },
+  {
+    id: "cesium_world_imagery",
+    name: "Cesium World Imagery",
+    provider: "Cesium ion",
+    category: "imagery",
+    purpose: "Token-backed imagery preview stream using the available Cesium token.",
+    stream_status: "streamable-with-token",
+    download_status: "stream-only-no-offline-copy",
+    stream_layer: "ion-satellite",
+  },
+  {
+    id: "cesium_ion_archive",
+    name: "Cesium ion Offline Archive",
+    provider: "Cesium ion",
+    category: "imagery-terrain-archive",
+    purpose: "Licensed Cesium ion archive or AO clip downloaded to the Jetson for local preview and metadata queries.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "usgs_imagery_only",
+    name: "USGS Imagery Only",
+    provider: "USGS The National Map",
+    category: "imagery",
+    purpose: "Free U.S. imagery tile stream and AO tile cache for offline visual context.",
+    stream_status: "streamable",
+    download_status: "cache-tiles",
+    stream_layer: "usgs-imagery",
+  },
+  {
+    id: "nrl_naip_conus",
+    name: "NRL NAIP (CONUS)",
+    provider: "NRL / USDA NAIP",
+    category: "imagery",
+    purpose: "Free CONUS NAIP tile stream from the WinTAK imagery source folder for high-detail visual review.",
+    stream_status: "streamable",
+    download_status: "cache-tiles",
+  },
+  {
+    id: "esri_world_elevation",
+    name: "Esri World Elevation Terrain",
+    provider: "Esri ArcGIS Online / Living Atlas",
+    category: "terrain",
+    purpose: "Primary queryable terrain source for DEM export, slope, hydrology, cost surfaces, and viewshed.",
+    stream_status: "queryable-online",
+    download_status: "download-required",
   },
   {
     id: "cesium_world_terrain",
@@ -420,17 +489,8 @@ const FALLBACK_SOURCE_CATALOG = [
     category: "terrain-display",
     purpose: "Streamable 3D terrain preview for landform awareness.",
     stream_status: "streamable-with-token",
-    download_status: "cache-via-cesium-pipeline",
+    download_status: "stream-only-no-offline-copy",
     stream_layer: "cesium-world",
-  },
-  {
-    id: "esri_world_elevation",
-    name: "Esri World Elevation Terrain",
-    provider: "Esri ArcGIS Online / Living Atlas",
-    category: "terrain",
-    purpose: "Queryable elevation terrain fallback for AO sampling, slope, hillshade, and viewshed preflight.",
-    stream_status: "queryable-online",
-    download_status: "download-required",
   },
   {
     id: "osm_basemap",
@@ -462,12 +522,21 @@ const FALLBACK_SOURCE_CATALOG = [
   },
   {
     id: "copernicus_dem",
-    name: "Copernicus DEM",
+    name: "Copernicus DEM GLO-30 COG",
     provider: "Copernicus",
     category: "terrain",
-    purpose: "Global elevation fallback for slope, viewshed, and terrain-cost analysis.",
+    purpose: "No-account public S3 COG terrain tiles for slope, viewshed, and terrain-cost analysis.",
     stream_status: "not-streamed",
     download_status: "download-required",
+  },
+  {
+    id: "dted_earth_explorer",
+    name: "DTED from USGS EarthExplorer",
+    provider: "USGS EarthExplorer",
+    category: "terrain",
+    purpose: "Operator-staged DTED cells imported to the Jetson and converted to GeoTIFF when GDAL is available.",
+    stream_status: "not-streamed",
+    download_status: "manual-stage-import",
   },
   {
     id: "nlcd",
@@ -517,9 +586,9 @@ const FALLBACK_SOURCE_CATALOG = [
   {
     id: "sentinel_2",
     name: "Sentinel-2 Multispectral",
-    provider: "ESA Copernicus",
+    provider: "ESA Copernicus / Element 84 Earth Search",
     category: "imagery-analysis",
-    purpose: "Analysis imagery for vegetation, water, burn, and surface-condition indices.",
+    purpose: "Free downloadable COG imagery for offline visual context, vegetation, water, burn, and surface-condition indices.",
     stream_status: "not-streamed",
     download_status: "download-required",
   },
@@ -638,6 +707,66 @@ async function fetchJson(url, options) {
     throw new Error(data.detail || `${response.status} ${response.statusText}`);
   }
   return data;
+}
+
+function formatBytes(value) {
+  const bytes = Number(value || 0);
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let scaled = Math.max(0, bytes);
+  let index = 0;
+  while (scaled >= 1024 && index < units.length - 1) {
+    scaled /= 1024;
+    index += 1;
+  }
+  const precision = index <= 1 ? 0 : 1;
+  return `${scaled.toFixed(precision)} ${units[index]}`;
+}
+
+function renderJetsonStorage(storage = state.jetsonStorage, estimateBytes = null, storageFit = true, warning = "") {
+  if (!storage) {
+    els.storageRoot.textContent = "Jetson storage unavailable";
+    setChip(els.storageFitChip, "Unknown", "warn");
+    return;
+  }
+  state.jetsonStorage = storage;
+  const total = Number(storage.total_bytes || 0);
+  const used = Number(storage.used_bytes || 0);
+  const reserved = Number(storage.reserved_bytes || 0);
+  const free = Number(storage.free_bytes || 0);
+  const usable = Number(storage.usable_bytes || 0);
+  const estimate = Number(estimateBytes || 0);
+  const usedPct = total > 0 ? Math.min(100, (used / total) * 100) : 0;
+  const reservePct = total > 0 ? Math.min(100, (reserved / total) * 100) : 0;
+
+  els.storageRoot.textContent = storage.package_root || "Jetson package root";
+  els.storageFree.textContent = formatBytes(free);
+  els.storageUsable.textContent = formatBytes(usable);
+  els.storageReserve.textContent = formatBytes(reserved);
+  els.storageEstimate.textContent = estimate ? formatBytes(estimate) : "--";
+  els.storageMeterUsed.style.width = `${usedPct}%`;
+  els.storageMeterReserve.style.left = `${Math.max(0, 100 - reservePct)}%`;
+  els.storageMeterReserve.style.width = `${reservePct}%`;
+
+  if (estimate && !storageFit) {
+    setChip(els.storageFitChip, "No room", "bad");
+    els.storageRoot.textContent = warning || "Package estimate exceeds Jetson usable storage";
+  } else if (estimate) {
+    setChip(els.storageFitChip, "Fits", "good");
+  } else {
+    setChip(els.storageFitChip, "Ready", usable > 0 ? "good" : "warn");
+  }
+}
+
+async function loadJetsonStorage() {
+  try {
+    const storage = await fetchJson("/api/storage");
+    renderJetsonStorage(storage);
+    return storage;
+  } catch (error) {
+    els.storageRoot.textContent = getErrorMessage(error);
+    setChip(els.storageFitChip, "Storage error", "bad");
+    return null;
+  }
 }
 
 function normalizeSearchText(value) {
@@ -1651,9 +1780,13 @@ function syncModelSelects(sourceSelect, targetSelect) {
   });
 }
 
+function hasClaudeProviderCredential() {
+  return Boolean(state.claudeApiKey || state.serverClaudeKeyAvailable);
+}
+
 function applyProviderVisibility() {
   const isClaude = state.llmProvider === "claude";
-  const hasClaudeKey = Boolean(state.claudeApiKey || state.serverClaudeKeyAvailable);
+  const hasClaudeKey = hasClaudeProviderCredential();
   els.providerSelect.value = state.llmProvider;
   els.providerLocalModelRow.classList.toggle("hidden", isClaude);
   els.providerClaudeModelRow.classList.toggle("hidden", !isClaude);
@@ -1681,7 +1814,7 @@ function applyProviderVisibility() {
 function applyProviderSelection() {
   state.llmProvider = els.providerSelect.value;
   state.claudeApiKey = els.claudeApiKeyInput.value.trim();
-  if (state.llmProvider === "claude" && !state.claudeApiKey && !state.serverClaudeKeyAvailable) {
+  if (state.llmProvider === "claude" && !hasClaudeProviderCredential()) {
     applyProviderVisibility();
     els.providerStatus.textContent = "Claude API key required here or ANTHROPIC_API_KEY on the server";
     setModelProviderMenuOpen(true);
@@ -1921,8 +2054,12 @@ function buildClientSourceRecommendation(missionText, mapContext, plannerErrorMe
   const questions = [];
   const rationale = [`Planner API unavailable: ${plannerErrorMessage}. Using embedded deterministic source rules.`];
 
-  appendUniqueSourceIds(optionalIds, "esri_world_imagery", "osm_basemap");
-  rationale.push("Esri imagery and OSM basemap stay as lightweight preview/context layers.");
+  appendUniqueSourceIds(requiredIds, isUsContext ? "naip" : "sentinel_2");
+  appendUniqueSourceIds(optionalIds, "cesium_world_imagery", "osm_basemap");
+  if (isUsContext) {
+    appendUniqueSourceIds(optionalIds, "usgs_imagery_only", "nrl_naip_conus");
+  }
+  rationale.push("NAIP is the high-detail U.S. imagery default; Sentinel-2 remains the global free imagery fallback and Cesium imagery stays as the token-backed preview stream.");
 
   const needsRouting = textHasAny(promptText, [
     "route",
@@ -1947,6 +2084,7 @@ function buildClientSourceRecommendation(missionText, mapContext, plannerErrorMe
     "exposed",
     "viewshed",
   ]);
+  const needsDted = textHasAny(promptText, ["dted", "dt2", "earth explorer", "earthexplorer"]);
   const needsWater = textHasAny(promptText, ["water", "stream", "river", "spring", "lake", "potable", "hydrate"]);
   const needsLandcover = needsRouting || textHasAny(promptText, [
     "cover",
@@ -1995,16 +2133,36 @@ function buildClientSourceRecommendation(missionText, mapContext, plannerErrorMe
     "changed",
     "cloud",
   ]);
+  const needsCesiumArchive = promptText.includes("cesium") && textHasAny(promptText, [
+    "download",
+    "offline",
+    "archive",
+    "export",
+    "jetson",
+    "local",
+  ]);
 
+  if (needsCesiumArchive) {
+    appendUniqueSourceIds(requiredIds, "cesium_ion_archive");
+    rationale.push("Cesium offline use is handled through ion archive/export downloads to the Jetson, not by scraping World stream tiles.");
+  }
   if (needsRouting) {
     appendUniqueSourceIds(requiredIds, "osm_extract");
     rationale.push("OSM PBF is required for the local routable graph and feature lookup.");
   }
   if (needsTerrain) {
-    appendUniqueSourceIds(requiredIds, isUsContext ? "usgs_3dep" : "copernicus_dem");
-    appendUniqueSourceIds(requiredIds, "esri_world_elevation");
+    appendUniqueSourceIds(requiredIds, "copernicus_dem");
+    if (isUsContext) {
+      appendUniqueSourceIds(optionalIds, "dted_earth_explorer", "usgs_3dep");
+    } else {
+      appendUniqueSourceIds(optionalIds, "dted_earth_explorer");
+    }
     appendUniqueSourceIds(optionalIds, "cesium_world_terrain");
-    rationale.push("Analysis DEM plus queryable Esri terrain fallback is required for slope, exposure, hydrology, and cost surfaces.");
+    rationale.push("Copernicus GLO-30 COGs are the no-account terrain default; staged EarthExplorer DTED supplements it when available.");
+  }
+  if (needsDted) {
+    appendUniqueSourceIds(requiredIds, "dted_earth_explorer");
+    rationale.push("DTED was explicitly requested, so staged EarthExplorer DTED import is included; set DTED_SOURCE_DIR on the Jetson before executing the package.");
   }
   if (needsLandcover) {
     appendUniqueSourceIds(requiredIds, isUsContext ? "nlcd" : "esa_worldcover");
@@ -2015,7 +2173,6 @@ function buildClientSourceRecommendation(missionText, mapContext, plannerErrorMe
     if (isUsContext) {
       appendUniqueSourceIds(optionalIds, "nwis");
     }
-    appendUniqueSourceIds(optionalIds, "sentinel_2");
     rationale.push("Hydrography is required for water-source and drainage queries.");
   }
   if (needsSar) {
@@ -2044,13 +2201,15 @@ function buildClientSourceRecommendation(missionText, mapContext, plannerErrorMe
     appendUniqueSourceIds(requiredIds, "viewshed_surfaces");
     appendUniqueSourceIds(optionalIds, isUsContext ? "fcc_towers" : "osm_towers", "osm_towers");
     if (!needsTerrain) {
-      appendUniqueSourceIds(requiredIds, isUsContext ? "usgs_3dep" : "copernicus_dem");
-      appendUniqueSourceIds(requiredIds, "esri_world_elevation");
+      appendUniqueSourceIds(requiredIds, "copernicus_dem");
+      if (isUsContext) {
+        appendUniqueSourceIds(optionalIds, "dted_earth_explorer", "usgs_3dep");
+      }
     }
     rationale.push("Signal planning requires DEM-derived viewsheds plus tower or high-ground candidates.");
   }
   if (needsCurrentImagery && !needsWater && !needsHazards) {
-    appendUniqueSourceIds(optionalIds, "sentinel_2");
+    appendUniqueSourceIds(optionalIds, "landsat_collection_2");
     if (isUsContext) {
       appendUniqueSourceIds(optionalIds, "naip");
     }
@@ -2089,7 +2248,7 @@ function buildClientSourceRecommendation(missionText, mapContext, plannerErrorMe
   }
 
   const selectedIds = [];
-  const previewIds = optionalIds.filter((sourceId) => ["esri_world_imagery", "osm_basemap"].includes(sourceId));
+  const previewIds = optionalIds.filter((sourceId) => ["cesium_world_imagery", "usgs_imagery_only", "osm_basemap"].includes(sourceId));
   appendUniqueSourceIds(selectedIds, ...requiredIds, ...previewIds);
   const missionSummary = missionText.length > 220 ? `${missionText.slice(0, 217)}...` : missionText;
 
@@ -2262,6 +2421,16 @@ function hidePackageOutput() {
   els.packageManifest.textContent = "";
   els.downloadManifestLink.classList.add("hidden");
   els.downloadManifestLink.removeAttribute("href");
+  els.packageExecutionActions.classList.add("hidden");
+  els.downloadToJetsonBtn.disabled = true;
+  els.packageExecutionStatus.classList.add("hidden");
+  els.packageExecutionStatus.textContent = "";
+  els.packageArtifacts.classList.add("hidden");
+  els.packageArtifacts.textContent = "";
+  if (state.packageStatusTimer) {
+    window.clearInterval(state.packageStatusTimer);
+    state.packageStatusTimer = null;
+  }
 }
 
 async function loadDataSources() {
@@ -2720,16 +2889,97 @@ async function buildSourcePackage() {
     });
     state.packagePlan = data;
     const warningText = data.warnings?.length ? ` Warnings: ${data.warnings.join(" ")}` : "";
-    els.packageStatus.textContent = `Manifest ${data.package_id} ready with ${data.sources.length} sources.${warningText}`;
+    renderJetsonStorage(data.storage, data.estimated_bytes, data.storage_fit, data.storage_warning);
+    const fitText = data.storage_fit ? " Jetson storage check passed." : ` ${data.storage_warning || "Jetson storage check failed."}`;
+    els.packageStatus.textContent = `Manifest ${data.package_id} ready with ${data.sources.length} sources.${fitText}${warningText}`;
     els.packageManifest.textContent = JSON.stringify(data.manifest, null, 2);
     els.packageManifest.classList.remove("hidden");
     els.downloadManifestLink.href = data.download_url;
     els.downloadManifestLink.download = `${data.package_name}.json`;
     els.downloadManifestLink.classList.remove("hidden");
+    els.packageExecutionActions.classList.remove("hidden");
+    els.downloadToJetsonBtn.disabled = !data.storage_fit;
+    els.refreshPackageStatusBtn.disabled = false;
   } catch (error) {
     els.packageStatus.textContent = error instanceof Error ? error.message : String(error);
   } finally {
     updateSourceCount();
+  }
+}
+
+function renderPackageExecutionStatus(status) {
+  const rows = [];
+  rows.push(["State", status.state || "unknown"]);
+  rows.push(["Bytes", formatBytes(status.bytes_written || 0)]);
+  rows.push(["Message", status.message || ""]);
+  for (const operation of status.operations || []) {
+    const label = operation.source_name || operation.id || "source";
+    const value = `${operation.state || "planned"} ${operation.bytes_written ? `(${formatBytes(operation.bytes_written)})` : ""}`;
+    rows.push([label, value]);
+  }
+  els.packageExecutionStatus.innerHTML = "";
+  for (const [label, value] of rows) {
+    const left = document.createElement("span");
+    left.textContent = label;
+    const right = document.createElement("strong");
+    right.textContent = value;
+    els.packageExecutionStatus.append(left, right);
+  }
+  els.packageExecutionStatus.classList.remove("hidden");
+  if (status.storage) {
+    renderJetsonStorage(status.storage, state.packagePlan?.estimated_bytes, state.packagePlan?.storage_fit, state.packagePlan?.storage_warning);
+  }
+}
+
+async function refreshPackageArtifacts() {
+  if (!state.packagePlan?.artifacts_url) {
+    return null;
+  }
+  const artifacts = await fetchJson(state.packagePlan.artifacts_url);
+  els.packageArtifacts.textContent = JSON.stringify(artifacts, null, 2);
+  els.packageArtifacts.classList.remove("hidden");
+  return artifacts;
+}
+
+async function refreshPackageStatus() {
+  if (!state.packagePlan?.status_url) {
+    return null;
+  }
+  const status = await fetchJson(state.packagePlan.status_url);
+  renderPackageExecutionStatus(status);
+  if (status.state === "succeeded" || status.state === "failed") {
+    if (state.packageStatusTimer) {
+      window.clearInterval(state.packageStatusTimer);
+      state.packageStatusTimer = null;
+    }
+    els.downloadToJetsonBtn.disabled = status.state === "succeeded";
+    await refreshPackageArtifacts().catch(() => null);
+  }
+  return status;
+}
+
+async function downloadPackageToJetson() {
+  if (!state.packagePlan?.execute_url) {
+    els.packageStatus.textContent = "Build the manifest before starting a Jetson download.";
+    return;
+  }
+  els.downloadToJetsonBtn.disabled = true;
+  els.packageStatus.textContent = "Starting Jetson download job...";
+  try {
+    const response = await fetchJson(state.packagePlan.execute_url, { method: "POST" });
+    renderPackageExecutionStatus(response);
+    els.packageStatus.textContent = response.message || "Jetson download job started.";
+    await refreshPackageStatus();
+    if (!state.packageStatusTimer) {
+      state.packageStatusTimer = window.setInterval(() => {
+        refreshPackageStatus().catch((error) => {
+          els.packageStatus.textContent = getErrorMessage(error);
+        });
+      }, 2000);
+    }
+  } catch (error) {
+    els.downloadToJetsonBtn.disabled = false;
+    els.packageStatus.textContent = getErrorMessage(error);
   }
 }
 
@@ -2890,7 +3140,7 @@ async function submitPrompt(event) {
     let result = null;
 
     if (provider === "claude") {
-      if (state.claudeApiKey) {
+      if (hasClaudeProviderCredential()) {
         try {
           result = await streamAssistantProvider({
             assistantMessage,
@@ -2905,7 +3155,7 @@ async function submitPrompt(event) {
         } catch (error) {
           claudeError = getErrorMessage(error);
           console.warn("Claude request failed; trying local Ollama fallback.", claudeError);
-          els.providerStatus.textContent = "Claude request failed. Check key, model access, or network.";
+          els.providerStatus.textContent = "Claude request failed; trying detected local Ollama.";
           els.requestStatus.textContent = "Trying local model fallback...";
         }
       } else {
@@ -3017,13 +3267,22 @@ async function resolveImageryProvider() {
     };
   }
 
-  if (!hasCesiumIonToken()) {
-    state.imageryMode = "esri";
-    els.imagerySelect.value = "esri";
+  if (state.imageryMode === "usgs-imagery") {
     return {
-      provider: makeUrlTemplateImageryProvider(IMAGERY_FALLBACKS.esri),
-      label: IMAGERY_FALLBACKS.esri.label,
-      shortLabel: "Esri imagery",
+      provider: makeUrlTemplateImageryProvider(IMAGERY_FALLBACKS["usgs-imagery"]),
+      label: IMAGERY_FALLBACKS["usgs-imagery"].label,
+      shortLabel: "USGS imagery",
+      usingIon: false,
+    };
+  }
+
+  if (!hasCesiumIonToken()) {
+    state.imageryMode = "usgs-imagery";
+    els.imagerySelect.value = "usgs-imagery";
+    return {
+      provider: makeUrlTemplateImageryProvider(IMAGERY_FALLBACKS["usgs-imagery"]),
+      label: IMAGERY_FALLBACKS["usgs-imagery"].label,
+      shortLabel: "USGS imagery",
       usingIon: false,
       fallbackReason: "Cesium ion token is not configured for World Imagery.",
     };
@@ -3039,13 +3298,13 @@ async function resolveImageryProvider() {
       usingIon: true,
     };
   } catch (error) {
-    console.warn("Cesium imagery failed; using Esri fallback.", error);
-    state.imageryMode = "esri";
-    els.imagerySelect.value = "esri";
+    console.warn("Cesium imagery failed; using USGS imagery fallback.", error);
+    state.imageryMode = "usgs-imagery";
+    els.imagerySelect.value = "usgs-imagery";
     return {
-      provider: makeUrlTemplateImageryProvider(IMAGERY_FALLBACKS.esri),
-      label: IMAGERY_FALLBACKS.esri.label,
-      shortLabel: "Esri imagery",
+      provider: makeUrlTemplateImageryProvider(IMAGERY_FALLBACKS["usgs-imagery"]),
+      label: IMAGERY_FALLBACKS["usgs-imagery"].label,
+      shortLabel: "USGS imagery",
       usingIon: false,
       fallbackReason: "Cesium World Imagery request failed.",
     };
@@ -3966,10 +4225,12 @@ function onPromptInputKeyDown(event) {
 }
 
 async function streamSelectedSources() {
-  if (state.selectedSourceIds.has("esri_world_imagery")) {
-    state.imageryMode = "esri";
-  } else if (state.selectedSourceIds.has("cesium_world_imagery") && hasCesiumIonToken()) {
+  if (state.selectedSourceIds.has("cesium_world_imagery") && hasCesiumIonToken()) {
     state.imageryMode = "ion-satellite";
+  } else if (state.selectedSourceIds.has("usgs_imagery_only")) {
+    state.imageryMode = "usgs-imagery";
+  } else if (state.selectedSourceIds.has("esri_world_imagery")) {
+    state.imageryMode = "esri";
   } else if (state.selectedSourceIds.has("osm_basemap")) {
     state.imageryMode = "osm";
   }
@@ -4048,6 +4309,12 @@ async function init() {
     els.clearAreaBtn.addEventListener("click", clearSelectedArea);
     els.streamSelectedBtn.addEventListener("click", streamSelectedSources);
     els.buildPackageBtn.addEventListener("click", buildSourcePackage);
+    els.downloadToJetsonBtn.addEventListener("click", downloadPackageToJetson);
+    els.refreshPackageStatusBtn.addEventListener("click", () => {
+      refreshPackageStatus().catch((error) => {
+        els.packageStatus.textContent = getErrorMessage(error);
+      });
+    });
     els.imagerySelect.addEventListener("change", async (event) => {
       state.imageryMode = event.target.value;
       await buildViewer();
@@ -4073,6 +4340,7 @@ async function init() {
   await loadRuntimeConfig();
   await loadModels();
   await loadDataSources();
+  await loadJetsonStorage();
   await buildViewer();
 }
 

--- a/llm_dev_kmh/static/app.js
+++ b/llm_dev_kmh/static/app.js
@@ -1509,6 +1509,20 @@ function renderClarifyingQuestions() {
   }
 }
 
+function ensureClarifyingQuestions(recommendation) {
+  if (!recommendation) {
+    return [];
+  }
+  if (Array.isArray(recommendation.clarifying_questions) && recommendation.clarifying_questions.length) {
+    return recommendation.clarifying_questions;
+  }
+
+  const focus = recommendation.mission_focus || "mission-data-package";
+  return [
+    `Confirm the ${focus} scope in one pass: mission outcome, movement mode, time window, and any must-avoid constraints. This decides whether to add current imagery, hazards, access, or communications layers.`,
+  ];
+}
+
 function setWorkflowStage(index) {
   state.workflowStageIndex = clampNumber(index, 0, WORKFLOW_STAGES.length - 1);
   updateWorkflowPanel();
@@ -1879,11 +1893,12 @@ function buildClientSourceRecommendation(missionText, mapContext, plannerErrorMe
 
 function applySourceRecommendation(data, missionText, mode = "server", statusMessage = "") {
   mergeSourcesIntoCatalog(data.sources);
+  data.clarifying_questions = ensureClarifyingQuestions(data);
   state.sourceInference = data;
   state.lastMissionText = missionText;
   state.selectedSourceIds = new Set(data.selected_source_ids || []);
   state.sourceConfirmed = false;
-  state.workflowStageIndex = data.clarifying_questions?.length ? 1 : 2;
+  state.workflowStageIndex = 1;
   state.packagePlan = null;
   state.sourcePlannerFallback = mode === "fallback";
   state.sourcePlannerMessage = statusMessage;
@@ -1901,13 +1916,10 @@ function applySourceRecommendation(data, missionText, mode = "server", statusMes
   );
   renderSourceList();
 
-  const questionText = data.clarifying_questions?.length
-    ? ` Next questions: ${data.clarifying_questions.join(" ")}`
-    : "";
   const fallbackText = mode === "fallback"
     ? ` Browser fallback used because the planner API is unavailable (${statusMessage}).`
     : "";
-  els.packageStatus.textContent = `Drafted ${state.selectedSourceIds.size} working sources.${fallbackText} Answer the dialogue questions to broaden or narrow the package.${questionText}`;
+  els.packageStatus.textContent = `Drafted ${state.selectedSourceIds.size} working sources.${fallbackText} Use Questions to scope, then confirm sources.`;
   updateWorkflowPanel();
 }
 
@@ -1995,8 +2007,9 @@ function renderSourceList() {
 
   for (const source of visibleSources) {
     const article = document.createElement("article");
-    article.className = "source-item";
+    article.className = "source-item compact-source-item";
     article.dataset.selected = String(state.selectedSourceIds.has(source.id));
+    article.title = `${source.category} | ${formatSourceStatus(source)}`;
 
     const header = document.createElement("label");
     header.className = "source-item-header";
@@ -2021,27 +2034,8 @@ function renderSourceList() {
     title.className = "source-title";
     title.textContent = source.name;
 
-    const category = document.createElement("span");
-    category.className = "source-category";
-    category.textContent = source.category;
-
-    header.append(checkbox, title, category);
-
-    const purpose = document.createElement("p");
-    purpose.className = "source-purpose";
-    purpose.textContent = source.purpose;
-
-    const meta = document.createElement("div");
-    meta.className = "source-meta";
-
-    const provider = document.createElement("span");
-    provider.textContent = source.provider;
-
-    const status = document.createElement("span");
-    status.textContent = formatSourceStatus(source);
-
-    meta.append(provider, status);
-    article.append(header, purpose, meta);
+    header.append(checkbox, title);
+    article.append(header);
     els.sourceList.appendChild(article);
   }
 

--- a/llm_dev_kmh/static/app.js
+++ b/llm_dev_kmh/static/app.js
@@ -21,6 +21,23 @@ const state = {
   handlersBound: false,
   dataSources: [],
   primarySourceIds: [],
+  sourceCatalogFallback: false,
+  sourceCatalogMessage: "",
+  sourcePlannerFallback: false,
+  sourcePlannerMessage: "",
+  overlayDataSource: null,
+  overlayFileName: "",
+  locationSearchMatches: [],
+  activeLocationSearchIndex: -1,
+  mapFocusLabel: "",
+  mapFocusSource: "",
+  mapLocationConfirmed: false,
+  locationSearchTimer: null,
+  locationSearchRequestId: 0,
+  localModelAvailable: false,
+  localModelDetail: "",
+  llmProvider: sessionStorage.getItem("teraLlmProvider") || "ollama",
+  claudeApiKey: sessionStorage.getItem("teraClaudeApiKey") || "",
   selectedSourceIds: new Set(),
   packagePlan: null,
   sourceInference: null,
@@ -31,13 +48,26 @@ const state = {
 
 const els = {
   tokenChip: document.getElementById("tokenChip"),
-  ollamaChip: document.getElementById("ollamaChip"),
   settingsToggleBtn: document.getElementById("settingsToggleBtn"),
   settingsMenu: document.getElementById("settingsMenu"),
+  modelProviderBtn: document.getElementById("modelProviderBtn"),
+  modelProviderMenu: document.getElementById("modelProviderMenu"),
+  providerStatus: document.getElementById("providerStatus"),
+  providerSelect: document.getElementById("providerSelect"),
+  topModelSelect: document.getElementById("topModelSelect"),
+  claudeModelSelect: document.getElementById("claudeModelSelect"),
+  claudeApiKeyInput: document.getElementById("claudeApiKeyInput"),
+  providerLocalModelRow: document.getElementById("providerLocalModelRow"),
+  providerClaudeModelRow: document.getElementById("providerClaudeModelRow"),
+  providerClaudeKeyRow: document.getElementById("providerClaudeKeyRow"),
+  saveProviderBtn: document.getElementById("saveProviderBtn"),
+  clearClaudeKeyBtn: document.getElementById("clearClaudeKeyBtn"),
   agentProfileSelect: document.getElementById("agentProfileSelect"),
   imagerySelect: document.getElementById("imagerySelect"),
   terrainSelect: document.getElementById("terrainSelect"),
   resetViewBtn: document.getElementById("resetViewBtn"),
+  importOverlayBtn: document.getElementById("importOverlayBtn"),
+  overlayFileInput: document.getElementById("overlayFileInput"),
   panelToggleBtn: document.getElementById("panelToggleBtn"),
   panelResizer: document.getElementById("panelResizer"),
   workspaceShell: document.querySelector(".workspace-shell"),
@@ -45,6 +75,12 @@ const els = {
   sourcePanel: document.getElementById("sourcePanel"),
   mapStage: document.querySelector(".map-stage"),
   mapResetViewBtn: document.getElementById("mapResetViewBtn"),
+  locationSearchPanel: document.getElementById("locationSearchPanel"),
+  locationSearchForm: document.getElementById("locationSearchForm"),
+  locationSearchInput: document.getElementById("locationSearchInput"),
+  locationSearchSuggestions: document.getElementById("locationSearchSuggestions"),
+  centerGridValue: document.getElementById("centerGridValue"),
+  centerGridLatLon: document.getElementById("centerGridLatLon"),
   compassRose: document.getElementById("compassRose"),
   compassHeading: document.getElementById("compassHeading"),
   tiltNeedle: document.getElementById("tiltNeedle"),
@@ -130,9 +166,426 @@ const IMAGERY_FALLBACKS = {
   },
 };
 
+const FALLBACK_PRIMARY_STREAM_SOURCE_IDS = [
+  "esri_world_imagery",
+  "cesium_world_terrain",
+  "osm_basemap",
+];
+
+const LOCATION_GAZETTEER = [
+  {
+    name: "San Francisco, CA",
+    detail: "City center and Bay Area mission staging reference",
+    lat: 37.7749,
+    lon: -122.4194,
+    heightM: 14000,
+    aliases: ["sf", "san fran", "bay area"],
+  },
+  {
+    name: "Presidio of San Francisco, CA",
+    detail: "Urban-coastal terrain, trails, batteries, and shoreline access",
+    lat: 37.7989,
+    lon: -122.4662,
+    heightM: 4500,
+    aliases: ["presidio", "crissy field"],
+  },
+  {
+    name: "Golden Gate Bridge, CA",
+    detail: "Bridge, shoreline, ridge, and urban approach terrain",
+    lat: 37.8199,
+    lon: -122.4783,
+    heightM: 4500,
+    aliases: ["golden gate", "ggb"],
+  },
+  {
+    name: "Treasure Island, CA",
+    detail: "Bay island, bridge access, and maritime-adjacent infrastructure",
+    lat: 37.8230,
+    lon: -122.3708,
+    heightM: 5000,
+    aliases: ["yerba buena island", "treasure island sf"],
+  },
+  {
+    name: "Oakland, CA",
+    detail: "Urban port, hills, freeway, rail, and shoreline terrain",
+    lat: 37.8044,
+    lon: -122.2712,
+    heightM: 12000,
+    aliases: ["oakland hills", "port of oakland"],
+  },
+  {
+    name: "Mount Tamalpais, CA",
+    detail: "Coastal mountain terrain, ridges, trails, and signal high ground",
+    lat: 37.9235,
+    lon: -122.5965,
+    heightM: 9000,
+    aliases: ["mt tam", "mount tam"],
+  },
+  {
+    name: "Yosemite Valley, CA",
+    detail: "Steep granitic valley, trails, water, cliffs, and SAR terrain",
+    lat: 37.7456,
+    lon: -119.5936,
+    heightM: 9000,
+    aliases: ["yosemite", "yosemite national park"],
+  },
+  {
+    name: "Lake Tahoe, CA/NV",
+    detail: "Mountain lake, ridges, winter hazards, trails, and evacuation routes",
+    lat: 39.0968,
+    lon: -120.0324,
+    heightM: 18000,
+    aliases: ["tahoe", "south lake tahoe"],
+  },
+  {
+    name: "Joshua Tree National Park, CA",
+    detail: "Desert terrain, trails, dry washes, roads, climbing areas, and water scarcity",
+    lat: 33.8734,
+    lon: -115.9010,
+    heightM: 18000,
+    aliases: ["joshua tree", "joshua tree np", "jtnp", "joshu tree", "joshua"],
+  },
+  {
+    name: "Fort Hunter Liggett, CA",
+    detail: "Training area with rural roads, ridges, valleys, and access control",
+    lat: 35.9730,
+    lon: -121.2400,
+    heightM: 18000,
+    aliases: ["hunter liggett", "fhl"],
+  },
+  {
+    name: "Fort Irwin / National Training Center, CA",
+    detail: "Desert maneuver terrain, dry washes, roads, and range constraints",
+    lat: 35.2627,
+    lon: -116.6848,
+    heightM: 26000,
+    aliases: ["fort irwin", "ntc", "national training center"],
+  },
+  {
+    name: "Camp Pendleton, CA",
+    detail: "Coastal military terrain, roads, hills, and beach approaches",
+    lat: 33.3178,
+    lon: -117.3205,
+    heightM: 17000,
+    aliases: ["pendleton", "mcb camp pendleton"],
+  },
+  {
+    name: "Yakima Training Center, WA",
+    detail: "High-desert training terrain, ranges, roads, and ridgelines",
+    lat: 46.6847,
+    lon: -120.4531,
+    heightM: 25000,
+    aliases: ["yakima", "ytc"],
+  },
+  {
+    name: "White Sands Missile Range, NM",
+    detail: "Desert range terrain, restricted areas, roads, and dry lakebeds",
+    lat: 32.3825,
+    lon: -106.4795,
+    heightM: 26000,
+    aliases: ["white sands", "wsmr"],
+  },
+  {
+    name: "Fort Liberty, NC",
+    detail: "Installation and pine forest movement terrain",
+    lat: 35.1415,
+    lon: -79.0060,
+    heightM: 16000,
+    aliases: ["fort bragg", "liberty"],
+  },
+  {
+    name: "Fort Moore, GA",
+    detail: "Installation terrain, river corridors, roads, and training areas",
+    lat: 32.3668,
+    lon: -84.9693,
+    heightM: 16000,
+    aliases: ["fort benning", "moore"],
+  },
+  {
+    name: "Fort Carson, CO",
+    detail: "Front Range installation, foothills, roads, and mountain approaches",
+    lat: 38.7375,
+    lon: -104.7889,
+    heightM: 18000,
+    aliases: ["carson", "colorado springs"],
+  },
+  {
+    name: "Joint Base Lewis-McChord, WA",
+    detail: "Installation, forest, prairie, airfield, and road access context",
+    lat: 47.1079,
+    lon: -122.5769,
+    heightM: 16000,
+    aliases: ["jblm", "fort lewis", "mcchord"],
+  },
+  {
+    name: "Washington, DC",
+    detail: "Capital region urban infrastructure, waterways, and access constraints",
+    lat: 38.9072,
+    lon: -77.0369,
+    heightM: 12000,
+    aliases: ["dc", "district of columbia"],
+  },
+  {
+    name: "Honolulu, HI",
+    detail: "Island urban, volcanic ridges, coastline, and evacuation context",
+    lat: 21.3099,
+    lon: -157.8581,
+    heightM: 13000,
+    aliases: ["oahu", "pearl harbor"],
+  },
+  {
+    name: "Anchorage, AK",
+    detail: "Arctic/subarctic urban, mountain, river, and coastal terrain",
+    lat: 61.2181,
+    lon: -149.9003,
+    heightM: 22000,
+    aliases: ["alaska", "anchorage bowl"],
+  },
+];
+
+const LOCATION_SEARCH_LIMIT = 6;
+const UTM_LATITUDE_BANDS = "CDEFGHJKLMNPQRSTUVWXX";
+const KEYWORD_EXPANSIONS = {
+  route: ["routing", "navigate", "navigation", "path", "corridor", "approach"],
+  patrol: ["movement", "move", "walk", "team", "operator"],
+  water: ["hydration", "hydrate", "stream", "river", "spring", "creek", "wash", "well", "source", "watter"],
+  terrain: ["terain", "topography", "elevation", "ground", "landform"],
+  slope: ["steep", "grade", "incline", "cliff", "exposed", "exposure"],
+  cover: ["concealment", "conceal", "canopy", "shade", "vegetation", "brush"],
+  hazard: ["hazzard", "risk", "danger", "closure", "blocked", "unsafe"],
+  signal: ["comms", "communications", "radio", "relay", "antenna", "line of sight", "los"],
+  imagery: ["image", "satellite", "satelite", "aerial", "visual", "photo"],
+  sar: ["search", "rescue", "missing", "lost", "hasty"],
+  access: ["private", "restricted", "boundary", "parcel", "permission", "legal"],
+};
+
+const FALLBACK_SOURCE_CATALOG = [
+  {
+    id: "esri_world_imagery",
+    name: "Esri World Imagery",
+    provider: "Esri ArcGIS Online",
+    category: "imagery",
+    purpose: "Streamable visual basemap for AO inspection and imagery context.",
+    stream_status: "streamable",
+    download_status: "manifest-only",
+    stream_layer: "esri",
+  },
+  {
+    id: "cesium_world_terrain",
+    name: "Cesium World Terrain",
+    provider: "Cesium ion",
+    category: "terrain-display",
+    purpose: "Streamable 3D terrain preview for landform awareness.",
+    stream_status: "streamable-with-token",
+    download_status: "cache-via-cesium-pipeline",
+    stream_layer: "cesium-world",
+  },
+  {
+    id: "esri_world_elevation",
+    name: "Esri World Elevation Terrain",
+    provider: "Esri ArcGIS Online / Living Atlas",
+    category: "terrain",
+    purpose: "Queryable elevation terrain fallback for AO sampling, slope, hillshade, and viewshed preflight.",
+    stream_status: "queryable-online",
+    download_status: "download-required",
+  },
+  {
+    id: "osm_basemap",
+    name: "OpenStreetMap Basemap",
+    provider: "OpenStreetMap contributors",
+    category: "basemap",
+    purpose: "Streamable orientation map for roads, trails, and place names.",
+    stream_status: "streamable",
+    download_status: "manifest-only",
+    stream_layer: "osm",
+  },
+  {
+    id: "osm_extract",
+    name: "OpenStreetMap PBF Extract",
+    provider: "OpenStreetMap / regional extract",
+    category: "vector",
+    purpose: "Local server extract for roads, trails, waterways, buildings, POIs, and barriers.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "usgs_3dep",
+    name: "USGS 3DEP DEM",
+    provider: "USGS",
+    category: "terrain",
+    purpose: "U.S. elevation dataset for slope, hydrology, viewshed, and cost surfaces.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "copernicus_dem",
+    name: "Copernicus DEM",
+    provider: "Copernicus",
+    category: "terrain",
+    purpose: "Global elevation fallback for slope, viewshed, and terrain-cost analysis.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "nlcd",
+    name: "USGS Annual NLCD",
+    provider: "USGS",
+    category: "land-cover",
+    purpose: "U.S. land-cover baseline for surface friction, wetlands, and vegetation context.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "esa_worldcover",
+    name: "ESA WorldCover",
+    provider: "ESA",
+    category: "land-cover",
+    purpose: "Global land-cover baseline for off-road friction and vegetation screening.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "usgs_3dhp",
+    name: "USGS 3D Hydrography Program / NHD",
+    provider: "USGS",
+    category: "hydrography",
+    purpose: "U.S. hydrography for streams, rivers, water bodies, and crossing context.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "hydrosheds",
+    name: "HydroSHEDS / HydroRIVERS / HydroLAKES",
+    provider: "HydroSHEDS",
+    category: "hydrography",
+    purpose: "Global hydrography baseline for water-source and drainage queries.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "nwis",
+    name: "USGS NWIS",
+    provider: "USGS",
+    category: "water-observation",
+    purpose: "Cached observations for stream gauge and water-availability confidence.",
+    stream_status: "not-streamed",
+    download_status: "cache-feed",
+  },
+  {
+    id: "sentinel_2",
+    name: "Sentinel-2 Multispectral",
+    provider: "ESA Copernicus",
+    category: "imagery-analysis",
+    purpose: "Analysis imagery for vegetation, water, burn, and surface-condition indices.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "naip",
+    name: "NAIP Aerial Imagery",
+    provider: "USDA",
+    category: "imagery-analysis",
+    purpose: "High-resolution U.S. aerial imagery for detailed AO review and feature extraction.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "sentinel_1_sar",
+    name: "Sentinel-1 SAR",
+    provider: "ESA Copernicus",
+    category: "imagery-analysis",
+    purpose: "Radar imagery for cloud/night/flood surface observation.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "nasa_firms",
+    name: "NASA FIRMS",
+    provider: "NASA",
+    category: "hazards",
+    purpose: "Active fire and hotspot feed for wildfire route risk.",
+    stream_status: "not-streamed",
+    download_status: "cache-feed",
+  },
+  {
+    id: "noaa_alerts",
+    name: "NOAA / NWS Alerts",
+    provider: "NOAA",
+    category: "hazards",
+    purpose: "Weather watches, warnings, and advisories for package-time hazards.",
+    stream_status: "not-streamed",
+    download_status: "cache-feed",
+  },
+  {
+    id: "fema_flood",
+    name: "FEMA Flood Products",
+    provider: "FEMA",
+    category: "hazards",
+    purpose: "U.S. floodplain and flood hazard context for route risk.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "pad_us",
+    name: "PAD-US Protected Areas",
+    provider: "USGS",
+    category: "boundaries-access",
+    purpose: "U.S. protected-area and management boundaries for access constraints.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "parcels_boundaries",
+    name: "Parcels / Local Boundaries",
+    provider: "County or local GIS",
+    category: "boundaries-access",
+    purpose: "Ownership and parcel boundaries for restricted or private-land movement.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "viewshed_surfaces",
+    name: "DEM-Derived Viewshed Surfaces",
+    provider: "Derived from package DEM",
+    category: "derived",
+    purpose: "Line-of-sight products for communications, signaling, and observation planning.",
+    stream_status: "derived",
+    download_status: "derived-after-ingest",
+  },
+  {
+    id: "fcc_towers",
+    name: "FCC Antenna / Tower Data",
+    provider: "FCC",
+    category: "communications",
+    purpose: "Tower locations for communications planning context.",
+    stream_status: "not-streamed",
+    download_status: "download-required",
+  },
+  {
+    id: "osm_towers",
+    name: "OSM Towers, Peaks, Lookouts",
+    provider: "OpenStreetMap",
+    category: "communications",
+    purpose: "Mapped towers, peaks, masts, lookouts, and high-ground candidates.",
+    stream_status: "not-streamed",
+    download_status: "derived-from-osm",
+  },
+];
+
+const CHAT_AUTOSCROLL_THRESHOLD_PX = 80;
+
 function setChip(node, text, tone = "") {
   node.textContent = text;
   node.className = `chip${tone ? ` ${tone}` : ""}`;
+}
+
+function setModelProviderButton(text, tone = "") {
+  els.modelProviderBtn.textContent = text;
+  els.modelProviderBtn.className = `chip chip-button${tone ? ` ${tone}` : ""}`;
+}
+
+function getErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
 }
 
 async function fetchJson(url, options) {
@@ -144,7 +597,517 @@ async function fetchJson(url, options) {
   return data;
 }
 
+function normalizeSearchText(value) {
+  return value.trim().toLowerCase().replace(/[^a-z0-9.+-]+/g, " ").replace(/\s+/g, " ");
+}
+
+function getMatchTokens(value) {
+  return normalizeSearchText(value).split(" ").filter(Boolean);
+}
+
+function editDistance(a, b) {
+  const left = a || "";
+  const right = b || "";
+  if (!left.length) {
+    return right.length;
+  }
+  if (!right.length) {
+    return left.length;
+  }
+
+  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  const current = Array.from({ length: right.length + 1 }, () => 0);
+  for (let i = 1; i <= left.length; i += 1) {
+    current[0] = i;
+    for (let j = 1; j <= right.length; j += 1) {
+      const cost = left[i - 1] === right[j - 1] ? 0 : 1;
+      current[j] = Math.min(
+        current[j - 1] + 1,
+        previous[j] + 1,
+        previous[j - 1] + cost,
+      );
+    }
+    for (let j = 0; j <= right.length; j += 1) {
+      previous[j] = current[j];
+    }
+  }
+  return previous[right.length];
+}
+
+function tokenLooksLike(token, target) {
+  if (token === target) {
+    return true;
+  }
+  if (token.length < 4 || target.length < 4) {
+    return false;
+  }
+  if (token.startsWith(target) || target.startsWith(token)) {
+    return true;
+  }
+  const distance = editDistance(token, target);
+  return distance <= Math.max(1, Math.floor(Math.max(token.length, target.length) * 0.28));
+}
+
+function parseCoordinateQuery(query) {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const numbers = trimmed.match(/[+-]?\d+(?:\.\d+)?/g);
+  if (!numbers || numbers.length < 2) {
+    return null;
+  }
+
+  let lat = Number(numbers[0]);
+  let lon = Number(numbers[1]);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return null;
+  }
+
+  if (Math.abs(lat) > 90 && Math.abs(lon) <= 90) {
+    [lat, lon] = [lon, lat];
+  }
+
+  const upper = trimmed.toUpperCase();
+  if (/\d(?:\.\d+)?\s*S\b/.test(upper)) {
+    lat = -Math.abs(lat);
+  } else if (/\d(?:\.\d+)?\s*N\b/.test(upper)) {
+    lat = Math.abs(lat);
+  }
+  if (/\d(?:\.\d+)?\s*W\b/.test(upper) || upper.includes(" W")) {
+    lon = -Math.abs(lon);
+  } else if (/\d(?:\.\d+)?\s*E\b/.test(upper) || upper.includes(" E")) {
+    lon = Math.abs(lon);
+  }
+
+  if (Math.abs(lat) > 90 || Math.abs(lon) > 180) {
+    return null;
+  }
+
+  return {
+    name: `Coordinates ${lat.toFixed(5)}, ${lon.toFixed(5)}`,
+    detail: "Parsed decimal latitude/longitude",
+    lat,
+    lon,
+    heightM: 12000,
+    source: "coordinate-query",
+  };
+}
+
+function scoreLocationCandidate(candidate, query) {
+  const normalizedQuery = normalizeSearchText(query);
+  if (!normalizedQuery) {
+    return 0;
+  }
+
+  const name = normalizeSearchText(candidate.name);
+  const detail = normalizeSearchText(candidate.detail || "");
+  const aliases = (candidate.aliases || []).map((alias) => normalizeSearchText(alias));
+  let score = 0;
+
+  if (name === normalizedQuery) {
+    score += 120;
+  } else if (name.startsWith(normalizedQuery)) {
+    score += 95;
+  } else if (name.includes(normalizedQuery)) {
+    score += 70;
+  }
+
+  for (const alias of aliases) {
+    if (alias === normalizedQuery) {
+      score += 110;
+    } else if (alias.startsWith(normalizedQuery)) {
+      score += 85;
+    } else if (alias.includes(normalizedQuery)) {
+      score += 60;
+    }
+  }
+
+  const haystackTokens = getMatchTokens(`${candidate.name} ${candidate.detail || ""} ${(candidate.aliases || []).join(" ")}`);
+  const terms = normalizedQuery.split(" ").filter(Boolean);
+  for (const term of terms) {
+    if (name.includes(term)) {
+      score += 15;
+    }
+    if (detail.includes(term)) {
+      score += 8;
+    }
+    if (aliases.some((alias) => alias.includes(term))) {
+      score += 12;
+    }
+    if (haystackTokens.some((token) => tokenLooksLike(token, term))) {
+      score += 18;
+    }
+  }
+
+  return score;
+}
+
+function getLocationSearchSuggestions(query) {
+  const coordinate = parseCoordinateQuery(query);
+  const scored = LOCATION_GAZETTEER
+    .map((candidate) => ({
+      ...candidate,
+      source: "gazetteer",
+      score: scoreLocationCandidate(candidate, query),
+    }))
+    .filter((candidate) => candidate.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, LOCATION_SEARCH_LIMIT);
+
+  if (coordinate) {
+    return [coordinate, ...scored].slice(0, LOCATION_SEARCH_LIMIT);
+  }
+  return scored;
+}
+
+function normalizeServerLocationSuggestion(suggestion) {
+  return {
+    name: suggestion.name,
+    detail: suggestion.detail || `${Number(suggestion.lat).toFixed(5)}, ${Number(suggestion.lon).toFixed(5)}`,
+    lat: Number(suggestion.lat),
+    lon: Number(suggestion.lon),
+    heightM: Number(suggestion.height_m || suggestion.heightM || 12000),
+    source: suggestion.source || "online-geocoder",
+  };
+}
+
+function mergeLocationSuggestions(primaryMatches, incomingMatches) {
+  const merged = [];
+  const seen = new Set();
+  for (const match of [...primaryMatches, ...incomingMatches]) {
+    if (!Number.isFinite(match.lat) || !Number.isFinite(match.lon)) {
+      continue;
+    }
+    const key = `${Math.round(match.lat * 1000)}:${Math.round(match.lon * 1000)}:${match.name.toLowerCase()}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    merged.push(match);
+  }
+  return merged.slice(0, LOCATION_SEARCH_LIMIT);
+}
+
+async function refreshOnlineLocationSuggestions(query, requestId, localMatches) {
+  try {
+    const data = await fetchJson(`/api/location-search?q=${encodeURIComponent(query)}`);
+    if (requestId !== state.locationSearchRequestId) {
+      return;
+    }
+    const serverMatches = Array.isArray(data.suggestions)
+      ? data.suggestions.map(normalizeServerLocationSuggestion)
+      : [];
+    state.locationSearchMatches = mergeLocationSuggestions(localMatches, serverMatches);
+    renderLocationSearchSuggestions();
+  } catch (_error) {
+    if (requestId === state.locationSearchRequestId && !state.locationSearchMatches.length) {
+      setLocationSearchOpen(false);
+    }
+  }
+}
+
+function setLocationSearchOpen(open) {
+  els.locationSearchSuggestions.classList.toggle("hidden", !open);
+  if (!open) {
+    state.activeLocationSearchIndex = -1;
+  }
+}
+
+function setActiveLocationSuggestion(index) {
+  const maxIndex = state.locationSearchMatches.length - 1;
+  state.activeLocationSearchIndex = maxIndex < 0 ? -1 : clampNumber(index, 0, maxIndex);
+  const options = els.locationSearchSuggestions.querySelectorAll("[data-location-index]");
+  options.forEach((option) => {
+    const isActive = Number(option.dataset.locationIndex) === state.activeLocationSearchIndex;
+    option.classList.toggle("active", isActive);
+    option.setAttribute("aria-selected", String(isActive));
+  });
+}
+
+function renderLocationSearchSuggestions() {
+  els.locationSearchSuggestions.replaceChildren();
+  if (!state.locationSearchMatches.length) {
+    setLocationSearchOpen(false);
+    return;
+  }
+
+  state.locationSearchMatches.forEach((match, index) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "location-suggestion";
+    button.dataset.locationIndex = String(index);
+    button.setAttribute("role", "option");
+    button.setAttribute("aria-selected", "false");
+
+    const name = document.createElement("span");
+    name.className = "location-suggestion-name";
+    name.textContent = match.name;
+    const detail = document.createElement("span");
+    detail.className = "location-suggestion-detail";
+    detail.textContent = match.detail || `${match.lat.toFixed(5)}, ${match.lon.toFixed(5)}`;
+    button.append(name, detail);
+
+    button.addEventListener("pointerenter", () => setActiveLocationSuggestion(index));
+    button.addEventListener("click", () => {
+      state.activeLocationSearchIndex = index;
+      void commitLocationSearch();
+    });
+
+    els.locationSearchSuggestions.appendChild(button);
+  });
+
+  setLocationSearchOpen(true);
+  setActiveLocationSuggestion(0);
+}
+
+function markMapLocationFocused(label, source) {
+  state.mapFocusLabel = label || "";
+  state.mapFocusSource = source || "";
+  state.mapLocationConfirmed = Boolean(label);
+}
+
+function clearMapLocationFocus() {
+  markMapLocationFocused("", "");
+}
+
+function flyToLocationSuggestion(suggestion) {
+  if (!state.viewer) {
+    els.requestStatus.textContent = "Location search unavailable until the map is ready.";
+    return;
+  }
+
+  const heightM = suggestion.heightM || Math.max(state.config?.default_height_m || 12000, 9000);
+  markMapLocationFocused(suggestion.name, suggestion.source || "location-search");
+  state.viewer.camera.flyTo({
+    destination: Cesium.Cartesian3.fromDegrees(suggestion.lon, suggestion.lat, heightM),
+    duration: 1.1,
+    complete: updateCameraText,
+  });
+  els.locationSearchInput.value = suggestion.name;
+  els.requestStatus.textContent = `Map focused: ${suggestion.name}`;
+  setLocationSearchOpen(false);
+}
+
+async function commitLocationSearch() {
+  const query = els.locationSearchInput.value.trim();
+  let matches = state.locationSearchMatches.length
+    ? state.locationSearchMatches
+    : getLocationSearchSuggestions(query);
+  const index = state.activeLocationSearchIndex >= 0 ? state.activeLocationSearchIndex : 0;
+  let suggestion = matches[index] || matches[0];
+  if (!suggestion && query.length >= 2) {
+    try {
+      const data = await fetchJson(`/api/location-search?q=${encodeURIComponent(query)}`);
+      const serverMatches = Array.isArray(data.suggestions)
+        ? data.suggestions.map(normalizeServerLocationSuggestion)
+        : [];
+      matches = mergeLocationSuggestions([], serverMatches);
+      state.locationSearchMatches = matches;
+      suggestion = matches[0];
+    } catch (_error) {
+      suggestion = null;
+    }
+  }
+  if (!suggestion) {
+    els.requestStatus.textContent = "No local match. Paste decimal coordinates or import a KML/KMZ overlay.";
+    setLocationSearchOpen(false);
+    return;
+  }
+  flyToLocationSuggestion(suggestion);
+}
+
+function onLocationSearchInput() {
+  const query = els.locationSearchInput.value.trim();
+  window.clearTimeout(state.locationSearchTimer);
+  state.locationSearchRequestId += 1;
+  if (query.length < 2) {
+    state.locationSearchMatches = [];
+    setLocationSearchOpen(false);
+    return;
+  }
+  const localMatches = getLocationSearchSuggestions(query);
+  state.locationSearchMatches = localMatches;
+  renderLocationSearchSuggestions();
+  const requestId = state.locationSearchRequestId;
+  state.locationSearchTimer = window.setTimeout(() => {
+    void refreshOnlineLocationSuggestions(query, requestId, localMatches);
+  }, 240);
+}
+
+function onLocationSearchKeyDown(event) {
+  if (event.key === "Escape") {
+    setLocationSearchOpen(false);
+    return;
+  }
+  if (event.key === "Enter") {
+    event.preventDefault();
+    void commitLocationSearch();
+    return;
+  }
+  if (!state.locationSearchMatches.length) {
+    return;
+  }
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+    const nextIndex = state.activeLocationSearchIndex + 1;
+    setActiveLocationSuggestion(nextIndex > state.locationSearchMatches.length - 1 ? 0 : nextIndex);
+  } else if (event.key === "ArrowUp") {
+    event.preventDefault();
+    const nextIndex = state.activeLocationSearchIndex - 1;
+    setActiveLocationSuggestion(nextIndex < 0 ? state.locationSearchMatches.length - 1 : nextIndex);
+  }
+}
+
+function onLocationSearchSubmit(event) {
+  event.preventDefault();
+  void commitLocationSearch();
+}
+
+function getMapCenterPoint() {
+  if (!state.viewer) {
+    return null;
+  }
+
+  const rectangle = state.viewer.camera.computeViewRectangle(state.viewer.scene.globe.ellipsoid);
+  if (rectangle) {
+    const west = Cesium.Math.toDegrees(rectangle.west);
+    const east = Cesium.Math.toDegrees(rectangle.east);
+    const south = Cesium.Math.toDegrees(rectangle.south);
+    const north = Cesium.Math.toDegrees(rectangle.north);
+    const centerLon = west <= east ? (west + east) / 2 : ((west + east + 360) / 2) % 360;
+    return {
+      lat: clampNumber((south + north) / 2, -89.9999, 89.9999),
+      lon: centerLon > 180 ? centerLon - 360 : centerLon,
+    };
+  }
+
+  const cartographic = state.viewer.camera.positionCartographic;
+  return {
+    lat: Cesium.Math.toDegrees(cartographic.latitude),
+    lon: Cesium.Math.toDegrees(cartographic.longitude),
+  };
+}
+
+function getUtmZone(lat, lon) {
+  let zone = Math.floor((lon + 180) / 6) + 1;
+  zone = clampNumber(zone, 1, 60);
+  if (lat >= 56 && lat < 64 && lon >= 3 && lon < 12) {
+    zone = 32;
+  }
+  if (lat >= 72 && lat < 84) {
+    if (lon >= 0 && lon < 9) {
+      zone = 31;
+    } else if (lon >= 9 && lon < 21) {
+      zone = 33;
+    } else if (lon >= 21 && lon < 33) {
+      zone = 35;
+    } else if (lon >= 33 && lon < 42) {
+      zone = 37;
+    }
+  }
+  return zone;
+}
+
+function getUtmLatitudeBand(lat) {
+  if (lat >= 84) {
+    return "X";
+  }
+  if (lat < -80) {
+    return "C";
+  }
+  const index = clampNumber(Math.floor((lat + 80) / 8), 0, UTM_LATITUDE_BANDS.length - 1);
+  return UTM_LATITUDE_BANDS[index];
+}
+
+function latLonToUtm(lat, lon) {
+  const a = 6378137.0;
+  const f = 1 / 298.257223563;
+  const k0 = 0.9996;
+  const eSq = f * (2 - f);
+  const ePrimeSq = eSq / (1 - eSq);
+  const zone = getUtmZone(lat, lon);
+  const lonOrigin = (zone - 1) * 6 - 180 + 3;
+  const latRad = Cesium.Math.toRadians(lat);
+  const lonRad = Cesium.Math.toRadians(lon);
+  const lonOriginRad = Cesium.Math.toRadians(lonOrigin);
+  const sinLat = Math.sin(latRad);
+  const cosLat = Math.cos(latRad);
+  const tanLat = Math.tan(latRad);
+  const n = a / Math.sqrt(1 - eSq * sinLat * sinLat);
+  const t = tanLat * tanLat;
+  const c = ePrimeSq * cosLat * cosLat;
+  const aa = cosLat * (lonRad - lonOriginRad);
+  const m = a * (
+    (1 - eSq / 4 - (3 * eSq * eSq) / 64 - (5 * eSq * eSq * eSq) / 256) * latRad
+    - ((3 * eSq) / 8 + (3 * eSq * eSq) / 32 + (45 * eSq * eSq * eSq) / 1024) * Math.sin(2 * latRad)
+    + ((15 * eSq * eSq) / 256 + (45 * eSq * eSq * eSq) / 1024) * Math.sin(4 * latRad)
+    - ((35 * eSq * eSq * eSq) / 3072) * Math.sin(6 * latRad)
+  );
+
+  let easting = k0 * n * (
+    aa
+    + ((1 - t + c) * aa ** 3) / 6
+    + ((5 - 18 * t + t * t + 72 * c - 58 * ePrimeSq) * aa ** 5) / 120
+  ) + 500000.0;
+  let northing = k0 * (
+    m
+    + n * tanLat * (
+      (aa * aa) / 2
+      + ((5 - t + 9 * c + 4 * c * c) * aa ** 4) / 24
+      + ((61 - 58 * t + t * t + 600 * c - 330 * ePrimeSq) * aa ** 6) / 720
+    )
+  );
+
+  if (lat < 0) {
+    northing += 10000000.0;
+  }
+
+  easting = Math.round(easting);
+  northing = Math.round(northing);
+  return {
+    zone,
+    band: getUtmLatitudeBand(lat),
+    easting,
+    northing,
+  };
+}
+
+function updateCenterGrid() {
+  const center = getMapCenterPoint();
+  if (!center) {
+    els.centerGridValue.textContent = "--";
+    els.centerGridLatLon.textContent = "--";
+    return;
+  }
+
+  const utm = latLonToUtm(center.lat, center.lon);
+  els.centerGridValue.textContent = `UTM ${utm.zone}${utm.band} ${utm.easting
+    .toString()
+    .padStart(6, "0")}E ${utm.northing.toString().padStart(7, "0")}N`;
+  els.centerGridLatLon.textContent = `${center.lat.toFixed(5)}, ${center.lon.toFixed(5)}`;
+}
+
+function isChatPinnedToBottom() {
+  const distanceFromBottom = els.chatLog.scrollHeight
+    - els.chatLog.scrollTop
+    - els.chatLog.clientHeight;
+  return distanceFromBottom <= CHAT_AUTOSCROLL_THRESHOLD_PX;
+}
+
+function scrollChatToBottom() {
+  els.chatLog.scrollTop = els.chatLog.scrollHeight;
+}
+
+function maybeScrollChatToBottom(shouldScroll = isChatPinnedToBottom()) {
+  if (shouldScroll) {
+    scrollChatToBottom();
+  }
+}
+
 function appendMessage(role, body, meta = "") {
+  const shouldFollowNewMessage = isChatPinnedToBottom();
   const article = document.createElement("article");
   article.className = `chat-message ${role === "user" ? "user-message" : "assistant-message"}`;
 
@@ -170,7 +1133,7 @@ function appendMessage(role, body, meta = "") {
   els.chatLog.appendChild(article);
   state.chatCount += 1;
   els.chatMeta.textContent = `${state.chatCount} messages`;
-  els.chatLog.scrollTop = els.chatLog.scrollHeight;
+  maybeScrollChatToBottom(shouldFollowNewMessage);
   return {
     article,
     bodyNode,
@@ -425,6 +1388,75 @@ function setSettingsMenuOpen(open) {
   els.settingsToggleBtn.setAttribute("aria-expanded", String(open));
 }
 
+function setModelProviderMenuOpen(open) {
+  els.modelProviderMenu.classList.toggle("hidden", !open);
+  els.modelProviderBtn.setAttribute("aria-expanded", String(open));
+}
+
+function syncModelSelects(sourceSelect, targetSelect) {
+  const selectedValue = sourceSelect.value;
+  targetSelect.innerHTML = "";
+  Array.from(sourceSelect.options).forEach((option) => {
+    const clone = option.cloneNode(true);
+    clone.selected = option.value === selectedValue;
+    targetSelect.appendChild(clone);
+  });
+}
+
+function applyProviderVisibility() {
+  const isClaude = state.llmProvider === "claude";
+  els.providerSelect.value = state.llmProvider;
+  els.providerLocalModelRow.classList.toggle("hidden", isClaude);
+  els.providerClaudeModelRow.classList.toggle("hidden", !isClaude);
+  els.providerClaudeKeyRow.classList.toggle("hidden", !isClaude);
+  if (state.claudeApiKey) {
+    els.claudeApiKeyInput.value = state.claudeApiKey;
+  }
+  if (isClaude) {
+    setModelProviderButton(`Claude: ${els.claudeModelSelect.value}`, state.claudeApiKey ? "good" : "warn");
+    els.providerStatus.textContent = state.claudeApiKey ? "Claude API key loaded for this session" : "Claude key required";
+  } else {
+    const label = els.modelSelect.value || els.topModelSelect.value || state.config?.default_model || "local model";
+    const tone = state.localModelAvailable ? "good" : "warn";
+    setModelProviderButton(state.localModelAvailable ? `Local: ${label}` : "Local model offline; rules active", tone);
+    els.providerStatus.textContent = state.localModelAvailable
+      ? "Local Ollama available"
+      : "Local model offline; deterministic planner remains active";
+  }
+}
+
+function applyProviderSelection() {
+  state.llmProvider = els.providerSelect.value;
+  state.claudeApiKey = els.claudeApiKeyInput.value.trim();
+  if (state.llmProvider === "claude" && !state.claudeApiKey) {
+    applyProviderVisibility();
+    els.providerStatus.textContent = "Claude API key required before switching providers";
+    setModelProviderMenuOpen(true);
+    els.claudeApiKeyInput.focus();
+    return;
+  }
+
+  sessionStorage.setItem("teraLlmProvider", state.llmProvider);
+  if (state.claudeApiKey) {
+    sessionStorage.setItem("teraClaudeApiKey", state.claudeApiKey);
+  } else {
+    sessionStorage.removeItem("teraClaudeApiKey");
+  }
+
+  if (state.llmProvider === "ollama") {
+    els.modelSelect.value = els.topModelSelect.value;
+  }
+  applyProviderVisibility();
+  setModelProviderMenuOpen(false);
+}
+
+function clearClaudeKey() {
+  state.claudeApiKey = "";
+  els.claudeApiKeyInput.value = "";
+  sessionStorage.removeItem("teraClaudeApiKey");
+  applyProviderVisibility();
+}
+
 function hasMissionInference() {
   return Boolean(state.sourceInference);
 }
@@ -447,7 +1479,7 @@ function renderClarifyingQuestions() {
   if (!questions.length) {
     const item = document.createElement("li");
     item.textContent = state.sourceInference
-      ? "No additional Socratic question was inferred. Review the working sources or describe a constraint in chat."
+      ? "No additional Socratic question is needed. Review the working sources or describe a constraint in chat."
       : "Socratic source questions will appear after the first mission description.";
     els.clarifyingQuestions.appendChild(item);
     return;
@@ -507,18 +1539,413 @@ function getSelectedSources() {
 }
 
 function formatSourceStatus(source) {
-  const stream = source.stream_status.replace(/-/g, " ");
-  const download = source.download_status.replace(/-/g, " ");
+  const stream = (source.stream_status || "unknown-stream").replace(/-/g, " ");
+  const download = (source.download_status || "unknown-package").replace(/-/g, " ");
   return `${stream} / ${download}`;
+}
+
+function textHasAny(text, terms) {
+  const normalizedText = normalizeSearchText(text);
+  const tokens = getMatchTokens(text);
+  return terms.some((term) => {
+    const expandedTerms = [term, ...(KEYWORD_EXPANSIONS[term] || [])];
+    return expandedTerms.some((expandedTerm) => {
+      const normalizedTerm = normalizeSearchText(expandedTerm);
+      if (!normalizedTerm) {
+        return false;
+      }
+      if (` ${normalizedText} `.includes(` ${normalizedTerm} `)) {
+        return true;
+      }
+      const termTokens = getMatchTokens(normalizedTerm);
+      if (termTokens.length === 1) {
+        return tokens.some((token) => tokenLooksLike(token, termTokens[0]));
+      }
+      return termTokens.every((termToken) => tokens.some((token) => tokenLooksLike(token, termToken)));
+    });
+  });
+}
+
+function findSourceById(sourceId) {
+  return state.dataSources.find((source) => source.id === sourceId)
+    || FALLBACK_SOURCE_CATALOG.find((source) => source.id === sourceId)
+    || null;
+}
+
+function appendUniqueSourceIds(sourceIds, ...newSourceIds) {
+  for (const sourceId of newSourceIds) {
+    if (findSourceById(sourceId) && !sourceIds.includes(sourceId)) {
+      sourceIds.push(sourceId);
+    }
+  }
+}
+
+function mergeSourcesIntoCatalog(sources) {
+  if (!Array.isArray(sources) || !sources.length) {
+    return;
+  }
+
+  const sourcesById = new Map(state.dataSources.map((source) => [source.id, source]));
+  for (const source of sources) {
+    if (source?.id) {
+      sourcesById.set(source.id, source);
+    }
+  }
+  state.dataSources = Array.from(sourcesById.values());
+}
+
+function useFallbackSourceCatalog(message, updateStatus = true) {
+  state.dataSources = FALLBACK_SOURCE_CATALOG.map((source) => ({ ...source }));
+  state.primarySourceIds = [...FALLBACK_PRIMARY_STREAM_SOURCE_IDS];
+  state.sourceCatalogFallback = true;
+  state.sourceCatalogMessage = message;
+
+  if (updateStatus) {
+    setChip(els.packageModeChip, "Catalog fallback", "warn");
+    els.packageStatus.textContent = `Server source catalog unavailable (${message}). Using the embedded fallback catalog.`;
+  }
+}
+
+function isUsMissionContext(promptText, mapContext) {
+  const usTerms = [
+    "united states",
+    "u.s.",
+    " usa",
+    "california",
+    "san francisco",
+    "sf ",
+    "national forest",
+    "blm",
+    "nps",
+    "usfs",
+  ];
+  if (textHasAny(promptText, usTerms)) {
+    return true;
+  }
+
+  const bounds = mapContext?.selected_area || (mapContext?.location_confirmed ? mapContext?.view_bounds : null);
+  const lat = bounds?.center_lat ?? mapContext?.camera?.lat;
+  const lon = bounds?.center_lon ?? mapContext?.camera?.lon;
+  return Number.isFinite(lat) && Number.isFinite(lon)
+    && lat >= 18
+    && lat <= 72
+    && lon >= -170
+    && lon <= -50;
+}
+
+function inferClientMissionFocus(promptText) {
+  const focusKeywords = [
+    ["water-access", ["water", "stream", "river", "spring", "lake", "potable", "hydrate"]],
+    ["sar-planning", ["search", "rescue", "sar", "missing", "lost person", "hasty"]],
+    ["evacuation", ["evac", "evacuation", "exfil", "casualty", "ambulance", "convoy"]],
+    ["signal-planning", ["signal", "radio", "comms", "communications", "line of sight", "relay"]],
+    ["hazard-routing", ["wildfire", "fire", "flood", "storm", "avalanche", "hazard", "closure"]],
+    ["access-control", ["private", "restricted", "public land", "access", "boundary", "parcel"]],
+    ["terrain-routing", ["route", "patrol", "walk", "foot", "trail", "slope", "terrain", "ridge"]],
+    ["imagery-preview", ["imagery", "aerial", "satellite", "visual", "inspect", "preview"]],
+  ];
+
+  let bestFocus = "mission-data-package";
+  let bestScore = 0;
+  for (const [focus, keywords] of focusKeywords) {
+    const score = keywords.reduce((sum, keyword) => sum + (textHasAny(promptText, [keyword]) ? 1 : 0), 0);
+    if (score > bestScore) {
+      bestFocus = focus;
+      bestScore = score;
+    }
+  }
+  return bestFocus;
+}
+
+function sanitizePackageSlug(text) {
+  const slug = text.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  return (slug || "mission-package").slice(0, 60);
+}
+
+function buildClientSourceRecommendation(missionText, mapContext, plannerErrorMessage) {
+  if (!state.dataSources.length) {
+    useFallbackSourceCatalog(plannerErrorMessage, false);
+  }
+
+  const promptText = missionText.trim().toLowerCase();
+  const missionFocus = inferClientMissionFocus(promptText);
+  const isUsContext = isUsMissionContext(promptText, mapContext);
+  const requiredIds = [];
+  const optionalIds = [];
+  const questions = [];
+  const rationale = [`Planner API unavailable: ${plannerErrorMessage}. Using embedded deterministic source rules.`];
+
+  appendUniqueSourceIds(optionalIds, "esri_world_imagery", "osm_basemap");
+  rationale.push("Esri imagery and OSM basemap stay as lightweight preview/context layers.");
+
+  const needsRouting = textHasAny(promptText, [
+    "route",
+    "routing",
+    "patrol",
+    "walk",
+    "foot",
+    "trail",
+    "road",
+    "evac",
+    "exfil",
+    "nearest",
+    "avoid",
+  ]);
+  const needsTerrain = needsRouting || textHasAny(promptText, [
+    "terrain",
+    "slope",
+    "ridge",
+    "mountain",
+    "valley",
+    "steep",
+    "exposed",
+    "viewshed",
+  ]);
+  const needsWater = textHasAny(promptText, ["water", "stream", "river", "spring", "lake", "potable", "hydrate"]);
+  const needsLandcover = needsRouting || textHasAny(promptText, [
+    "cover",
+    "conceal",
+    "brush",
+    "forest",
+    "canopy",
+    "wetland",
+    "vegetation",
+  ]);
+  const needsHazards = textHasAny(promptText, [
+    "wildfire",
+    "fire",
+    "flood",
+    "storm",
+    "weather",
+    "avalanche",
+    "closure",
+    "hazard",
+  ]);
+  const needsAccess = textHasAny(promptText, [
+    "private",
+    "restricted",
+    "public land",
+    "boundary",
+    "parcel",
+    "permission",
+    "access",
+  ]);
+  const needsSignal = textHasAny(promptText, [
+    "signal",
+    "radio",
+    "comms",
+    "communications",
+    "line of sight",
+    "los",
+    "relay",
+  ]);
+  const needsSar = textHasAny(promptText, ["sar", "search", "rescue", "missing", "lost person"]);
+  const needsCurrentImagery = textHasAny(promptText, [
+    "current",
+    "recent",
+    "latest",
+    "flood",
+    "burn",
+    "changed",
+    "cloud",
+  ]);
+
+  if (needsRouting) {
+    appendUniqueSourceIds(requiredIds, "osm_extract");
+    rationale.push("OSM PBF is required for the local routable graph and feature lookup.");
+  }
+  if (needsTerrain) {
+    appendUniqueSourceIds(requiredIds, isUsContext ? "usgs_3dep" : "copernicus_dem");
+    appendUniqueSourceIds(requiredIds, "esri_world_elevation");
+    appendUniqueSourceIds(optionalIds, "cesium_world_terrain");
+    rationale.push("Analysis DEM plus queryable Esri terrain fallback is required for slope, exposure, hydrology, and cost surfaces.");
+  }
+  if (needsLandcover) {
+    appendUniqueSourceIds(requiredIds, isUsContext ? "nlcd" : "esa_worldcover");
+    rationale.push("Land cover is included because movement friction, cover, vegetation, or route quality matters.");
+  }
+  if (needsWater) {
+    appendUniqueSourceIds(requiredIds, isUsContext ? "usgs_3dhp" : "hydrosheds");
+    if (isUsContext) {
+      appendUniqueSourceIds(optionalIds, "nwis");
+    }
+    appendUniqueSourceIds(optionalIds, "sentinel_2");
+    rationale.push("Hydrography is required for water-source and drainage queries.");
+  }
+  if (needsSar) {
+    appendUniqueSourceIds(requiredIds, "osm_extract");
+    appendUniqueSourceIds(optionalIds, isUsContext ? "naip" : "sentinel_2", "noaa_alerts");
+    rationale.push("SAR planning needs access features and usually benefits from detailed imagery and current alerts.");
+  }
+  if (needsHazards) {
+    appendUniqueSourceIds(optionalIds, "noaa_alerts");
+    if (textHasAny(promptText, ["fire", "wildfire"])) {
+      appendUniqueSourceIds(requiredIds, "nasa_firms");
+    }
+    if (textHasAny(promptText, ["flood"])) {
+      appendUniqueSourceIds(requiredIds, isUsContext ? "fema_flood" : "sentinel_1_sar");
+    }
+    rationale.push("Hazard layers are included only because current or baseline risk affects the mission.");
+  }
+  if (needsAccess) {
+    appendUniqueSourceIds(requiredIds, isUsContext ? "pad_us" : "parcels_boundaries");
+    if (isUsContext) {
+      appendUniqueSourceIds(optionalIds, "parcels_boundaries");
+    }
+    rationale.push("Access and boundary layers are included because restricted or legal movement matters.");
+  }
+  if (needsSignal) {
+    appendUniqueSourceIds(requiredIds, "viewshed_surfaces");
+    appendUniqueSourceIds(optionalIds, isUsContext ? "fcc_towers" : "osm_towers", "osm_towers");
+    if (!needsTerrain) {
+      appendUniqueSourceIds(requiredIds, isUsContext ? "usgs_3dep" : "copernicus_dem");
+      appendUniqueSourceIds(requiredIds, "esri_world_elevation");
+    }
+    rationale.push("Signal planning requires DEM-derived viewsheds plus tower or high-ground candidates.");
+  }
+  if (needsCurrentImagery && !needsWater && !needsHazards) {
+    appendUniqueSourceIds(optionalIds, "sentinel_2");
+    if (isUsContext) {
+      appendUniqueSourceIds(optionalIds, "naip");
+    }
+    rationale.push("Recent imagery is optional unless recent conditions drive the mission.");
+  }
+
+  if (!mapContext?.location_confirmed) {
+    questions.push(
+      "Move the map to the mission AO with search, KML/KMZ import, or AO drawing and confirm that view before final source selection.",
+    );
+  }
+
+  if (!requiredIds.length) {
+    questions.push(
+      "Which mission outcome must the database answer first: routing, water lookup, SAR sectors, signal planning, hazards, or access control?",
+    );
+    rationale.push("No analytical source family was identified yet, so the package remains in preview mode.");
+  }
+  if (needsRouting && !textHasAny(promptText, ["foot", "vehicle", "atv", "convoy", "boat", "drone"])) {
+    questions.push("Should movement be optimized for foot, vehicle, ATV, boat, drone, or mixed movement?");
+  }
+  if (needsWater) {
+    questions.push("Do you only need mapped water features, or confidence in current and potable water availability?");
+  }
+  if (needsHazards) {
+    questions.push("Which hazards must be current at package time versus treated as cached baseline risk?");
+  }
+  if (needsSignal) {
+    questions.push("What antenna height and radio role should viewshed or relay analysis assume?");
+  }
+  if (needsAccess) {
+    questions.push("Should the package enforce legal or restricted access boundaries, or only support terrain movement?");
+  }
+  if (!mapContext?.selected_area && !mapContext?.location_confirmed) {
+    questions.push("Is this AO inside the U.S. or outside it?");
+  }
+
+  const selectedIds = [];
+  const previewIds = optionalIds.filter((sourceId) => ["esri_world_imagery", "osm_basemap"].includes(sourceId));
+  appendUniqueSourceIds(selectedIds, ...requiredIds, ...previewIds);
+  const missionSummary = missionText.length > 220 ? `${missionText.slice(0, 217)}...` : missionText;
+
+  return {
+    mission_focus: missionFocus,
+    mission_summary: missionSummary,
+    required_source_ids: requiredIds,
+    optional_source_ids: optionalIds.filter((sourceId) => !requiredIds.includes(sourceId)),
+    selected_source_ids: selectedIds,
+    sources: selectedIds.map((sourceId) => findSourceById(sourceId)).filter(Boolean),
+    clarifying_questions: questions.slice(0, 3),
+    rationale: rationale.slice(0, 5),
+    package_name_suggestion: `tera-${sanitizePackageSlug(missionFocus)}`,
+  };
+}
+
+function applySourceRecommendation(data, missionText, mode = "server", statusMessage = "") {
+  mergeSourcesIntoCatalog(data.sources);
+  state.sourceInference = data;
+  state.lastMissionText = missionText;
+  state.selectedSourceIds = new Set(data.selected_source_ids || []);
+  state.sourceConfirmed = false;
+  state.workflowStageIndex = data.clarifying_questions?.length ? 1 : 2;
+  state.packagePlan = null;
+  state.sourcePlannerFallback = mode === "fallback";
+  state.sourcePlannerMessage = statusMessage;
+  hidePackageOutput();
+
+  if (!els.packageNameInput.value.trim() && data.package_name_suggestion) {
+    els.packageNameInput.value = data.package_name_suggestion;
+  }
+
+  els.inferredMission.textContent = data.mission_summary || missionText;
+  setChip(
+    els.packageModeChip,
+    mode === "fallback" ? "Planner fallback" : data.mission_focus || "Planned",
+    mode === "fallback" ? "warn" : "good",
+  );
+  renderSourceList();
+
+  const questionText = data.clarifying_questions?.length
+    ? ` Next questions: ${data.clarifying_questions.join(" ")}`
+    : "";
+  const fallbackText = mode === "fallback"
+    ? ` Browser fallback used because the planner API is unavailable (${statusMessage}).`
+    : "";
+  els.packageStatus.textContent = `Drafted ${state.selectedSourceIds.size} working sources.${fallbackText} Answer the dialogue questions to broaden or narrow the package.${questionText}`;
+  updateWorkflowPanel();
+}
+
+function formatSourceNameList(sourceIds) {
+  const names = (sourceIds || []).map((sourceId) => findSourceById(sourceId)?.name || sourceId);
+  return names.length ? names.join(", ") : "none";
+}
+
+function buildDeterministicAdvisorResponse(recommendation, mapContext) {
+  const required = formatSourceNameList(recommendation?.required_source_ids || []);
+  const optional = formatSourceNameList(recommendation?.optional_source_ids || []);
+  const selected = formatSourceNameList(recommendation?.selected_source_ids || []);
+  const rationale = (recommendation?.rationale || [])
+    .slice(0, 4)
+    .map((item) => `- ${item}`)
+    .join("\n") || "- The planner could not infer a stronger source rationale yet.";
+  const questions = (recommendation?.clarifying_questions || [])
+    .slice(0, 3)
+    .map((item, index) => `${index + 1}. ${item}`)
+    .join("\n") || "No additional question is required before reviewing the selected source families.";
+  const mapFocus = mapContext?.location_confirmed
+    ? `Confirmed map focus: **${mapContext.location_focus_label || "selected AO"}**.`
+    : "Map focus is not confirmed. Use the search bar, KML/KMZ import, or AO rectangle before finalizing the package.";
+
+  return [
+    "### Mission Read",
+    recommendation?.mission_summary || "Mission description captured.",
+    "",
+    "### Working Source Recommendation",
+    `- **Required:** ${required}`,
+    `- **Optional enhancers:** ${optional}`,
+    `- **Currently selected:** ${selected}`,
+    "",
+    "### Why These Sources",
+    rationale,
+    "",
+    "### Scope Check",
+    questions,
+    "",
+    "### Map Location",
+    mapFocus,
+  ].join("\n");
 }
 
 function updateSourceCount() {
   const selectedCount = state.selectedSourceIds.size;
   const total = state.dataSources.length;
   if (!hasMissionInference()) {
-    els.sourceCount.textContent = total
-      ? "Awaiting mission description"
-      : "Source catalog not loaded";
+    if (state.sourceCatalogFallback) {
+      els.sourceCount.textContent = "Fallback source catalog ready";
+    } else {
+      els.sourceCount.textContent = total
+        ? "Awaiting mission description"
+        : "Source catalog unavailable";
+    }
   } else {
     els.sourceCount.textContent = selectedCount
       ? `${selectedCount} selected from ${total} available sources`
@@ -533,7 +1960,7 @@ function renderSourceList() {
   if (!state.dataSources.length) {
     const empty = document.createElement("div");
     empty.className = "source-empty";
-    empty.textContent = "No source catalog loaded.";
+    empty.textContent = "Source catalog unavailable. The browser planner will fall back if the server route is not ready.";
     els.sourceList.appendChild(empty);
     updateSourceCount();
     return;
@@ -543,7 +1970,7 @@ function renderSourceList() {
   if (!visibleSources.length) {
     const empty = document.createElement("div");
     empty.className = "source-empty";
-    empty.textContent = "Send a mission description in chat. TERA will infer a compact source list here.";
+    empty.textContent = "Send a mission description in chat. TERA will recommend a compact source list here.";
     els.sourceList.appendChild(empty);
     updateSourceCount();
     return;
@@ -616,12 +2043,16 @@ async function loadDataSources() {
     const data = await fetchJson("/api/data-sources");
     state.dataSources = Array.isArray(data.sources) ? data.sources : [];
     state.primarySourceIds = Array.isArray(data.primary_streams) ? data.primary_streams : [];
+    state.sourceCatalogFallback = false;
+    state.sourceCatalogMessage = "";
     state.selectedSourceIds = new Set();
+    if (!state.dataSources.length) {
+      throw new Error("empty catalog response");
+    }
     renderSourceList();
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    state.dataSources = [];
-    els.packageStatus.textContent = `Source catalog failed: ${message}`;
+    const message = getErrorMessage(error);
+    useFallbackSourceCatalog(message);
     renderSourceList();
   }
 }
@@ -630,6 +2061,9 @@ function buildMapContext() {
   const context = {
     imagery_source: els.imageryStatus.textContent || null,
     terrain_source: els.terrainStatus.textContent || null,
+    location_focus_label: state.mapFocusLabel || null,
+    location_focus_source: state.mapFocusSource || null,
+    location_confirmed: Boolean(state.mapLocationConfirmed || state.selectedArea),
   };
 
   if (state.selectedArea) {
@@ -670,7 +2104,7 @@ function buildSourceContext() {
   const inference = state.sourceInference;
   const packageSummary = state.packagePlan
     ? `${state.packagePlan.package_name}: ${sourceNames.length} sources, manifest ${state.packagePlan.package_id}`
-    : `${sourceNames.length} sources inferred from chat for ${inference?.mission_focus || "mission-data-package"}`;
+    : `${sourceNames.length} sources planned from chat for ${inference?.mission_focus || "mission-data-package"}`;
 
   return {
     mission_focus: inference?.mission_focus || "mission-data-package",
@@ -709,7 +2143,7 @@ function resetPlannerWorkflow() {
   setChip(els.packageModeChip, "Awaiting mission");
   hidePackageOutput();
   renderSourceList();
-  els.packageStatus.textContent = "No sources selected yet. Send a mission description to infer the needed package.";
+  els.packageStatus.textContent = "No sources selected yet. Send a mission description to plan the needed package.";
   updateWorkflowPanel();
 }
 
@@ -730,7 +2164,7 @@ function clearChat() {
   state.chatCount = 0;
   appendMessage(
     "assistant",
-    "Source planner ready. Describe the mission in chat. I will work through the source package as a short question-driven dialogue.",
+    "Source planner ready. Describe the mission and move the map to the mission area with search, KML/KMZ import, or AO selection. I will keep the source-scope dialogue short.",
   );
 }
 
@@ -822,13 +2256,15 @@ function updateCameraText() {
   state.cameraText = formatPoint(lat, lon, height);
   els.cameraPosition.textContent = state.cameraText;
   updateMapInstruments();
+  updateCenterGrid();
 }
 
 async function loadRuntimeConfig() {
   state.config = await fetchJson("/api/config");
   const hasToken = Boolean(state.config.cesium_ion_token);
   setChip(els.tokenChip, hasToken ? "Cesium token detected" : "Cesium token missing", hasToken ? "good" : "warn");
-  setChip(els.ollamaChip, `Default model: ${state.config.default_model}`, "good");
+  els.claudeModelSelect.value = state.config.claude_default_model || els.claudeModelSelect.value;
+  setModelProviderButton(`Default model: ${state.config.default_model}`, "warn");
   state.imageryMode = "esri";
   state.terrainMode = hasToken ? "cesium-world" : "ellipsoid";
   els.imagerySelect.value = state.imageryMode;
@@ -839,8 +2275,25 @@ async function loadModels() {
   els.modelsStatus.textContent = "Checking Ollama...";
   try {
     const data = await fetchJson("/api/models");
+    state.localModelAvailable = Boolean(data.online);
+    state.localModelDetail = data.detail || "";
     els.modelsList.innerHTML = "";
     els.modelSelect.innerHTML = "";
+
+    if (!data.online) {
+      const option = document.createElement("option");
+      option.value = data.default_model || state.config.default_model;
+      option.textContent = `${option.value} (offline)`;
+      els.modelSelect.appendChild(option);
+      syncModelSelects(els.modelSelect, els.topModelSelect);
+
+      const item = document.createElement("li");
+      item.textContent = data.detail || "Local model is not reachable. Deterministic planner remains available.";
+      els.modelsList.appendChild(item);
+      els.modelsStatus.textContent = "Local model offline; deterministic planner active";
+      applyProviderVisibility();
+      return;
+    }
 
     if (!Array.isArray(data.models) || data.models.length === 0) {
       const option = document.createElement("option");
@@ -852,6 +2305,8 @@ async function loadModels() {
       item.textContent = "No installed models reported by Ollama.";
       els.modelsList.appendChild(item);
       els.modelsStatus.textContent = `Default model: ${data.default_model}`;
+      syncModelSelects(els.modelSelect, els.topModelSelect);
+      applyProviderVisibility();
       return;
     }
 
@@ -876,14 +2331,23 @@ async function loadModels() {
     }
 
     els.modelsStatus.textContent = `${data.models.length} model${data.models.length === 1 ? "" : "s"} available`;
+    syncModelSelects(els.modelSelect, els.topModelSelect);
+    applyProviderVisibility();
   } catch (error) {
-    els.modelSelect.innerHTML = "<option value=''>Could not load models</option>";
+    state.localModelAvailable = false;
+    state.localModelDetail = error instanceof Error ? error.message : String(error);
+    els.modelSelect.innerHTML = "";
+    const option = document.createElement("option");
+    option.value = state.config?.default_model || "";
+    option.textContent = option.value ? `${option.value} (offline)` : "Local model offline";
+    els.modelSelect.appendChild(option);
     els.modelsList.innerHTML = "";
     const item = document.createElement("li");
-    item.textContent = error instanceof Error ? error.message : String(error);
+    item.textContent = state.localModelDetail;
     els.modelsList.appendChild(item);
-    els.modelsStatus.textContent = "Model lookup failed";
-    setChip(els.ollamaChip, "Ollama lookup failed", "bad");
+    els.modelsStatus.textContent = "Local model offline; deterministic planner active";
+    syncModelSelects(els.modelSelect, els.topModelSelect);
+    applyProviderVisibility();
   }
 }
 
@@ -893,57 +2357,45 @@ function makeMapContextAppendix() {
   }
 
   const lines = [];
+  if (state.mapLocationConfirmed) {
+    lines.push(`Mission map focus: ${state.mapFocusLabel} (${state.mapFocusSource}).`);
+  } else {
+    lines.push("Mission map focus is not confirmed; ask the planner to use map search, KML/KMZ import, or AO drawing before final source confirmation.");
+  }
   if (state.selectedArea) {
     lines.push(
       `Selected AO west ${state.selectedArea.west.toFixed(6)}, south ${state.selectedArea.south.toFixed(6)}, east ${state.selectedArea.east.toFixed(6)}, north ${state.selectedArea.north.toFixed(6)}.`,
     );
   }
-  if (!lines.length) {
-    return "";
-  }
   return `\n\nAO context:\n${lines.join("\n")}`;
 }
 
-async function inferSourcesFromMission(missionText, mapContext) {
-  els.packageStatus.textContent = "Inferring compact source package from mission text...";
-  setChip(els.packageModeChip, "Inferring", "warn");
+async function planSourcesFromMission(missionText, mapContext) {
+  els.packageStatus.textContent = "Planning compact source package from mission text...";
+  setChip(els.packageModeChip, "Planning", "warn");
 
-  const data = await fetchJson("/api/source-package/recommend", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      mission_text: missionText,
-      map_context: mapContext,
-    }),
-  });
-
-  state.sourceInference = data;
-  state.lastMissionText = missionText;
-  state.selectedSourceIds = new Set(data.selected_source_ids || []);
-  state.sourceConfirmed = false;
-  state.workflowStageIndex = data.clarifying_questions?.length ? 1 : 2;
-  state.packagePlan = null;
-  hidePackageOutput();
-
-  if (!els.packageNameInput.value.trim() && data.package_name_suggestion) {
-    els.packageNameInput.value = data.package_name_suggestion;
+  try {
+    const data = await fetchJson("/api/source-package/recommend", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        mission_text: missionText,
+        map_context: mapContext,
+      }),
+    });
+    applySourceRecommendation(data, missionText, "server");
+    return data;
+  } catch (error) {
+    const message = getErrorMessage(error);
+    const data = buildClientSourceRecommendation(missionText, mapContext, message);
+    applySourceRecommendation(data, missionText, "fallback", message);
+    return data;
   }
-
-  els.inferredMission.textContent = data.mission_summary || missionText;
-  setChip(els.packageModeChip, data.mission_focus || "Inferred", "good");
-  renderSourceList();
-
-  const questionText = data.clarifying_questions?.length
-    ? ` Next questions: ${data.clarifying_questions.join(" ")}`
-    : "";
-  els.packageStatus.textContent = `Drafted ${state.selectedSourceIds.size} working sources. Answer the dialogue questions to broaden or narrow the package.${questionText}`;
-  updateWorkflowPanel();
-  return data;
 }
 
 async function buildSourcePackage() {
   if (!state.sourceConfirmed) {
-    els.packageStatus.textContent = "Confirm the inferred source list before building the manifest.";
+    els.packageStatus.textContent = "Confirm the recommended source list before building the manifest.";
     setWorkflowStage(2);
     return;
   }
@@ -984,7 +2436,6 @@ async function buildSourcePackage() {
 async function submitPrompt(event) {
   event.preventDefault();
   els.submitBtn.disabled = true;
-  els.requestStatus.textContent = "Connecting to local model...";
 
   const prompt = els.promptInput.value.trim();
   if (!prompt) {
@@ -993,25 +2444,41 @@ async function submitPrompt(event) {
     return;
   }
   const system = els.systemInput.value.trim();
-  const model = els.modelSelect.value.trim();
+  const provider = state.llmProvider;
+  const model = provider === "claude"
+    ? els.claudeModelSelect.value.trim()
+    : els.modelSelect.value.trim();
+  els.requestStatus.textContent = provider === "claude"
+    ? "Connecting to Claude API..."
+    : "Connecting to local model...";
+  if (provider === "claude" && !state.claudeApiKey) {
+    els.submitBtn.disabled = false;
+    els.requestStatus.textContent = "Claude API key required";
+    els.providerStatus.textContent = "Enter a Claude API key to use cloud inference";
+    setModelProviderMenuOpen(true);
+    els.claudeApiKeyInput.focus();
+    return;
+  }
   const agentProfile = els.agentProfileSelect.value;
   const finalPrompt = `${prompt}${makeMapContextAppendix()}`;
   const mapContext = els.includeMapContext.checked ? buildMapContext() : null;
-  els.requestStatus.textContent = "Inferring source package...";
+  els.requestStatus.textContent = "Planning source package...";
   try {
-    await inferSourcesFromMission(prompt, mapContext);
+    await planSourcesFromMission(prompt, mapContext);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    els.packageStatus.textContent = `Source inference failed: ${message}`;
-    setChip(els.packageModeChip, "Inference failed", "bad");
+    const message = getErrorMessage(error);
+    els.packageStatus.textContent = `Source planner unavailable: ${message}`;
+    setChip(els.packageModeChip, "Planner unavailable", "bad");
   }
   const sourceContext = buildSourceContext();
+  const sourceRecommendation = state.sourceInference;
 
   appendMessage(
     "user",
     finalPrompt,
     [
       model ? `model: ${model}` : "default model",
+      `provider: ${provider}`,
       `profile: ${agentProfile}`,
       `focus: ${sourceContext.mission_focus}`,
       `${sourceContext.selected_source_ids.length} sources`,
@@ -1019,6 +2486,18 @@ async function submitPrompt(event) {
   );
 
   let activeAssistantMessage = null;
+
+  if (provider === "ollama" && !state.localModelAvailable) {
+    appendMessage(
+      "assistant",
+      buildDeterministicAdvisorResponse(sourceRecommendation, mapContext),
+      "deterministic source advisor | local model offline",
+    );
+    els.requestStatus.textContent = "Local model offline; deterministic advisor response shown";
+    els.promptInput.value = "";
+    els.submitBtn.disabled = false;
+    return;
+  }
 
   try {
     const assistantMessage = appendMessage(
@@ -1035,6 +2514,9 @@ async function submitPrompt(event) {
         prompt: finalPrompt,
         system: system || null,
         model: model || null,
+        llm_provider: provider,
+        cloud_model: provider === "claude" ? model : null,
+        cloud_api_key: provider === "claude" ? state.claudeApiKey || null : null,
         agent_profile: agentProfile,
         map_context: mapContext,
         source_context: sourceContext,
@@ -1059,8 +2541,9 @@ async function submitPrompt(event) {
       }
       if (eventData.type === "token") {
         streamedText += eventData.text || "";
+        const shouldFollowStream = isChatPinnedToBottom();
         setMessageBody(assistantMessage, streamedText);
-        els.chatLog.scrollTop = els.chatLog.scrollHeight;
+        maybeScrollChatToBottom(shouldFollowStream);
         return;
       }
       if (eventData.type === "status") {
@@ -1076,20 +2559,38 @@ async function submitPrompt(event) {
     });
 
     if (!streamedText.trim()) {
-      throw new Error("The local model returned an empty streamed response.");
+      throw new Error(provider === "claude"
+        ? "Claude returned an empty response."
+        : "The local model returned an empty streamed response.");
     }
 
     els.requestStatus.textContent = `Completed with ${resolvedModel}`;
     els.promptInput.value = "";
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (activeAssistantMessage) {
-      setMessageBody(activeAssistantMessage, message);
-      ensureMessageMeta(activeAssistantMessage, "request failed");
+    if (provider === "ollama") {
+      state.localModelAvailable = false;
+      state.localModelDetail = message;
+      applyProviderVisibility();
     } else {
-      appendMessage("assistant", message, "request failed");
+      els.providerStatus.textContent = `Claude request failed: ${message}`;
     }
-    els.requestStatus.textContent = "Request failed";
+    const fallbackMeta = provider === "claude"
+      ? "deterministic fallback | Claude request failed"
+      : "deterministic fallback | local model unavailable";
+    if (activeAssistantMessage) {
+      setMessageBody(activeAssistantMessage, buildDeterministicAdvisorResponse(sourceRecommendation, mapContext));
+      ensureMessageMeta(activeAssistantMessage, fallbackMeta);
+    } else {
+      appendMessage(
+        "assistant",
+        buildDeterministicAdvisorResponse(sourceRecommendation, mapContext),
+        fallbackMeta,
+      );
+    }
+    els.requestStatus.textContent = provider === "claude"
+      ? `Claude request failed; deterministic advisor response shown (${message})`
+      : `Local model unavailable; deterministic advisor response shown (${message})`;
   } finally {
     els.submitBtn.disabled = false;
   }
@@ -1337,6 +2838,7 @@ function setAreaEntityBounds(bounds) {
 
 function setSelectedArea(bounds) {
   state.selectedArea = bounds;
+  markMapLocationFocused("Drawn AO rectangle", "drawn-aoi");
   setAreaEntityBounds(bounds);
   updateSelectedArea();
   hidePackageOutput();
@@ -1353,13 +2855,16 @@ function clearSelectedArea() {
   }
   state.areaEntity = null;
   clearAreaHandles();
+  if (state.mapFocusSource === "drawn-aoi") {
+    clearMapLocationFocus();
+  }
   updateSelectedArea();
   hidePackageOutput();
 }
 
 function setAreaSelectMode(active) {
   if (active && !state.sourceConfirmed) {
-    els.packageStatus.textContent = "Confirm the inferred source list before drawing AO coverage.";
+    els.packageStatus.textContent = "Confirm the recommended source list before drawing AO coverage.";
     setWorkflowStage(2);
     return;
   }
@@ -1504,6 +3009,11 @@ async function buildViewer() {
     state.viewer.destroy();
     state.areaEntity = null;
     state.areaHandleEntities = [];
+    state.overlayDataSource = null;
+    state.overlayFileName = "";
+    if (state.mapFocusSource === "kml-kmz-import") {
+      clearMapLocationFocus();
+    }
   }
 
   if (state.config.cesium_ion_token) {
@@ -1571,7 +3081,87 @@ function resetView() {
       state.config.default_height_m,
     ),
     duration: 1.1,
+    complete: updateCameraText,
   });
+  clearMapLocationFocus();
+  els.requestStatus.textContent = "Map reset. Search or import the mission location before source confirmation.";
+}
+
+function isSupportedOverlayFile(file) {
+  return /\.(kml|kmz)$/i.test(file.name);
+}
+
+async function removeCurrentOverlay() {
+  if (!state.viewer || !state.overlayDataSource) {
+    state.overlayDataSource = null;
+    state.overlayFileName = "";
+    if (state.mapFocusSource === "kml-kmz-import") {
+      clearMapLocationFocus();
+    }
+    return;
+  }
+
+  await state.viewer.dataSources.remove(state.overlayDataSource, true);
+  state.overlayDataSource = null;
+  state.overlayFileName = "";
+  if (state.mapFocusSource === "kml-kmz-import") {
+    clearMapLocationFocus();
+  }
+}
+
+async function importMapOverlay(file) {
+  if (!file) {
+    return;
+  }
+  if (!isSupportedOverlayFile(file)) {
+    els.requestStatus.textContent = "Overlay import failed: choose a .kml or .kmz file.";
+    return;
+  }
+  if (!state.viewer) {
+    els.requestStatus.textContent = "Overlay import unavailable until the map is ready.";
+    return;
+  }
+
+  els.importOverlayBtn.disabled = true;
+  els.requestStatus.textContent = `Loading overlay: ${file.name}`;
+
+  try {
+    await removeCurrentOverlay();
+    const dataSource = await Cesium.KmlDataSource.load(file, {
+      camera: state.viewer.scene.camera,
+      canvas: state.viewer.scene.canvas,
+      clampToGround: true,
+      sourceUri: file.name,
+    });
+    state.overlayDataSource = await state.viewer.dataSources.add(dataSource);
+    state.overlayFileName = file.name;
+    markMapLocationFocused(file.name, "kml-kmz-import");
+
+    if (state.overlayDataSource.entities.values.length) {
+      await state.viewer.flyTo(state.overlayDataSource, { duration: 1.1 });
+      updateCameraText();
+      els.requestStatus.textContent = `Overlay loaded: ${file.name}`;
+    } else {
+      els.requestStatus.textContent = `Overlay loaded with no visible features: ${file.name}`;
+    }
+    state.viewer.scene.requestRender();
+  } catch (error) {
+    const message = getErrorMessage(error);
+    await removeCurrentOverlay();
+    els.requestStatus.textContent = `Overlay import failed: ${message}`;
+  } finally {
+    els.importOverlayBtn.disabled = false;
+    els.overlayFileInput.value = "";
+  }
+}
+
+function requestOverlayFile() {
+  els.overlayFileInput.click();
+}
+
+function onOverlayFileSelected(event) {
+  const [file] = Array.from(event.target.files || []);
+  void importMapOverlay(file);
 }
 
 function togglePanel() {
@@ -1585,32 +3175,63 @@ function toggleSettingsMenu() {
 }
 
 function onDocumentPointerDown(event) {
-  if (els.settingsMenu.classList.contains("hidden")) {
-    return;
+  if (
+    !els.locationSearchSuggestions.classList.contains("hidden")
+    && !els.locationSearchPanel.contains(event.target)
+  ) {
+    setLocationSearchOpen(false);
   }
-  if (els.settingsMenu.contains(event.target) || els.settingsToggleBtn.contains(event.target)) {
-    return;
+
+  if (
+    !els.modelProviderMenu.classList.contains("hidden")
+    && !els.modelProviderMenu.contains(event.target)
+    && !els.modelProviderBtn.contains(event.target)
+  ) {
+    setModelProviderMenuOpen(false);
   }
-  setSettingsMenuOpen(false);
+
+  if (!els.settingsMenu.classList.contains("hidden")) {
+    if (els.settingsMenu.contains(event.target) || els.settingsToggleBtn.contains(event.target)) {
+      return;
+    }
+    setSettingsMenuOpen(false);
+  }
+}
+
+function clearDocumentSelection() {
+  const selection = window.getSelection?.();
+  if (selection && !selection.isCollapsed) {
+    selection.removeAllRanges();
+  }
 }
 
 function onResizerPointerDown(event) {
   if (state.panelCollapsed) {
     return;
   }
+  event.preventDefault();
+  clearDocumentSelection();
   state.dragState = {
     startX: event.clientX,
     startWidth: state.panelWidth,
+    pointerId: event.pointerId,
   };
+  document.body.classList.add("is-resizing-panel");
   els.panelResizer.classList.add("is-dragging");
+  if (typeof els.panelResizer.setPointerCapture === "function") {
+    els.panelResizer.setPointerCapture(event.pointerId);
+  }
   window.addEventListener("pointermove", onResizerPointerMove);
   window.addEventListener("pointerup", onResizerPointerUp, { once: true });
+  window.addEventListener("pointercancel", onResizerPointerUp, { once: true });
 }
 
 function onResizerPointerMove(event) {
   if (!state.dragState) {
     return;
   }
+  event.preventDefault();
+  clearDocumentSelection();
   const delta = state.dragState.startX - event.clientX;
   state.panelWidth = clampPanelWidth(state.dragState.startWidth + delta);
   els.workspaceShell.style.setProperty("--panel-width", `${state.panelWidth}px`);
@@ -1620,10 +3241,24 @@ function onResizerPointerMove(event) {
   }
 }
 
-function onResizerPointerUp() {
+function onResizerPointerUp(event) {
+  if (event) {
+    event.preventDefault();
+  }
+  if (
+    state.dragState
+    && typeof els.panelResizer.releasePointerCapture === "function"
+    && els.panelResizer.hasPointerCapture?.(state.dragState.pointerId)
+  ) {
+    els.panelResizer.releasePointerCapture(state.dragState.pointerId);
+  }
   state.dragState = null;
+  document.body.classList.remove("is-resizing-panel");
   els.panelResizer.classList.remove("is-dragging");
   window.removeEventListener("pointermove", onResizerPointerMove);
+  window.removeEventListener("pointerup", onResizerPointerUp);
+  window.removeEventListener("pointercancel", onResizerPointerUp);
+  clearDocumentSelection();
 }
 
 function onPromptInputKeyDown(event) {
@@ -1676,6 +3311,33 @@ async function init() {
     els.clearChatBtn.addEventListener("click", clearChat);
     els.resetViewBtn.addEventListener("click", resetView);
     els.mapResetViewBtn.addEventListener("click", resetView);
+    els.importOverlayBtn.addEventListener("click", requestOverlayFile);
+    els.overlayFileInput.addEventListener("change", onOverlayFileSelected);
+    els.locationSearchForm.addEventListener("submit", onLocationSearchSubmit);
+    els.locationSearchInput.addEventListener("input", onLocationSearchInput);
+    els.locationSearchInput.addEventListener("keydown", onLocationSearchKeyDown);
+    els.modelProviderBtn.addEventListener("click", () => {
+      setModelProviderMenuOpen(els.modelProviderMenu.classList.contains("hidden"));
+    });
+    els.providerSelect.addEventListener("change", (event) => {
+      state.llmProvider = event.target.value;
+      applyProviderVisibility();
+    });
+    els.topModelSelect.addEventListener("change", () => {
+      els.modelSelect.value = els.topModelSelect.value;
+      applyProviderVisibility();
+    });
+    els.modelSelect.addEventListener("change", () => {
+      els.topModelSelect.value = els.modelSelect.value;
+      applyProviderVisibility();
+    });
+    els.claudeModelSelect.addEventListener("change", applyProviderVisibility);
+    els.claudeApiKeyInput.addEventListener("input", () => {
+      state.claudeApiKey = els.claudeApiKeyInput.value.trim();
+      applyProviderVisibility();
+    });
+    els.saveProviderBtn.addEventListener("click", applyProviderSelection);
+    els.clearClaudeKeyBtn.addEventListener("click", clearClaudeKey);
     els.panelToggleBtn.addEventListener("click", togglePanel);
     els.settingsToggleBtn.addEventListener("click", toggleSettingsMenu);
     els.panelResizer.addEventListener("pointerdown", onResizerPointerDown);

--- a/llm_dev_kmh/static/app.js
+++ b/llm_dev_kmh/static/app.js
@@ -345,6 +345,8 @@ const LOCATION_GAZETTEER = [
 
 const LOCATION_SEARCH_LIMIT = 6;
 const UTM_LATITUDE_BANDS = "CDEFGHJKLMNPQRSTUVWXX";
+const MGRS_COLUMN_LETTER_SETS = ["ABCDEFGH", "JKLMNPQR", "STUVWXYZ"];
+const MGRS_ROW_LETTER_SETS = ["ABCDEFGHJKLMNPQRSTUV", "FGHJKLMNPQRSTUVABCDE"];
 const KEYWORD_EXPANSIONS = {
   route: ["routing", "navigate", "navigation", "path", "corridor", "approach"],
   patrol: ["movement", "move", "walk", "team", "operator"],
@@ -1074,6 +1076,24 @@ function latLonToUtm(lat, lon) {
   };
 }
 
+function utmToMgrs(utm) {
+  const columnSet = MGRS_COLUMN_LETTER_SETS[(utm.zone - 1) % MGRS_COLUMN_LETTER_SETS.length];
+  const rowSet = MGRS_ROW_LETTER_SETS[(utm.zone - 1) % MGRS_ROW_LETTER_SETS.length];
+  const columnIndex = clampNumber(Math.floor(utm.easting / 100000) - 1, 0, columnSet.length - 1);
+  const rowIndex = Math.floor(utm.northing / 100000) % rowSet.length;
+  const square = `${columnSet[columnIndex]}${rowSet[rowIndex]}`;
+  const easting = (utm.easting % 100000).toString().padStart(5, "0");
+  const northing = (utm.northing % 100000).toString().padStart(5, "0");
+  return `${utm.zone}${utm.band} ${square} ${easting} ${northing}`;
+}
+
+function latLonToMgrs(lat, lon) {
+  if (lat < -80 || lat >= 84) {
+    return "MGRS unavailable";
+  }
+  return utmToMgrs(latLonToUtm(lat, lon));
+}
+
 function updateCenterGrid() {
   const center = getMapCenterPoint();
   if (!center) {
@@ -1082,10 +1102,7 @@ function updateCenterGrid() {
     return;
   }
 
-  const utm = latLonToUtm(center.lat, center.lon);
-  els.centerGridValue.textContent = `UTM ${utm.zone}${utm.band} ${utm.easting
-    .toString()
-    .padStart(6, "0")}E ${utm.northing.toString().padStart(7, "0")}N`;
+  els.centerGridValue.textContent = `MGRS ${latLonToMgrs(center.lat, center.lon)}`;
   els.centerGridLatLon.textContent = `${center.lat.toFixed(5)}, ${center.lon.toFixed(5)}`;
 }
 

--- a/llm_dev_kmh/static/index.html
+++ b/llm_dev_kmh/static/index.html
@@ -46,11 +46,11 @@
               <label id="providerClaudeModelRow" class="hidden">
                 Claude model
                 <select id="claudeModelSelect">
-                  <option value="claude-sonnet-4-6" selected>Claude Sonnet 4.6</option>
+                  <option value="claude-sonnet-4-20250514" selected>Claude Sonnet 4</option>
                   <option value="claude-opus-4-7">Claude Opus 4.7</option>
+                  <option value="claude-opus-4-20250514">Claude Opus 4</option>
                   <option value="claude-opus-4-1-20250805">Claude Opus 4.1</option>
                   <option value="claude-haiku-4-5">Claude Haiku 4.5</option>
-                  <option value="claude-sonnet-4-20250514">Claude Sonnet 4</option>
                   <option value="claude-3-7-sonnet-20250219">Claude Sonnet 3.7</option>
                   <option value="claude-3-5-haiku-20241022">Claude Haiku 3.5</option>
                 </select>
@@ -184,6 +184,25 @@
                     <button id="clearAreaBtn" class="ghost-button small-button" type="button">Clear AO</button>
                   </div>
                 </div>
+                <div id="jetsonStorageCard" class="storage-card" aria-live="polite">
+                  <div class="storage-header">
+                    <div>
+                      <div class="section-subtitle">Jetson Storage</div>
+                      <div id="storageRoot" class="section-meta">Checking package root...</div>
+                    </div>
+                    <span id="storageFitChip" class="chip">Checking</span>
+                  </div>
+                  <div class="storage-meter" aria-hidden="true">
+                    <span id="storageMeterUsed"></span>
+                    <span id="storageMeterReserve"></span>
+                  </div>
+                  <div class="storage-grid">
+                    <span>Free</span><strong id="storageFree">--</strong>
+                    <span>Usable</span><strong id="storageUsable">--</strong>
+                    <span>Reserve</span><strong id="storageReserve">--</strong>
+                    <span>Estimate</span><strong id="storageEstimate">--</strong>
+                  </div>
+                </div>
                 <div class="button-row source-actions">
                   <button id="buildPackageBtn" class="primary-button" type="button">Build Manifest</button>
                 </div>
@@ -194,6 +213,12 @@
           <div id="packageStatus" class="section-meta">No sources selected yet. Send a mission description to plan the needed package.</div>
           <pre id="packageManifest" class="package-output hidden"></pre>
           <a id="downloadManifestLink" class="download-link hidden" href="#" download>Download manifest JSON</a>
+          <div id="packageExecutionActions" class="button-row package-execution-actions hidden">
+            <button id="downloadToJetsonBtn" class="primary-button" type="button">Download to Jetson</button>
+            <button id="refreshPackageStatusBtn" class="ghost-button" type="button">Refresh Status</button>
+          </div>
+          <div id="packageExecutionStatus" class="package-status-grid hidden" aria-live="polite"></div>
+          <pre id="packageArtifacts" class="package-output hidden"></pre>
         </section>
 
         <section class="sidebar-card panel-chat-shell chat-panel-shell">
@@ -231,9 +256,10 @@
                     <label>
                       Imagery stream
                       <select id="imagerySelect">
-                        <option value="esri">Esri World Imagery</option>
                         <option value="ion-satellite">Cesium World Imagery</option>
+                        <option value="usgs-imagery">USGS Imagery Only</option>
                         <option value="osm">OpenStreetMap</option>
+                        <option value="esri">Esri World Imagery</option>
                       </select>
                     </label>
                     <label>

--- a/llm_dev_kmh/static/index.html
+++ b/llm_dev_kmh/static/index.html
@@ -15,12 +15,55 @@
   <div class="app-shell">
     <header class="top-bar">
       <div>
-        <div class="eyebrow">Mission data sourcing workspace</div>
         <h1>TERA Source Planner</h1>
+        <div class="eyebrow">Mission data sourcing workspace</div>
       </div>
       <div class="top-bar-controls">
+        <button id="importOverlayBtn" class="ghost-button" type="button">Import KML/KMZ</button>
+        <input id="overlayFileInput" class="file-input" type="file" accept=".kml,.kmz,application/vnd.google-earth.kml+xml,application/vnd.google-earth.kmz" />
         <span class="chip" id="tokenChip">Cesium token: checking</span>
-        <span class="chip" id="ollamaChip">Ollama: checking</span>
+        <div class="top-provider-shell">
+          <button id="modelProviderBtn" class="chip chip-button" type="button" aria-expanded="false" aria-controls="modelProviderMenu">Model: checking</button>
+          <div id="modelProviderMenu" class="provider-menu hidden">
+            <div class="settings-menu-header">
+              <strong>Model Provider</strong>
+              <span id="providerStatus" class="section-meta">Checking</span>
+            </div>
+            <div class="settings-grid">
+              <label>
+                Provider
+                <select id="providerSelect">
+                  <option value="ollama" selected>Local Ollama</option>
+                  <option value="claude">Claude API</option>
+                </select>
+              </label>
+              <label id="providerLocalModelRow">
+                Local model
+                <select id="topModelSelect">
+                  <option value="">Loading models...</option>
+                </select>
+              </label>
+              <label id="providerClaudeModelRow" class="hidden">
+                Claude model
+                <select id="claudeModelSelect">
+                  <option value="claude-sonnet-4-20250514" selected>Claude Sonnet 4</option>
+                  <option value="claude-opus-4-1-20250805">Claude Opus 4.1</option>
+                  <option value="claude-3-7-sonnet-20250219">Claude Sonnet 3.7</option>
+                  <option value="claude-3-5-haiku-20241022">Claude Haiku 3.5</option>
+                </select>
+              </label>
+              <label id="providerClaudeKeyRow" class="span-2 hidden">
+                Claude API key
+                <input id="claudeApiKeyInput" type="password" autocomplete="off" placeholder="sk-ant-..." />
+              </label>
+            </div>
+            <div class="provider-actions">
+              <button id="saveProviderBtn" class="primary-button" type="button">Use Provider</button>
+              <button id="clearClaudeKeyBtn" class="ghost-button" type="button">Clear Key</button>
+            </div>
+            <div class="section-meta">Claude keys stay in this browser session and are sent only with prompt requests.</div>
+          </div>
+        </div>
         <button id="panelToggleBtn" class="ghost-button" type="button" aria-expanded="true">Collapse Planner</button>
       </div>
     </header>
@@ -28,6 +71,21 @@
     <div class="workspace-shell">
       <main class="map-stage">
         <div id="cesiumContainer" class="map-canvas"></div>
+        <div id="locationSearchPanel" class="map-overlay top-left map-search-panel" role="search">
+          <form id="locationSearchForm" class="location-search-form">
+            <label class="visually-hidden" for="locationSearchInput">Mission location search</label>
+            <input
+              id="locationSearchInput"
+              type="search"
+              autocomplete="off"
+              placeholder="Search mission location or paste lat, lon"
+              aria-autocomplete="list"
+              aria-controls="locationSearchSuggestions"
+            />
+            <button class="ghost-button" type="submit">Go</button>
+          </form>
+          <div id="locationSearchSuggestions" class="location-suggestions hidden" role="listbox"></div>
+        </div>
         <div class="map-overlay top-right">
           <div class="map-instruments" aria-label="Map orientation controls">
             <div class="instrument-row">
@@ -52,6 +110,11 @@
             </div>
             <button id="mapResetViewBtn" class="map-reset-button" type="button">Reset View</button>
           </div>
+        </div>
+        <div class="map-overlay bottom-left center-grid-panel" aria-live="polite">
+          <div class="section-subtitle">Center Grid</div>
+          <div id="centerGridValue" class="center-grid-value">--</div>
+          <div id="centerGridLatLon" class="center-grid-latlon">--</div>
         </div>
       </main>
 
@@ -131,7 +194,7 @@
             </div>
           </div>
 
-          <div id="packageStatus" class="section-meta">No sources selected yet. Send a mission description to infer the needed package.</div>
+          <div id="packageStatus" class="section-meta">No sources selected yet. Send a mission description to plan the needed package.</div>
           <pre id="packageManifest" class="package-output hidden"></pre>
           <a id="downloadManifestLink" class="download-link hidden" href="#" download>Download manifest JSON</a>
         </section>

--- a/llm_dev_kmh/static/index.html
+++ b/llm_dev_kmh/static/index.html
@@ -22,6 +22,7 @@
         <button id="importOverlayBtn" class="ghost-button" type="button">Import KML/KMZ</button>
         <input id="overlayFileInput" class="file-input" type="file" accept=".kml,.kmz,application/vnd.google-earth.kml+xml,application/vnd.google-earth.kmz" />
         <span class="chip" id="tokenChip">Cesium token: checking</span>
+        <button id="atakAgentBtn" class="chip chip-button" type="button">ATAK Local</button>
         <div class="top-provider-shell">
           <button id="modelProviderBtn" class="chip chip-button" type="button" aria-expanded="false" aria-controls="modelProviderMenu">Model: checking</button>
           <div id="modelProviderMenu" class="provider-menu hidden">
@@ -47,7 +48,7 @@
               <label id="providerClaudeModelRow" class="hidden">
                 Claude model
                 <select id="claudeModelSelect">
-                  <option value="claude-sonnet-4-20250514" selected>Claude Sonnet 4.6</option>
+                  <option value="claude-sonnet-4-6" selected>Claude Sonnet 4.6</option>
                   <option value="claude-opus-4-1-20250805">Claude Opus 4.1</option>
                   <option value="claude-opus-4-20250514">Claude Opus 4</option>
                   <option value="claude-3-7-sonnet-20250219">Claude Sonnet 3.7</option>
@@ -241,6 +242,7 @@
                       Agent profile
                       <select id="agentProfileSelect">
                         <option value="imagery-sourcing" selected>Imagery Sourcing</option>
+                        <option value="tera-atak-live">TERA ATAK Link</option>
                         <option value="terrain-route">Terrain Route</option>
                         <option value="map-analysis">Map Analysis</option>
                         <option value="survival-sar">Survival / SAR</option>
@@ -308,6 +310,17 @@
           </div>
 
           <div id="chatLog" class="chat-log"></div>
+
+          <section id="atakMirrorPanel" class="atak-mirror-panel hidden" aria-live="polite">
+            <div class="atak-mirror-header">
+              <div>
+                <div class="section-subtitle">ATAK Mirror</div>
+                <div id="atakMirrorStatus" class="section-meta">Waiting for ATAK traffic</div>
+              </div>
+              <button id="atakMirrorRefreshBtn" class="ghost-button small-button" type="button">Refresh</button>
+            </div>
+            <div id="atakMirrorLog" class="atak-mirror-log"></div>
+          </section>
 
           <form id="promptForm" class="chat-composer" autocomplete="off">
             <textarea id="promptInput" name="prompt" placeholder="We need an offline package for a patrol to find the nearest reliable water source while avoiding steep exposed terrain." required></textarea>

--- a/llm_dev_kmh/static/index.html
+++ b/llm_dev_kmh/static/index.html
@@ -130,7 +130,7 @@
             <span id="packageModeChip" class="chip">Awaiting mission</span>
           </div>
 
-          <div id="workflowEmpty" class="workflow-empty">Describe the mission in chat to begin source planning.</div>
+          <div id="workflowEmpty" class="workflow-empty" aria-hidden="true"></div>
 
           <div id="workflowCarousel" class="workflow-carousel hidden" aria-live="polite">
             <div class="workflow-nav">
@@ -154,13 +154,6 @@
                     Package name
                     <input id="packageNameInput" type="text" placeholder="sf-water-route-package" />
                   </label>
-                </div>
-              </section>
-
-              <section class="workflow-slide" data-workflow-slide="questions">
-                <div class="workflow-card">
-                  <div class="section-subtitle">Socratic questions</div>
-                  <ul id="clarifyingQuestions" class="question-list"></ul>
                 </div>
               </section>
 

--- a/llm_dev_kmh/static/index.html
+++ b/llm_dev_kmh/static/index.html
@@ -33,7 +33,8 @@
               <label>
                 Provider
                 <select id="providerSelect">
-                  <option value="ollama" selected>Local Ollama</option>
+                  <option value="auto" selected>Auto: Claude -> Local</option>
+                  <option value="ollama">Local Ollama</option>
                   <option value="claude">Claude API</option>
                 </select>
               </label>
@@ -46,11 +47,9 @@
               <label id="providerClaudeModelRow" class="hidden">
                 Claude model
                 <select id="claudeModelSelect">
-                  <option value="claude-sonnet-4-20250514" selected>Claude Sonnet 4</option>
-                  <option value="claude-opus-4-7">Claude Opus 4.7</option>
-                  <option value="claude-opus-4-20250514">Claude Opus 4</option>
+                  <option value="claude-sonnet-4-20250514" selected>Claude Sonnet 4.6</option>
                   <option value="claude-opus-4-1-20250805">Claude Opus 4.1</option>
-                  <option value="claude-haiku-4-5">Claude Haiku 4.5</option>
+                  <option value="claude-opus-4-20250514">Claude Opus 4</option>
                   <option value="claude-3-7-sonnet-20250219">Claude Sonnet 3.7</option>
                   <option value="claude-3-5-haiku-20241022">Claude Haiku 3.5</option>
                 </select>

--- a/llm_dev_kmh/static/index.html
+++ b/llm_dev_kmh/static/index.html
@@ -46,8 +46,11 @@
               <label id="providerClaudeModelRow" class="hidden">
                 Claude model
                 <select id="claudeModelSelect">
-                  <option value="claude-sonnet-4-20250514" selected>Claude Sonnet 4</option>
+                  <option value="claude-sonnet-4-6" selected>Claude Sonnet 4.6</option>
+                  <option value="claude-opus-4-7">Claude Opus 4.7</option>
                   <option value="claude-opus-4-1-20250805">Claude Opus 4.1</option>
+                  <option value="claude-haiku-4-5">Claude Haiku 4.5</option>
+                  <option value="claude-sonnet-4-20250514">Claude Sonnet 4</option>
                   <option value="claude-3-7-sonnet-20250219">Claude Sonnet 3.7</option>
                   <option value="claude-3-5-haiku-20241022">Claude Haiku 3.5</option>
                 </select>
@@ -109,6 +112,7 @@
               </div>
             </div>
             <button id="mapResetViewBtn" class="map-reset-button" type="button">Reset View</button>
+            <button id="mapModeToggleBtn" class="ghost-button map-mode-toggle" type="button" aria-pressed="false">3D View</button>
           </div>
         </div>
         <div class="map-overlay bottom-left center-grid-panel" aria-live="polite">
@@ -194,9 +198,9 @@
 
         <section class="sidebar-card panel-chat-shell chat-panel-shell">
           <div class="section-header rail-header chat-panel-header">
-            <div>
-              <h2>Source Advisor</h2>
-              <div id="requestStatus" class="section-meta">Idle</div>
+            <div class="visually-hidden">
+              <h2>Advisor conversation</h2>
+              <div id="requestStatus" class="section-meta" aria-live="polite">Idle</div>
             </div>
             <div class="panel-header-actions">
               <div class="settings-shell">
@@ -296,6 +300,7 @@
     window.CESIUM_BASE_URL = "https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/";
   </script>
   <script src="https://cesium.com/downloads/cesiumjs/releases/1.124/Build/Cesium/Cesium.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
   <script type="module" src="/static/app.js"></script>
 </body>
 </html>

--- a/llm_dev_kmh/static/styles.css
+++ b/llm_dev_kmh/static/styles.css
@@ -302,9 +302,20 @@ textarea {
 }
 
 .location-suggestion-status {
+  display: grid;
+  gap: var(--space-1);
   padding: var(--space-2);
   color: var(--color-text-secondary);
   font-size: var(--text-sm);
+}
+
+.location-suggestion-external {
+  color: var(--color-accent-gold);
+  text-decoration: none;
+}
+
+.location-suggestion-external:hover {
+  color: var(--color-accent-gold-dim);
 }
 
 .center-grid-panel {
@@ -330,6 +341,10 @@ textarea {
   display: grid;
   gap: var(--space-1);
   justify-items: end;
+}
+
+.map-mode-toggle {
+  width: 100%;
 }
 
 .instrument-row {

--- a/llm_dev_kmh/static/styles.css
+++ b/llm_dev_kmh/static/styles.css
@@ -20,12 +20,12 @@
 
   --text-xs: 10px;
   --text-sm: 12px;
-  --text-base: 13px;
-  --text-md: 14px;
-  --text-lg: 16px;
-  --text-xl: 20px;
-  --text-2xl: 24px;
-  --text-display: 34px;
+  --text-base: 12px;
+  --text-md: 13px;
+  --text-lg: 15px;
+  --text-xl: 18px;
+  --text-2xl: 22px;
+  --text-display: 32px;
 
   --space-1: 4px;
   --space-2: 8px;
@@ -647,8 +647,8 @@ textarea {
 
 .workflow-carousel {
   display: grid;
-  gap: var(--space-2);
-  margin-top: var(--space-2);
+  gap: var(--space-1);
+  margin-top: var(--space-1);
 }
 
 .workflow-nav {
@@ -705,7 +705,7 @@ textarea {
 
 .workflow-slide.active {
   display: grid;
-  gap: var(--space-2);
+  gap: var(--space-1);
 }
 
 .workflow-card,
@@ -719,7 +719,7 @@ textarea {
 
 .workflow-card {
   display: grid;
-  gap: var(--space-2);
+  gap: var(--space-1);
   padding: var(--space-2);
   color: var(--color-text-secondary);
   font-size: var(--text-sm);
@@ -729,7 +729,7 @@ textarea {
   margin: 0;
   padding-left: var(--space-4);
   display: grid;
-  gap: var(--space-2);
+  gap: var(--space-1);
   color: var(--color-text-secondary);
 }
 
@@ -781,17 +781,17 @@ textarea {
 
 .source-list {
   display: grid;
-  gap: var(--space-2);
-  max-height: min(42vh, 460px);
+  gap: var(--space-1);
+  max-height: min(18vh, 180px);
   overflow: auto;
-  margin: var(--space-2) 0;
+  margin: var(--space-1) 0;
   padding-right: var(--space-1);
 }
 
 .source-item {
   display: grid;
-  gap: var(--space-2);
-  padding: var(--space-2);
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
 }
 
 .source-item[data-selected="true"] {
@@ -801,11 +801,12 @@ textarea {
 
 .source-item-header {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr);
   gap: var(--space-2);
   align-items: center;
   color: var(--color-text-primary);
   cursor: pointer;
+  min-height: 22px;
 }
 
 .source-item-header input,
@@ -819,6 +820,7 @@ textarea {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-weight: 700;
+  font-size: var(--text-sm);
 }
 
 .source-category {
@@ -850,7 +852,7 @@ textarea {
 }
 
 .source-actions {
-  margin-bottom: var(--space-2);
+  margin-bottom: var(--space-1);
 }
 
 .package-output {
@@ -1011,7 +1013,7 @@ textarea {
 }
 
 .chat-composer textarea {
-  min-height: 92px;
+  min-height: 76px;
 }
 
 .composer-actions {

--- a/llm_dev_kmh/static/styles.css
+++ b/llm_dev_kmh/static/styles.css
@@ -1090,6 +1090,65 @@ textarea {
   padding: 0 var(--space-1) 0 0;
 }
 
+.atak-mirror-panel {
+  display: grid;
+  gap: var(--space-2);
+  flex: 0 0 auto;
+  max-height: min(32vh, 260px);
+  margin-top: var(--space-2);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--color-border);
+}
+
+.atak-mirror-header {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  justify-content: space-between;
+}
+
+.atak-mirror-log {
+  display: grid;
+  gap: var(--space-2);
+  min-height: 72px;
+  overflow-y: auto;
+}
+
+.atak-mirror-empty {
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+}
+
+.atak-mirror-event {
+  display: grid;
+  gap: var(--space-1);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-status-online);
+  background: var(--color-bg-tertiary);
+}
+
+.atak-mirror-event.inbound {
+  border-left-color: var(--color-accent-gold);
+}
+
+.atak-mirror-event-header {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  justify-content: space-between;
+  color: var(--color-text-secondary);
+  font-family: var(--font-display);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.atak-mirror-event-body {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
 .chat-composer {
   display: grid;
   gap: var(--space-2);

--- a/llm_dev_kmh/static/styles.css
+++ b/llm_dev_kmh/static/styles.css
@@ -133,6 +133,10 @@ h2 {
   justify-content: flex-end;
 }
 
+.top-provider-shell {
+  position: relative;
+}
+
 select,
 textarea,
 input {
@@ -152,6 +156,10 @@ select:focus,
 textarea:focus,
 input:focus {
   border-color: var(--color-accent-gold);
+}
+
+.file-input {
+  display: none;
 }
 
 textarea {
@@ -205,6 +213,111 @@ textarea {
 .top-right {
   top: var(--space-3);
   right: var(--space-3);
+}
+
+.top-left {
+  top: var(--space-3);
+  left: var(--space-3);
+}
+
+.bottom-left {
+  bottom: var(--space-3);
+  left: var(--space-3);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.map-search-panel {
+  width: min(520px, calc(100% - 340px));
+  min-width: 320px;
+}
+
+.location-search-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  background: var(--color-overlay);
+}
+
+.location-search-form input {
+  min-height: 32px;
+  border-color: var(--color-border);
+  background: var(--color-bg-primary);
+}
+
+.location-search-form .ghost-button {
+  min-height: 32px;
+  padding: var(--space-2) var(--space-3);
+}
+
+.location-suggestions {
+  margin-top: var(--space-1);
+  border: 1px solid var(--color-border);
+  background: var(--color-overlay);
+}
+
+.location-suggestion {
+  width: 100%;
+  display: grid;
+  gap: 2px;
+  padding: var(--space-2);
+  border: 0;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.location-suggestion:last-child {
+  border-bottom: 0;
+}
+
+.location-suggestion:hover,
+.location-suggestion.active {
+  color: var(--color-accent-gold);
+  background: var(--color-bg-tertiary);
+}
+
+.location-suggestion-name {
+  font-weight: 700;
+}
+
+.location-suggestion-detail {
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
+  white-space: normal;
+}
+
+.center-grid-panel {
+  min-width: 220px;
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  background: var(--color-overlay);
+}
+
+.center-grid-value {
+  margin-top: var(--space-1);
+  color: var(--color-text-primary);
+  font-weight: 700;
+}
+
+.center-grid-latlon {
+  margin-top: 2px;
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
 }
 
 .map-instruments {
@@ -439,6 +552,35 @@ textarea {
 
 .chip.bad {
   color: var(--color-status-offline);
+}
+
+.chip-button {
+  cursor: pointer;
+}
+
+.chip-button:hover,
+.chip-button[aria-expanded="true"] {
+  border-color: var(--color-accent-gold);
+  color: var(--color-accent-gold);
+}
+
+.provider-menu {
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  right: 0;
+  z-index: 30;
+  width: min(440px, calc(100vw - 40px));
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+}
+
+.provider-actions {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: flex-end;
 }
 
 .primary-button,
@@ -1057,11 +1199,19 @@ textarea {
   width: var(--space-1);
   cursor: col-resize;
   background: var(--color-border);
+  touch-action: none;
+  user-select: none;
 }
 
 .panel-resizer:hover,
 .panel-resizer.is-dragging {
   background: var(--color-accent-gold);
+}
+
+body.is-resizing-panel,
+body.is-resizing-panel * {
+  cursor: col-resize !important;
+  user-select: none !important;
 }
 
 body.panel-collapsed .panel-resizer,
@@ -1098,6 +1248,21 @@ body.panel-collapsed .workspace-shell {
     flex-wrap: wrap;
   }
 
+  .top-provider-shell {
+    width: 100%;
+  }
+
+  .chip-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .provider-menu {
+    left: 0;
+    right: auto;
+    width: 100%;
+  }
+
   .workspace-shell {
     grid-template-columns: 1fr;
     height: auto;
@@ -1109,6 +1274,15 @@ body.panel-collapsed .workspace-shell {
 
   .map-stage {
     min-height: 50vh;
+  }
+
+  .map-search-panel {
+    width: calc(100% - var(--space-6));
+    min-width: 0;
+  }
+
+  .center-grid-panel {
+    max-width: calc(100% - var(--space-6));
   }
 
   .agent-panel {

--- a/llm_dev_kmh/static/styles.css
+++ b/llm_dev_kmh/static/styles.css
@@ -238,8 +238,8 @@ textarea {
 }
 
 .map-search-panel {
-  width: min(520px, calc(100% - 340px));
-  min-width: 320px;
+  width: min(312px, max(240px, calc((100% - 340px) * 0.6)));
+  min-width: 240px;
 }
 
 .location-search-form {
@@ -299,6 +299,12 @@ textarea {
   color: var(--color-text-secondary);
   font-size: var(--text-xs);
   white-space: normal;
+}
+
+.location-suggestion-status {
+  padding: var(--space-2);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
 }
 
 .center-grid-panel {
@@ -643,6 +649,10 @@ textarea {
   margin-top: var(--space-2);
   color: var(--color-text-secondary);
   font-size: var(--text-sm);
+}
+
+.workflow-empty:empty {
+  display: none;
 }
 
 .workflow-carousel {

--- a/llm_dev_kmh/static/styles.css
+++ b/llm_dev_kmh/static/styles.css
@@ -800,6 +800,67 @@ textarea {
   justify-content: flex-end;
 }
 
+.storage-card {
+  display: grid;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-tertiary);
+}
+
+.storage-header {
+  display: flex;
+  gap: var(--space-2);
+  align-items: start;
+  justify-content: space-between;
+}
+
+.storage-meter {
+  position: relative;
+  height: 10px;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-primary);
+}
+
+.storage-meter span {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+}
+
+#storageMeterUsed {
+  background: var(--color-accent-gold);
+}
+
+#storageMeterReserve {
+  background: rgba(239, 68, 68, 0.6);
+}
+
+.storage-grid,
+.package-status-grid {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-1) var(--space-2);
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
+}
+
+.storage-grid strong,
+.package-status-grid strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--color-text-primary);
+  text-align: right;
+}
+
+.package-execution-actions {
+  margin-top: var(--space-2);
+  justify-content: flex-start;
+}
+
 .map-stage.is-drawing-area .cesium-widget canvas {
   cursor: crosshair;
 }

--- a/prompts/local_model_prompts/imagery_sourcing_local_model_system_prompt.md
+++ b/prompts/local_model_prompts/imagery_sourcing_local_model_system_prompt.md
@@ -60,23 +60,51 @@ Downstream TAK output target:
   Source it when it changes route computation, POI discovery, hazard exclusion,
   confidence, or operator decision overlays.
 
-Primary streamable layers in this web app:
-- Esri World Imagery: high-value visual context for roads, tracks, buildings,
-  vegetation patterns, water bodies, clearings, recent construction, and AO
-  sanity checks. It is not a routable graph or authoritative terrain source.
+Primary streamable and downloadable imagery layers in this web app:
+- Cesium World Imagery: the token-backed visual stream available to this
+  planner. Use it for AO preview, manual sanity checks, and operator context
+  while the Jetson is online. Do not download, scrape, or store Cesium ion
+  imagery/terrain into offline Jetson packages unless the team has an explicit
+  Cesium offline license or clip/export grant. It is not a routable graph or
+  authoritative terrain source.
+- Cesium ion Offline Archive: the only valid Cesium download path in this app.
+  If a mission explicitly needs Cesium on the Jetson, require a completed
+  CESIUM_ION_ARCHIVE_ID or clippable CESIUM_ION_ASSET_IDS plus CESIUM_ION_TOKEN.
+  The Jetson downloads the archive, extracts it, indexes tileset/layer metadata,
+  and serves local files for preview/query. Do not claim that a plain World
+  Imagery/Terrain stream token grants offline download rights.
+- NAIP: primary high-resolution U.S. imagery for this workflow. Prefer staged
+  EarthExplorer GeoTIFFs when the operator has downloaded them, otherwise use
+  the public NAIP AWS prefix path (for example `naip-analytic/<state>/<year>/
+  <resolution>/rgbir/`) with storage limits. The Jetson indexes and serves the
+  local NAIP files to the planner and TERA plugin.
+- Sentinel-2 Cloud Optimized GeoTIFFs: global fallback free downloadable imagery
+  when NAIP is outside coverage or not suitable. Query Earth Search STAC for
+  AO-intersecting COG assets and save selected visual/RGB/NIR/SCL bands to the
+  Jetson.
+- Esri World Imagery: optional licensed imagery only. Do not require it in this
+  workflow unless the planner explicitly has an ArcGIS token/account. The current
+  assumed token is Cesium only.
+- Copernicus DEM GLO-30: primary no-login terrain source for this planner.
+  Download AO-intersecting public S3 COG tiles and feed slope, flow,
+  cost-distance, viewshed, and isochrone algorithms.
+- DTED from USGS EarthExplorer: use when the operator has staged .dt2 files from
+  EarthExplorer. The Jetson imports the files and converts them with
+  `gdal_translate input.dt2 output.tif` when GDAL is available.
 - Terrain display layer: useful for 3D operator preview, landform awareness,
-  ridge/valley interpretation, and manual AO review. Use analysis DEMs for
-  slope, viewshed, hydrology, and cost surfaces.
+  ridge/valley interpretation, and manual AO review. Use queryable terrain DEMs
+  for slope, viewshed, hydrology, and cost surfaces.
 - OpenStreetMap basemap: useful visual and vector context for roads, trails,
   paths, waterways, buildings, POIs, barriers, and place names. Use an OSM PBF
   extract for server-side graph routing and POI queries.
 
 Data source knowledge:
-- DEM / terrain: USGS 3DEP is the best U.S. default; Copernicus DEM is a strong
-  global default; Esri World Elevation Terrain is a queryable online fallback
-  that can be clipped/cached for terrain queries when primary DEM downloads are
-  delayed; SRTM is the broad global fallback; OpenTopography is useful for
-  lidar/regional DEM discovery; ArcticDEM/REMA support polar regions. Terrain
+- DEM / terrain: Copernicus DEM GLO-30 COGs are the planner's primary no-login
+  queryable terrain source. DTED from EarthExplorer is a staged import path when
+  the operator has USGS credentials and .dt2 cells; USGS 3DEP is the best U.S.
+  authoritative supplement; SRTM is the broad global
+  fallback; OpenTopography is useful for lidar/regional DEM discovery;
+  ArcticDEM/REMA support polar regions. Terrain
   enables slope, aspect, roughness, curvature, TPI, ridges/valleys, contours,
   hydrology, viewshed, least-cost routing, avalanche/flood/cliff screening, and
   signal line-of-sight estimation.
@@ -97,12 +125,13 @@ Data source knowledge:
   source lookup, crossings, floodplain risk, flow context, drainage, and route
   constraints. OSM water is useful but not enough by itself for high-confidence
   hydrology.
-- Imagery: Esri imagery is the main visual stream. Sentinel-2 supports
-  multispectral vegetation and water indices; Landsat supports historical
-  change; NAIP gives high-resolution U.S. aerial imagery; Sentinel-1 SAR helps
-  with cloud/night/flood observations; MODIS/VIIRS support broad-area current
-  hazard context; commercial Planet/Maxar can provide high-detail current AO
-  evidence when licensed.
+- Imagery: NAIP is the U.S. downloadable default for high-detail aerial context;
+  Sentinel-2 COGs are the global free fallback; Cesium imagery is preview-only
+  unless a licensed archive/export exists. Landsat supports historical change;
+  Sentinel-1 SAR helps with
+  cloud/night/flood observations; MODIS/VIIRS support broad-area current hazard
+  context; commercial Planet/Maxar can provide high-detail current AO evidence
+  when licensed.
 - Hazards and weather: NOAA/NWS alerts, nowCOAST, NWPS, NASA FIRMS, FEMA flood
   products, DOT closures, SNOTEL, avalanche centers, and tide/current products
   are needed when time-sensitive hazards affect route safety or data freshness.

--- a/prompts/local_model_prompts/imagery_sourcing_local_model_system_prompt.md
+++ b/prompts/local_model_prompts/imagery_sourcing_local_model_system_prompt.md
@@ -18,16 +18,25 @@ survival/SAR queries, field logistics, route visualization, and local model
 reasoning. Your job is to advise which data sources must be included, which are
 optional enhancers, and which are unnecessary for the user's mission.
 
-Use a Socratic sourcing dialogue. Do not start by dumping a catalog or final
-manifest. Start by reflecting the mission as you understand it, then ask the
-few questions that would most change the source package. Each question should
-make the planner choose between a broader package and a smaller package.
-Explain the source decision that depends on the answer.
+Use a Socratic sourcing dialogue that drives to mission scope in the fewest
+useful turns. Do not start by dumping a catalog or final manifest. Start by
+reflecting the mission as you understand it, then ask the smallest set of
+ranked questions that would most change the source package. Combine missing
+AO, objective, movement mode, time horizon, and constraints into one scope pass
+when possible. Each question should make the planner choose between a broader
+package and a smaller package. Explain the source decision that depends on the
+answer.
 
 The planner should not have to pick a mission category manually. Infer the
 mission from the chat description, identify the features the eventual operator
 will ask the database to support, and keep the source package as small as
 possible while still enabling those features.
+
+The planner must move the map to the mission area before final source
+confirmation. If the current map focus is not confirmed, tell the planner to
+use the map location search, import a KML/KMZ mission overlay, or draw the AO
+rectangle after source families are understood. Do not treat the default camera
+view as the mission AO.
 
 Core operating principle:
 - Streamed basemaps are display context.
@@ -64,7 +73,9 @@ Primary streamable layers in this web app:
 
 Data source knowledge:
 - DEM / terrain: USGS 3DEP is the best U.S. default; Copernicus DEM is a strong
-  global default; SRTM is the global fallback; OpenTopography is useful for
+  global default; Esri World Elevation Terrain is a queryable online fallback
+  that can be clipped/cached for terrain queries when primary DEM downloads are
+  delayed; SRTM is the broad global fallback; OpenTopography is useful for
   lidar/regional DEM discovery; ArcticDEM/REMA support polar regions. Terrain
   enables slope, aspect, roughness, curvature, TPI, ridges/valleys, contours,
   hydrology, viewshed, least-cost routing, avalanche/flood/cliff screening, and
@@ -105,8 +116,8 @@ Data source knowledge:
   opportunity, relay placement, and open-sky/satellite messenger analysis.
 
 How to decide:
-1. Normalize the mission: AO, objective, mode, time horizon, constraints, and
-   outputs the database must support.
+1. Normalize the mission: confirmed AO/map focus, objective, mode, time
+   horizon, constraints, and outputs the database must support.
 2. Mark sources REQUIRED when the requested mission cannot be answered
    deterministically without them.
 3. Mark sources OPTIONAL when they improve confidence, freshness, or tactical
@@ -119,10 +130,11 @@ How to decide:
    broad all-domain package. Over-selecting sources makes the download too slow
    and the edge database too large.
 8. Ask at most three clarifying questions, and only ask questions that would
-   materially change which sources get downloaded.
+   materially change which sources get downloaded. Prefer a single combined
+   scope question set over multiple back-and-forth turns.
 9. Prefer one high-leverage question at a time when the planner's intent is
    underspecified. If multiple decisions are urgent, ask up to three in ranked
-   order.
+   order and identify which answer lets you finalize the package.
 10. For every question, state what a broad answer would add and what a narrow
     answer would omit.
 11. Do not ask for rectangle/AO drawing until the mission scope and source

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -220,6 +220,7 @@ def test_anthropic_complete_structured(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_ollama_complete_structured(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+    monkeypatch.delenv("OLLAMA_MODEL", raising=False)
     fake_response = {"message": {"content": '{"a": 1}'}}
     with patch("agent.llm.OllamaLib") as mock_ollama_cls:
         mock_ollama_cls.return_value.chat.return_value = fake_response
@@ -228,6 +229,7 @@ def test_ollama_complete_structured(monkeypatch: pytest.MonkeyPatch) -> None:
             messages=[Message(role="user", content="x")],
             schema={"type": "object"},
         )
+    assert client.model == "gemma3:4b"
     assert result == {"a": 1}
 
 

--- a/tests/test_llm_dev_stream.py
+++ b/tests/test_llm_dev_stream.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import zipfile
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -9,6 +10,7 @@ from typing import Any
 import pytest
 
 from llm_dev_kmh import app as kmh_app
+from llm_dev_kmh import geo_algorithms
 
 
 class _FakeStreamContext:
@@ -118,7 +120,7 @@ async def test_prompt_stream_can_use_claude_provider(monkeypatch: pytest.MonkeyP
         kmh_app.PromptRequest(
             prompt="Recommend sources.",
             llm_provider="claude",
-            cloud_model="Claude Sonnet 4.6",
+            cloud_model="Claude Sonnet 4",
             cloud_api_key="sk-ant-test",
         )
     )
@@ -132,7 +134,8 @@ async def test_prompt_stream_can_use_claude_provider(monkeypatch: pytest.MonkeyP
 
 
 @pytest.mark.asyncio
-async def test_prompt_stream_reports_missing_claude_key() -> None:
+async def test_prompt_stream_reports_missing_claude_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     response = await kmh_app.prompt_ollama_stream(
         kmh_app.PromptRequest(
             prompt="Recommend sources.",
@@ -145,6 +148,29 @@ async def test_prompt_stream_reports_missing_claude_key() -> None:
 
     assert '"type": "error"' in body
     assert "Claude API key required" in body
+
+
+@pytest.mark.asyncio
+async def test_prompt_stream_uses_server_claude_key_when_browser_key_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _FakeAsyncClient.response = _ClaudeResponse()
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-server-test")
+    monkeypatch.setattr(kmh_app.httpx, "AsyncClient", _FakeAsyncClient)
+
+    response = await kmh_app.prompt_ollama_stream(
+        kmh_app.PromptRequest(
+            prompt="Recommend sources.",
+            llm_provider="claude",
+            cloud_model="Claude Sonnet 4",
+        )
+    )
+
+    body = await _collect_stream(response)
+
+    assert '"provider": "claude"' in body
+    assert "Claude source recommendation." in body
+    assert '"type": "done"' in body
 
 
 def test_imagery_sourcing_prompt_uses_socratic_dialogue() -> None:
@@ -211,8 +237,8 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
         'id="claudeModelSelect"',
         'id="claudeApiKeyInput"',
         "Claude API",
-        "claude-sonnet-4-6",
-        "Claude Sonnet 4.6",
+        "claude-sonnet-4-20250514",
+        "Claude Sonnet 4",
     ]:
         assert token in html
 
@@ -228,6 +254,7 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
         "teraLlmProvider",
         "teraClaudeApiKey",
         "serverClaudeKeyAvailable",
+        "hasClaudeProviderCredential",
         "anthropic_api_key_configured",
         "applyProviderSelection",
         "void loadModels();",
@@ -244,9 +271,11 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
         "ANTHROPIC_VERSION",
         "CLAUDE_MODEL",
         "CLAUDE_MODEL_ALIASES",
+        "CLAUDE_MODEL_FALLBACKS",
         "claude_default_model",
         "anthropic_api_key_configured",
         "_normalize_claude_model",
+        "_claude_model_candidates",
         "_select_ollama_default_model",
         "Auto-detected installed Gemma model",
         "_post_claude_message",
@@ -256,9 +285,9 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
 
 
 def test_claude_model_labels_normalize_to_current_sonnet() -> None:
-    assert kmh_app._normalize_claude_model("Claude Sonnet 4.6") == "claude-sonnet-4-6"
-    assert kmh_app._normalize_claude_model("claude-sonnet-4.6") == "claude-sonnet-4-6"
-    assert kmh_app._normalize_claude_model("claude-sonnet-4-20250514") == "claude-sonnet-4-6"
+    assert kmh_app._normalize_claude_model("Claude Sonnet 4.6") == "claude-sonnet-4-20250514"
+    assert kmh_app._normalize_claude_model("claude-sonnet-4.6") == "claude-sonnet-4-20250514"
+    assert kmh_app._normalize_claude_model("claude-sonnet-4-20250514") == "claude-sonnet-4-20250514"
 
 
 def test_local_model_detection_prefers_installed_gemma_alias() -> None:
@@ -422,7 +451,7 @@ def test_prompt_submission_tries_selected_provider_then_local_then_deterministic
     assert "streamAssistantProvider" in js
     assert "resolveLocalModelForFallback" in js
     assert "Trying local model fallback" in js
-    assert "Claude request failed. Check key, model access, or network." in js
+    assert "Claude request failed; trying detected local Ollama." in js
     assert "deterministic planner response" in js
     assert "Model providers unavailable; deterministic planner response shown." in js
     assert 'provider === "ollama" && !state.localModelAvailable' not in js
@@ -450,19 +479,561 @@ def test_esri_queryable_terrain_is_available_for_download_fallbacks() -> None:
     assert source.category == "terrain"
     assert source.stream_status == "queryable-online"
     assert source.download_status == "download-required"
+    assert source.download_methods
+    assert source.jetson_query_formats
+    assert source.source_url == kmh_app.ESRI_WORLD_ELEVATION_TERRAIN_URL
+    assert "dem_cog" in source.derived_layers
     assert "elevation_samples" in source.derived_layers
     assert "esri_world_elevation" in js
     assert "Esri World Elevation Terrain" in js
     assert "queryable-online" in js
     assert "download-required" in js
-    assert "Esri World Elevation Terrain is a queryable online fallback" in prompt
+    assert "Copernicus DEM GLO-30 COGs are the planner's primary" in prompt
 
     recommendation = kmh_app._infer_source_recommendation(
         "Need a terrain route that avoids steep exposed terrain.",
         None,
     )
-    assert "esri_world_elevation" in recommendation.required_source_ids
-    assert "esri_world_elevation" in recommendation.selected_source_ids
+    assert "copernicus_dem" in recommendation.required_source_ids
+    assert "dted_earth_explorer" in recommendation.optional_source_ids
+    assert "copernicus_dem" in recommendation.selected_source_ids
+
+
+def test_esri_imagery_exports_use_official_export_tiles_contract() -> None:
+    source = kmh_app.SOURCE_BY_ID["esri_world_imagery"]
+
+    assert source.download_status == "export-tiles-with-account"
+    assert source.download_methods
+    export_method = source.download_methods[0]
+    assert export_method.endpoint.endswith("/World_Imagery/MapServer/exportTiles")
+    assert export_method.params["tilePackage"] == "true"
+    assert export_method.params["token"] == "${ESRI_ARCGIS_TOKEN}"
+    assert export_method.requires_account is True
+    assert source.jetson_query_formats[0].artifact_type == "esri_tpkx_imagery_package"
+
+
+def test_free_imagery_sources_use_sentinel_and_wintak_tile_caches() -> None:
+    sentinel = kmh_app.SOURCE_BY_ID["sentinel_2"]
+    naip = kmh_app.SOURCE_BY_ID["naip"]
+    usgs = kmh_app.SOURCE_BY_ID["usgs_imagery_only"]
+    nrl = kmh_app.SOURCE_BY_ID["nrl_naip_conus"]
+    osm = kmh_app.SOURCE_BY_ID["osm_extract"]
+    copernicus = kmh_app.SOURCE_BY_ID["copernicus_dem"]
+    dted = kmh_app.SOURCE_BY_ID["dted_earth_explorer"]
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+    prompt = (
+        Path("prompts/local_model_prompts/imagery_sourcing_local_model_system_prompt.md")
+        .read_text(encoding="utf-8")
+    )
+
+    assert naip.download_methods[0].id == "naip_aws_public_prefix"
+    assert naip.download_methods[0].params["bucket"] == "{naip_aws_bucket}"
+    assert naip.download_methods[0].params["prefix"] == "{naip_s3_prefix}"
+    assert naip.jetson_query_formats[0].artifact_type == "naip_imagery_index"
+    assert sentinel.download_methods[0].endpoint == kmh_app.EARTH_SEARCH_STAC_SEARCH_URL
+    assert sentinel.download_methods[0].params["collections"] == ["sentinel-2-l2a"]
+    assert sentinel.download_methods[0].requires_token_env is None
+    assert sentinel.jetson_query_formats[0].artifact_type == "sentinel2_cog_band_stack"
+    assert osm.download_methods[0].id == "osm_geofabrik_pbf"
+    assert osm.download_methods[0].params["region_url"] == "{geofabrik_osm_pbf_url}"
+    assert copernicus.download_methods[0].id == "copernicus_dem_glo30_cog"
+    assert copernicus.download_methods[0].params["tile_urls"] == "{copernicus_dem_tile_urls}"
+    assert dted.download_methods[0].id == "dted_earthexplorer_import_convert"
+    assert dted.download_status == "manual-stage-import"
+    assert usgs.download_methods[0].id == "usgs_imagery_tile_cache"
+    assert usgs.download_methods[0].requires_token_env is None
+    assert "basemap.nationalmap.gov" in usgs.source_url
+    assert nrl.download_methods[0].id == "nrl_naip_tile_cache"
+    assert "geoint.nrlssc.navy.mil" in nrl.source_url
+    assert "NAIP is the high-detail U.S. imagery default" in js
+    assert "NAIP is the U.S. downloadable default" in prompt
+
+
+def test_naip_osm_and_copernicus_download_params_are_aoi_scoped() -> None:
+    bounds = kmh_app.ViewBounds(
+        west=-117.5,
+        south=36.0,
+        east=-114.0,
+        north=38.5,
+        center_lat=37.2,
+        center_lon=-116.0,
+    )
+
+    assert kmh_app._naip_state_code(bounds) == "nv"
+    assert kmh_app._naip_s3_prefix(bounds) == "nv/2022/60cm/rgbir/"
+    assert kmh_app._geofabrik_region_slug(bounds) == "north-america/us/nevada"
+    assert kmh_app._geofabrik_osm_pbf_url(bounds).endswith(
+        "/north-america/us/nevada-latest.osm.pbf"
+    )
+
+    tiles = kmh_app._copernicus_dem_tiles(bounds)
+    tile_ids = {tile["tile_id"] for tile in tiles}
+    assert "Copernicus_DSM_COG_10_N36_00_W118_00_DEM" in tile_ids
+    assert "Copernicus_DSM_COG_10_N38_00_W115_00_DEM" in tile_ids
+
+
+def test_cesium_sources_are_stream_only_not_offline_downloads() -> None:
+    imagery = kmh_app.SOURCE_BY_ID["cesium_world_imagery"]
+    terrain = kmh_app.SOURCE_BY_ID["cesium_world_terrain"]
+    archive = kmh_app.SOURCE_BY_ID["cesium_ion_archive"]
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+
+    assert imagery.download_status == "stream-only-no-offline-copy"
+    assert terrain.download_status == "stream-only-no-offline-copy"
+    assert imagery.download_methods == []
+    assert terrain.download_methods == []
+    assert archive.download_status == "download-required"
+    assert {method.id for method in archive.download_methods} == {
+        "cesium_ion_archive_download",
+        "cesium_ion_clip_create_download",
+    }
+    assert archive.download_methods[0].endpoint == kmh_app.CESIUM_ION_ARCHIVE_DOWNLOAD_URL
+    assert archive.download_methods[0].params["archive_id"] == "${CESIUM_ION_ARCHIVE_ID}"
+    assert archive.download_methods[0].params["token"] == "${CESIUM_ION_TOKEN}"
+    assert archive.jetson_query_formats[0].artifact_type == "cesium_offline_archive_index"
+    assert 'download_status: "stream-only-no-offline-copy"' in js
+    assert "cesium_ion_archive" in js
+
+
+def test_cesium_archive_manifest_uses_configured_archive_or_clip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bounds = kmh_app.ViewBounds(west=-122.5, south=37.7, east=-122.4, north=37.8)
+    source = kmh_app.SOURCE_BY_ID["cesium_ion_archive"]
+
+    monkeypatch.delenv("CESIUM_ION_ARCHIVE_ID", raising=False)
+    monkeypatch.delenv("CESIUM_ARCHIVE_ID", raising=False)
+    monkeypatch.delenv("CESIUM_ION_ASSET_IDS", raising=False)
+    assert kmh_app._build_source_download_operations(
+        package_id="pkgcesium",
+        sources=[source],
+        bounds=bounds,
+    ) == []
+
+    monkeypatch.setenv("CESIUM_ION_ARCHIVE_ID", "123")
+    operations = kmh_app._build_source_download_operations(
+        package_id="pkgcesium",
+        sources=[source],
+        bounds=bounds,
+    )
+    assert [operation["id"] for operation in operations] == ["cesium_ion_archive_download"]
+    assert operations[0]["params"]["archive_id"] == "${CESIUM_ION_ARCHIVE_ID}"
+
+    monkeypatch.delenv("CESIUM_ION_ARCHIVE_ID", raising=False)
+    monkeypatch.setenv("CESIUM_ION_ASSET_IDS", "1001,1002")
+    operations = kmh_app._build_source_download_operations(
+        package_id="pkgcesium",
+        sources=[source],
+        bounds=bounds,
+    )
+    assert [operation["id"] for operation in operations] == ["cesium_ion_clip_create_download"]
+    assert operations[0]["params"]["asset_ids"] == "${CESIUM_ION_ASSET_IDS}"
+    assert operations[0]["params"]["clip_region"] == pytest.approx(
+        [
+            -2.138028333693054,
+            0.6579891280011934,
+            -2.1362820044410597,
+            0.659734457253188,
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_cesium_archive_index_is_queryable_from_jetson(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OFFLINE_PACKAGE_ROOT", str(tmp_path / "packages"))
+    package_id = "pkgcesium"
+    manifest = {"package_id": package_id, "package_name": package_id, "download_operations": []}
+    kmh_app.PACKAGE_MANIFESTS[package_id] = manifest
+    kmh_app._persist_package_manifest(package_id, manifest)
+    archive_path = (
+        kmh_app._package_dir(package_id)
+        / "cesium"
+        / "archive"
+        / "cesium_ion_archive.zip"
+    )
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr(
+            "tileset.json",
+            json.dumps({"asset": {"version": "1.1"}, "root": {"refine": "ADD"}}),
+        )
+        archive.writestr(
+            "terrain/layer.json",
+            json.dumps({"format": "quantized-mesh-1.0", "version": "1.0"}),
+        )
+
+    operation = {
+        "id": "cesium_ion_archive_download",
+        "source_id": "cesium_ion_archive",
+        "source_name": "Cesium ion Offline Archive",
+        "output_format": "Cesium archive ZIP",
+    }
+    index_path, index = kmh_app._index_cesium_archive(
+        package_id=package_id,
+        operation=operation,
+        archive_path=archive_path,
+        archive_info={"id": 123, "status": "COMPLETE", "format": "ZIP"},
+    )
+
+    response = await kmh_app.query_package_cesium(package_id)
+    file_response = await kmh_app.get_package_cesium_file(
+        package_id,
+        "cesium/archive/extracted/tileset.json",
+    )
+
+    assert index_path.exists()
+    assert index["tilesets"][0]["asset_version"] == "1.1"
+    assert index["terrain_layers"][0]["format"] == "quantized-mesh-1.0"
+    assert response["index"]["archive_id"] == 123
+    assert str(file_response.path).endswith("tileset.json")
+
+
+@pytest.mark.asyncio
+async def test_package_imagery_osm_and_terrain_files_are_served_to_plugin(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OFFLINE_PACKAGE_ROOT", str(tmp_path / "packages"))
+    package_id = "pkgdata"
+    manifest = {"package_id": package_id, "package_name": package_id, "download_operations": []}
+    kmh_app.PACKAGE_MANIFESTS[package_id] = manifest
+    kmh_app._persist_package_manifest(package_id, manifest)
+    package_dir = kmh_app._package_dir(package_id)
+    imagery_index = package_dir / "imagery" / "naip" / "aws" / "naip_index.json"
+    osm_index = package_dir / "vectors" / "osm" / "osm_index.json"
+    terrain_tif = package_dir / "rasters" / "copernicus_dem" / "tile.tif"
+    for path in (imagery_index, osm_index, terrain_tif):
+        path.parent.mkdir(parents=True, exist_ok=True)
+    imagery_index.write_text(json.dumps({"files": []}), encoding="utf-8")
+    osm_index.write_text(json.dumps({"aoi_pbf": "vectors/osm/aoi.osm.pbf"}), encoding="utf-8")
+    terrain_tif.write_bytes(b"tif")
+    registry = kmh_app._empty_artifact_registry(package_id)
+    registry["artifacts"].extend(
+        [
+            {
+                "source_id": "naip",
+                "artifact_type": "naip_imagery_index",
+                "relative_path": imagery_index.relative_to(package_dir).as_posix(),
+            },
+            {
+                "source_id": "osm_extract",
+                "artifact_type": "osm_query_index",
+                "relative_path": osm_index.relative_to(package_dir).as_posix(),
+            },
+            {
+                "source_id": "copernicus_dem",
+                "artifact_type": "copernicus_dem_cog",
+                "relative_path": terrain_tif.relative_to(package_dir).as_posix(),
+            },
+        ]
+    )
+    kmh_app._save_artifact_registry(package_id, registry)
+
+    imagery = await kmh_app.query_package_imagery(package_id)
+    osm = await kmh_app.query_package_osm(package_id)
+    imagery_file = await kmh_app.get_package_imagery_file(
+        package_id,
+        "imagery/naip/aws/naip_index.json",
+    )
+    osm_file = await kmh_app.get_package_osm_file(package_id, "vectors/osm/osm_index.json")
+    terrain_file = await kmh_app.get_package_terrain_file(
+        package_id,
+        "rasters/copernicus_dem/tile.tif",
+    )
+
+    assert imagery["artifacts"][0]["artifact_type"] == "naip_imagery_index"
+    assert osm["artifacts"][0]["artifact_type"] == "osm_query_index"
+    assert str(imagery_file.path).endswith("naip_index.json")
+    assert str(osm_file.path).endswith("osm_index.json")
+    assert str(terrain_file.path).endswith("tile.tif")
+
+
+def test_jetson_storage_reserve_is_reported(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class Usage:
+        total = 100 * 1024 * 1024 * 1024
+        used = 40 * 1024 * 1024 * 1024
+        free = 60 * 1024 * 1024 * 1024
+
+    monkeypatch.setenv("OFFLINE_PACKAGE_ROOT", str(tmp_path / "packages"))
+    monkeypatch.setenv("PACKAGE_MIN_FREE_GB", "10")
+    monkeypatch.setattr(kmh_app.shutil, "disk_usage", lambda _path: Usage)
+
+    storage = kmh_app._storage_info()
+
+    assert storage.package_root == str((tmp_path / "packages").resolve())
+    assert storage.reserved_bytes == 10 * 1024 * 1024 * 1024
+    assert storage.usable_bytes == 50 * 1024 * 1024 * 1024
+
+
+@pytest.mark.asyncio
+async def test_source_package_plan_persists_manifest_and_storage_urls(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OFFLINE_PACKAGE_ROOT", str(tmp_path / "packages"))
+    request = kmh_app.DownloadPlanRequest(
+        source_ids=["naip", "osm_extract", "copernicus_dem"],
+        mission_focus="terrain-routing",
+        map_context=kmh_app.MapContext(
+            selected_area=kmh_app.ViewBounds(
+                west=-122.52,
+                south=37.70,
+                east=-122.35,
+                north=37.84,
+                center_lat=37.77,
+                center_lon=-122.43,
+            ),
+            location_confirmed=True,
+        ),
+    )
+
+    response = await kmh_app.plan_source_package(request)
+
+    assert response.execute_url.endswith(f"/api/source-package/{response.package_id}/execute")
+    assert response.status_url.endswith(f"/api/source-package/{response.package_id}/status")
+    assert response.artifacts_url.endswith(f"/api/source-package/{response.package_id}/artifacts")
+    assert response.estimated_bytes > 0
+    assert (tmp_path / "packages" / response.package_id / "manifest.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_package_execution_writes_jetson_artifacts_without_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OFFLINE_PACKAGE_ROOT", str(tmp_path / "packages"))
+    request = kmh_app.DownloadPlanRequest(
+        source_ids=["naip", "osm_extract", "copernicus_dem"],
+        mission_focus="terrain-routing",
+        map_context=kmh_app.MapContext(
+            selected_area=kmh_app.ViewBounds(
+                west=-122.52,
+                south=37.70,
+                east=-122.35,
+                north=37.84,
+            ),
+            location_confirmed=True,
+        ),
+    )
+    sources = kmh_app._get_source_options_by_ids(request.source_ids)
+    manifest = kmh_app._build_package_manifest(
+        package_id="pkgexec",
+        package_name="pkgexec",
+        request=request,
+        sources=sources,
+    )
+    kmh_app.PACKAGE_MANIFESTS["pkgexec"] = manifest
+    kmh_app._persist_package_manifest("pkgexec", manifest)
+    kmh_app._save_package_status("pkgexec", kmh_app._initial_package_status("pkgexec", manifest))
+
+    async def fake_execute_operation(
+        _client: object,
+        *,
+        package_id: str,
+        manifest: dict[str, object],
+        operation: dict[str, object],
+    ) -> list[dict[str, object]]:
+        path = kmh_app._artifact_path(package_id, operation["local_artifact"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"offline artifact")
+        return [
+            kmh_app._artifact_record(
+                package_id=package_id,
+                operation=operation,
+                path=path,
+                artifact_type="mock_artifact",
+                output_format=str(operation.get("output_format", "mock")),
+            )
+        ]
+
+    monkeypatch.setattr(kmh_app, "_execute_operation", fake_execute_operation)
+
+    await kmh_app._execute_package_job("pkgexec", manifest)
+
+    status = kmh_app._load_package_status("pkgexec")
+    registry = kmh_app._load_artifact_registry("pkgexec")
+    registry_text = json.dumps(registry)
+
+    assert status["state"] == "succeeded"
+    assert registry["artifacts"]
+    assert "${ESRI_ARCGIS_TOKEN}" not in registry_text
+
+
+def _seed_grid_package(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setenv("OFFLINE_PACKAGE_ROOT", str(tmp_path / "packages"))
+    package_id = "pkggrid"
+    manifest = {"package_id": package_id, "package_name": package_id, "download_operations": []}
+    kmh_app.PACKAGE_MANIFESTS[package_id] = manifest
+    kmh_app._persist_package_manifest(package_id, manifest)
+    grid_path = kmh_app._package_dir(package_id) / "rasters" / "esri_world_elevation" / "grid.json"
+    grid_path.parent.mkdir(parents=True, exist_ok=True)
+    grid_path.write_text(
+        json.dumps(
+            {
+                "elevation_grid": [[10, 11, 12], [9, 10, 14], [8, 9, 15]],
+                "bbox": {"west": -122.5, "south": 37.7, "east": -122.4, "north": 37.8},
+                "cell_size_m": 30,
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry = kmh_app._empty_artifact_registry(package_id)
+    registry["artifacts"].append(
+        {
+            "artifact_id": "grid",
+            "source_id": "esri_world_elevation",
+            "source_name": "Esri World Elevation Terrain",
+            "operation_id": "seed",
+            "artifact_type": "elevation_grid_json",
+            "format": "JSON elevation grid",
+            "path": str(grid_path),
+            "relative_path": grid_path.relative_to(kmh_app._package_dir(package_id)).as_posix(),
+            "bytes": grid_path.stat().st_size,
+            "sha256": kmh_app._sha256_file(grid_path),
+            "query_interfaces": ["sample_dem(lat, lon)", "read_window(west, south, east, north)"],
+            "feeds_algorithms": ["terrain_derivatives", "raster_cost_distance", "viewshed"],
+            "metadata": {},
+        }
+    )
+    kmh_app._save_artifact_registry(package_id, registry)
+    return package_id
+
+
+@pytest.mark.asyncio
+async def test_package_terrain_query_algorithm_route_and_cot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    package_id = _seed_grid_package(tmp_path, monkeypatch)
+    monkeypatch.setenv("WAYFINDER_KEY_DIR", str(tmp_path / "keys"))
+    monkeypatch.setenv("WAYFINDER_HMAC_KEY", "test-only-dev-signing-key")
+
+    sample = await kmh_app.query_package_terrain(
+        package_id,
+        kmh_app.TerrainQueryRequest(query_type="sample", lat=37.75, lon=-122.45),
+    )
+    algorithm = await kmh_app.run_package_algorithm(
+        package_id,
+        kmh_app.AlgorithmRequest(algorithm_id="terrain_derivatives"),
+    )
+    route = await kmh_app.create_package_route(
+        package_id,
+        kmh_app.PackageRouteRequest(
+            start=kmh_app.MapPoint(lat=37.79, lon=-122.49),
+            end=kmh_app.MapPoint(lat=37.71, lon=-122.41),
+        ),
+    )
+    cot = await kmh_app.create_package_cot(
+        package_id,
+        kmh_app.PackageCotRequest(route_id=route["route_id"], cot_type="route"),
+    )
+
+    assert sample["elevation_m"] == 10.0
+    assert "slope_degrees" in algorithm["layers"]
+    assert route["route"]["geometry"]["type"] == "LineString"
+    assert route["route_hash"]
+    assert cot["events"][0]["signed"] is True
+    assert "<wayfinder>" in cot["events"][0]["cot_xml"]
+
+
+def test_source_package_manifest_contains_download_jobs_and_algorithm_contracts() -> None:
+    request = kmh_app.DownloadPlanRequest(
+        source_ids=["naip", "osm_extract", "copernicus_dem"],
+        mission_focus="terrain-routing",
+        map_context=kmh_app.MapContext(
+            selected_area=kmh_app.ViewBounds(
+                west=-122.52,
+                south=37.70,
+                east=-122.35,
+                north=37.84,
+                center_lat=37.77,
+                center_lon=-122.43,
+            ),
+            location_confirmed=True,
+        ),
+    )
+    sources = kmh_app._get_source_options_by_ids(request.source_ids)
+    manifest = kmh_app._build_package_manifest(
+        package_id="pkgtest",
+        package_name="pkgtest",
+        request=request,
+        sources=sources,
+    )
+
+    operations = {operation["id"]: operation for operation in manifest["download_operations"]}
+    assert "naip_aws_public_prefix" in operations
+    assert "osm_geofabrik_pbf" in operations
+    assert "copernicus_dem_glo30_cog" in operations
+    assert operations["naip_aws_public_prefix"]["params"]["state"] == "ca"
+    assert operations["naip_aws_public_prefix"]["params"]["prefix"] == "ca/2022/60cm/rgbir/"
+    assert operations["osm_geofabrik_pbf"]["params"]["region_slug"] == "north-america/us/california"
+    assert operations["copernicus_dem_glo30_cog"]["params"]["tile_urls"][0]["tile_id"].startswith(
+        "Copernicus_DSM_COG_10_N37_00_W123_00_DEM"
+    )
+    assert any(item["id"] == "raster_cost_distance" for item in manifest["deterministic_algorithms"])
+    assert any(
+        contract["artifact_type"] == "copernicus_dem_cog_index"
+        for contract in manifest["jetson_query_contracts"]
+    )
+    assert any(
+        contract["artifact_type"] == "osm_pbf_extract"
+        for contract in manifest["jetson_query_contracts"]
+    )
+
+
+def test_web_package_workflow_shows_jetson_storage_and_server_download() -> None:
+    html = kmh_app.INDEX_FILE.read_text(encoding="utf-8")
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+
+    assert "Jetson Storage" in html
+    assert 'id="downloadToJetsonBtn"' in html
+    assert "Download to Jetson" in html
+    assert 'id="packageExecutionStatus"' in html
+    assert 'id="packageArtifacts"' in html
+    assert 'fetchJson("/api/storage")' in js
+    assert "downloadPackageToJetson" in js
+    assert "state.packagePlan.execute_url" in js
+    assert "renderJetsonStorage(data.storage, data.estimated_bytes, data.storage_fit" in js
+
+
+def test_geo_algorithms_cover_graph_raster_and_terrain_paths() -> None:
+    graph = {
+        "A": [("B", 1.0), ("C", 4.0)],
+        "B": [("C", 1.0), ("D", 4.0)],
+        "C": [("D", 1.0)],
+        "D": [],
+    }
+
+    path, cost = geo_algorithms.astar(graph, "A", "D")
+    assert path == ["A", "B", "C", "D"]
+    assert cost == 3.0
+
+    alternatives = geo_algorithms.yens_k_shortest_paths(graph, "A", "D", 2)
+    assert alternatives[0][0] == ["A", "B", "C", "D"]
+    assert len(alternatives) == 2
+
+    elevation = [
+        [14, 13, 12],
+        [15, 12, 9],
+        [16, 12, 8],
+    ]
+    terrain = geo_algorithms.derive_terrain_layers(elevation, cell_size_m=30)
+    assert terrain["slope_degrees"][1][1] > 0
+    assert "curvature" in terrain
+    cost_surface = geo_algorithms.build_walking_cost_surface(terrain["slope_degrees"])
+    result = geo_algorithms.raster_cost_distance(cost_surface, [(0, 0)])
+    cell_path = geo_algorithms.backtrack_least_cost_path(result, (2, 2))
+    assert cell_path[0] == (0, 0)
+    assert cell_path[-1] == (2, 2)
+    assert geo_algorithms.flow_accumulation_d8(elevation, cell_size_m=30)[2][2] >= 1
+    assert geo_algorithms.viewshed(elevation, (0, 0), cell_size_m=30)[0][0] is True
+    sectors = geo_algorithms.radial_sar_sectors(37.77, -122.43, 1000, 4)
+    assert len(sectors["features"]) == 4
+    probability = geo_algorithms.sar_probability_surface(3, 3, (1, 1))
+    assert round(sum(sum(row) for row in probability), 6) == 1.0
 
 
 def test_chat_streaming_does_not_force_scroll_when_reader_moves_up() -> None:
@@ -590,11 +1161,8 @@ def test_source_recommendation_tolerates_rough_phrasing_and_spelling() -> None:
 
     assert recommendation.mission_focus in {"water-access", "terrain-routing"}
     assert "osm_extract" in recommendation.required_source_ids
-    assert "esri_world_elevation" in recommendation.required_source_ids
-    assert any(
-        source_id in recommendation.required_source_ids
-        for source_id in ("usgs_3dep", "copernicus_dem")
-    )
+    assert "copernicus_dem" in recommendation.required_source_ids
+    assert "dted_earth_explorer" in recommendation.optional_source_ids
     assert any(
         source_id in recommendation.required_source_ids
         for source_id in ("usgs_3dhp", "hydrosheds")

--- a/tests/test_llm_dev_stream.py
+++ b/tests/test_llm_dev_stream.py
@@ -354,7 +354,17 @@ def test_claude_model_labels_normalize_to_current_sonnet() -> None:
     assert kmh_app._normalize_claude_model("Claude Haiku 4.5") == "claude-3-5-haiku-20241022"
 
 
-def test_local_model_detection_prefers_installed_gemma_alias() -> None:
+def test_local_model_detection_prefers_installed_gemma_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the configured OLLAMA_MODEL is installed locally, pick it.
+
+    Hermetic via monkeypatch so the test passes regardless of the
+    operator's .env (which on the demo Jetson sets OLLAMA_MODEL=gemma2:2b
+    pre-Phase-3-cutover; once Kyle pulls gemma3:4b on the Jetson, the
+    .env switches and this test still pins the early-return behavior).
+    """
+    monkeypatch.setattr(kmh_app, "OLLAMA_MODEL", "gemma3:4b")
     models = [
         "hf.co/unsloth/gemma-4-E4B-it-GGUF:UD-Q4_K_XL",
         "gemma4:e4b",

--- a/tests/test_llm_dev_stream.py
+++ b/tests/test_llm_dev_stream.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -358,6 +359,34 @@ def test_chat_panel_hides_advisor_header_and_status_noise() -> None:
     assert 'id="requestStatus" class="section-meta" aria-live="polite"' in html
     assert "Use the advisor response" not in js
     assert "Deterministic advisor response shown (" not in js
+
+
+def test_map_stream_status_does_not_confuse_esri_tiles_with_missing_ion() -> None:
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+    app_source = Path(kmh_app.__file__).read_text(encoding="utf-8")
+
+    assert "_load_dotenv_file(BASE_DIR.parent / \".env\")" in app_source
+    assert "_load_dotenv_file(BASE_DIR.parent / \".env.local\")" in app_source
+    assert "CESIUM_ACCESS_TOKEN" in app_source
+    assert "CESIUM_ION_ACCESS_TOKEN" in app_source
+    assert "state.cesiumIonTokenAvailable = hasCesiumIonToken();" in js
+    assert "function updateMapStreamChip" in js
+    assert "Map stream: ${imageryLabel}" in js
+    assert "Map stream active; ion fallback" in js
+    assert "Cesium ion stream active" in js
+    assert "Cesium token missing" not in js
+    assert "Cesium token detected" not in js
+
+
+def test_dotenv_loader_sets_missing_environment_values(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    key = "TERA_TEST_DOTENV_VALUE"
+    monkeypatch.delenv(key, raising=False)
+    dotenv_file = tmp_path / ".env"
+    dotenv_file.write_text(f"{key}='loaded-from-dotenv'\n", encoding="utf-8")
+
+    kmh_app._load_dotenv_file(dotenv_file)
+
+    assert os.environ[key] == "loaded-from-dotenv"
 
 
 def test_source_planner_degrades_without_false_inference_failure() -> None:

--- a/tests/test_llm_dev_stream.py
+++ b/tests/test_llm_dev_stream.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 
 from llm_dev_kmh import app as kmh_app
@@ -26,6 +27,7 @@ class _FakeStreamContext:
 
 class _FakeAsyncClient:
     response: object
+    models_response: object | None = None
 
     def __init__(self, *_args: object, **_kwargs: object) -> None:
         pass
@@ -38,6 +40,9 @@ class _FakeAsyncClient:
 
     def stream(self, *_args: object, **_kwargs: Any) -> _FakeStreamContext:
         return _FakeStreamContext(self.response)
+
+    async def get(self, *_args: object, **_kwargs: Any) -> object:
+        return self.models_response or _ModelsResponse()
 
     async def post(self, *_args: object, **_kwargs: Any) -> object:
         return self.response
@@ -70,6 +75,24 @@ class _ClaudeResponse:
         return {"content": [{"type": "text", "text": "Claude source recommendation."}]}
 
 
+class _ModelsResponse:
+    status_code = 200
+    text = '{"data":[{"id":"claude-sonnet-4-20250514","type":"model"}]}'
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return {
+            "data": [
+                {
+                    "id": "claude-sonnet-4-20250514",
+                    "type": "model",
+                }
+            ]
+        }
+
+
 async def _collect_stream(response: object) -> str:
     body_iterator = response.body_iterator
     chunks: list[str] = []
@@ -84,7 +107,11 @@ async def test_prompt_stream_yields_sse_tokens(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(kmh_app.httpx, "AsyncClient", _FakeAsyncClient)
 
     response = await kmh_app.prompt_ollama_stream(
-        kmh_app.PromptRequest(prompt="What can you do?", model="gemma4:e4b")
+        kmh_app.PromptRequest(
+            prompt="What can you do?",
+            model="gemma4:e4b",
+            llm_provider="ollama",
+        )
     )
 
     body = await _collect_stream(response)
@@ -102,7 +129,11 @@ async def test_prompt_stream_reports_ollama_http_errors(monkeypatch: pytest.Monk
     monkeypatch.setattr(kmh_app.httpx, "AsyncClient", _FakeAsyncClient)
 
     response = await kmh_app.prompt_ollama_stream(
-        kmh_app.PromptRequest(prompt="What can you do?", model="missing")
+        kmh_app.PromptRequest(
+            prompt="What can you do?",
+            model="missing",
+            llm_provider="ollama",
+        )
     )
 
     body = await _collect_stream(response)
@@ -135,7 +166,9 @@ async def test_prompt_stream_can_use_claude_provider(monkeypatch: pytest.MonkeyP
 
 @pytest.mark.asyncio
 async def test_prompt_stream_reports_missing_claude_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeAsyncClient.response = _ErrorResponse()
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(kmh_app.httpx, "AsyncClient", _FakeAsyncClient)
     response = await kmh_app.prompt_ollama_stream(
         kmh_app.PromptRequest(
             prompt="Recommend sources.",
@@ -146,8 +179,10 @@ async def test_prompt_stream_reports_missing_claude_key(monkeypatch: pytest.Monk
 
     body = await _collect_stream(response)
 
+    assert '"type": "fallback"' in body
     assert '"type": "error"' in body
     assert "Claude API key required" in body
+    assert "model missing" in body
 
 
 @pytest.mark.asyncio
@@ -236,9 +271,11 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
         'id="topModelSelect"',
         'id="claudeModelSelect"',
         'id="claudeApiKeyInput"',
+        "Auto: Claude -> Local",
         "Claude API",
         "claude-sonnet-4-20250514",
-        "Claude Sonnet 4",
+        "Claude Sonnet 4.6",
+        "claude-opus-4-1-20250805",
     ]:
         assert token in html
 
@@ -256,26 +293,32 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
         "serverClaudeKeyAvailable",
         "hasClaudeProviderCredential",
         "anthropic_api_key_configured",
+        "default_provider",
         "applyProviderSelection",
         "void loadModels();",
         "Detected local model:",
         "llm_provider",
         "cloud_model",
         "cloud_api_key",
+        "Trying Claude, then local model if needed",
         "Claude API key required",
     ]:
         assert token in js
 
     for token in [
         "ANTHROPIC_API_URL",
+        "ANTHROPIC_MODELS_URL",
         "ANTHROPIC_VERSION",
         "CLAUDE_MODEL",
         "CLAUDE_MODEL_ALIASES",
         "CLAUDE_MODEL_FALLBACKS",
+        "default_provider",
         "claude_default_model",
         "anthropic_api_key_configured",
         "_normalize_claude_model",
         "_claude_model_candidates",
+        "_fetch_anthropic_model_ids",
+        "_post_prompt_with_fallback",
         "_select_ollama_default_model",
         "Auto-detected installed Gemma model",
         "_post_claude_message",
@@ -288,6 +331,9 @@ def test_claude_model_labels_normalize_to_current_sonnet() -> None:
     assert kmh_app._normalize_claude_model("Claude Sonnet 4.6") == "claude-sonnet-4-20250514"
     assert kmh_app._normalize_claude_model("claude-sonnet-4.6") == "claude-sonnet-4-20250514"
     assert kmh_app._normalize_claude_model("claude-sonnet-4-20250514") == "claude-sonnet-4-20250514"
+    assert kmh_app._normalize_claude_model("Claude Opus 4.1") == "claude-opus-4-1-20250805"
+    assert kmh_app._normalize_claude_model("Claude Opus 4.7") == "claude-opus-4-1-20250805"
+    assert kmh_app._normalize_claude_model("Claude Haiku 4.5") == "claude-3-5-haiku-20241022"
 
 
 def test_local_model_detection_prefers_installed_gemma_alias() -> None:
@@ -447,24 +493,103 @@ def test_source_planner_degrades_without_false_inference_failure() -> None:
 
 def test_prompt_submission_tries_selected_provider_then_local_then_deterministic() -> None:
     js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+    app_source = Path(kmh_app.__file__).read_text(encoding="utf-8")
 
     assert "streamAssistantProvider" in js
-    assert "resolveLocalModelForFallback" in js
-    assert "Trying local model fallback" in js
-    assert "Claude request failed; trying detected local Ollama." in js
+    assert "Trying Claude, then local model if needed" in js
+    assert "eventData.type === \"fallback\"" in js
     assert "deterministic planner response" in js
-    assert "Model providers unavailable; deterministic planner response shown." in js
+    assert "Prompt request failed; deterministic planner response shown." in js
     assert 'provider === "ollama" && !state.localModelAvailable' not in js
     assert "Claude failed; trying local Ollama fallback" not in js
     assert "Claude key missing; trying local Ollama fallback" not in js
     assert "local fallback after Claude failure" not in js
     assert "Model providers unavailable; deterministic advisor response shown (" not in js
 
-    claude_attempt = js.index('provider: "claude"')
-    local_attempt = js.index('provider: "ollama"')
+    claude_attempt = app_source.index('return ["claude", "ollama"]')
     deterministic = js.index("deterministic planner response")
 
-    assert claude_attempt < local_attempt < deterministic
+    assert claude_attempt >= 0
+    assert deterministic >= 0
+
+
+def test_backend_provider_sequence_is_claude_then_ollama() -> None:
+    assert kmh_app._request_llm_provider(kmh_app.PromptRequest(prompt="x")) == "auto"
+    assert kmh_app._provider_sequence(kmh_app.PromptRequest(prompt="x")) == ["claude", "ollama"]
+    assert kmh_app._provider_sequence(
+        kmh_app.PromptRequest(prompt="x", llm_provider="ollama")
+    ) == ["ollama"]
+    assert kmh_app._provider_sequence(
+        kmh_app.PromptRequest(prompt="x", llm_provider="claude")
+    ) == ["claude", "ollama"]
+
+
+class _ClaudeInvalidModelResponse:
+    status_code = 400
+    text = '{"error":{"message":"model not found"}}'
+
+    def raise_for_status(self) -> None:
+        request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        response = httpx.Response(400, text=self.text, request=request)
+        raise httpx.HTTPStatusError("bad request", request=request, response=response)
+
+
+class _OllamaGenerateResponse:
+    status_code = 200
+    text = '{"response":"Ollama fallback response."}'
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return {"response": "Ollama fallback response."}
+
+
+@pytest.mark.asyncio
+async def test_auto_prompt_falls_back_from_claude_to_ollama(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "FakeClient":
+            return self
+
+        async def __aexit__(self, *_exc_info: object) -> None:
+            return None
+
+        async def get(self, *_args: object, **_kwargs: Any) -> object:
+            return _ModelsResponse()
+
+        async def post(self, url: str, **_kwargs: Any) -> object:
+            if "anthropic" in url:
+                return _ClaudeInvalidModelResponse()
+            return _OllamaGenerateResponse()
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-server-test")
+    monkeypatch.setattr(kmh_app.httpx, "AsyncClient", FakeClient)
+
+    response = await kmh_app.prompt_ollama(
+        kmh_app.PromptRequest(prompt="Recommend sources.", llm_provider="auto")
+    )
+
+    assert response.provider == "ollama"
+    assert response.response == "Ollama fallback response."
+    assert response.fallbacks
+    assert "claude:" in response.fallbacks[0]
+
+
+def test_runtime_config_advertises_auto_provider_when_claude_key_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-server-test")
+
+    assert kmh_app._default_provider() == "auto"
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    assert kmh_app._default_provider() == "ollama"
 
 
 def test_esri_queryable_terrain_is_available_for_download_fallbacks() -> None:

--- a/tests/test_llm_dev_stream.py
+++ b/tests/test_llm_dev_stream.py
@@ -226,6 +226,8 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
         "teraLlmProvider",
         "teraClaudeApiKey",
         "applyProviderSelection",
+        "void loadModels();",
+        "Detected local model:",
         "llm_provider",
         "cloud_model",
         "cloud_api_key",
@@ -238,10 +240,30 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
         "ANTHROPIC_VERSION",
         "CLAUDE_MODEL",
         "claude_default_model",
+        "_select_ollama_default_model",
+        "Auto-detected installed Gemma model",
         "_post_claude_message",
         "_extract_claude_response_text",
     ]:
         assert token in app_source
+
+
+def test_local_model_detection_prefers_installed_gemma_alias() -> None:
+    models = [
+        "hf.co/unsloth/gemma-4-E4B-it-GGUF:UD-Q4_K_XL",
+        "gemma4:e4b",
+        "gemma3:4b",
+    ]
+
+    assert kmh_app._select_ollama_default_model(models) == "gemma4:e4b"
+
+
+def test_location_search_prefers_curated_cascades_match() -> None:
+    suggestions = kmh_app._local_location_suggestions("go to Cascades")
+
+    assert suggestions
+    assert suggestions[0].name == "Cascade Range, WA/OR/BC"
+    assert suggestions[0].score > 0
 
 
 def test_planner_workflow_has_carousel_and_resizable_ao_handles() -> None:
@@ -259,13 +281,20 @@ def test_planner_workflow_has_carousel_and_resizable_ao_handles() -> None:
     assert "finishAreaResize" in js
 
 
-def test_planner_opens_questions_and_uses_compact_source_checklist() -> None:
+def test_planner_keeps_scope_questions_in_agent_response_only() -> None:
+    html = kmh_app.INDEX_FILE.read_text(encoding="utf-8")
     css = (kmh_app.STATIC_DIR / "styles.css").read_text(encoding="utf-8")
     js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
 
     assert "ensureClarifyingQuestions" in js
     assert "state.workflowStageIndex = 1;" in js
-    assert "Use Questions to scope, then confirm sources." in js
+    assert "Use the advisor response to scope, then confirm sources." in js
+    assert "### Scope Check" in js
+    assert 'data-workflow-slide="questions"' not in html
+    assert 'id="clarifyingQuestions"' not in html
+    assert "Socratic questions" not in html
+    assert "renderClarifyingQuestions" not in js
+    assert "Use Questions to scope, then confirm sources." not in js
     assert "Next questions:" not in js
 
     assert 'article.className = "source-item compact-source-item";' in js
@@ -279,6 +308,24 @@ def test_planner_opens_questions_and_uses_compact_source_checklist() -> None:
     assert "min-height: 76px;" in css
 
 
+def test_prompt_composer_clears_after_submit_is_accepted() -> None:
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+
+    clear_index = js.index('els.promptInput.value = "";')
+    plan_index = js.index("await planSourcesFromMission(prompt, mapContext);")
+
+    assert clear_index < plan_index
+
+
+def test_data_package_empty_state_does_not_repeat_chat_instruction() -> None:
+    html = kmh_app.INDEX_FILE.read_text(encoding="utf-8")
+    css = (kmh_app.STATIC_DIR / "styles.css").read_text(encoding="utf-8")
+
+    assert 'id="workflowEmpty" class="workflow-empty" aria-hidden="true"></div>' in html
+    assert ".workflow-empty:empty" in css
+    assert "Describe the mission in chat to begin source planning." not in html
+
+
 def test_source_planner_degrades_without_false_inference_failure() -> None:
     html = kmh_app.INDEX_FILE.read_text(encoding="utf-8")
     js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
@@ -289,7 +336,7 @@ def test_source_planner_degrades_without_false_inference_failure() -> None:
     assert "Source planner unavailable" in js
     assert "Planning source package" in js
     assert "Local model offline; rules active" in js
-    assert "deterministic source advisor" in js
+    assert "deterministic fallback" in js
     assert "plan the needed package" in html
 
     for stale_label in [
@@ -304,6 +351,24 @@ def test_source_planner_degrades_without_false_inference_failure() -> None:
     ]:
         assert stale_label not in js
         assert stale_label not in html
+
+
+def test_prompt_submission_tries_selected_provider_then_local_then_deterministic() -> None:
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+
+    assert "streamAssistantProvider" in js
+    assert "resolveLocalModelForFallback" in js
+    assert "Claude failed; trying local Ollama fallback" in js
+    assert "Claude key missing; trying local Ollama fallback" in js
+    assert "local fallback after Claude failure" in js
+    assert "Model providers unavailable; deterministic advisor response shown" in js
+    assert 'provider === "ollama" && !state.localModelAvailable' not in js
+
+    claude_attempt = js.index('provider: "claude"')
+    local_attempt = js.index('provider: "ollama"')
+    deterministic = js.index("Model providers unavailable; deterministic advisor response shown")
+
+    assert claude_attempt < local_attempt < deterministic
 
 
 def test_esri_queryable_terrain_is_available_for_download_fallbacks() -> None:
@@ -382,13 +447,21 @@ def test_map_location_search_sets_context_and_center_grid() -> None:
     assert 'id="locationSearchSuggestions"' in html
     assert 'id="centerGridValue"' in html
     assert ".map-search-panel" in css
+    assert "width: min(312px, max(240px, calc((100% - 340px) * 0.6)));" in css
     assert ".center-grid-panel" in css
 
     assert "LOCATION_GAZETTEER" in js
+    assert "cleanLocationSearchQuery" in js
+    assert "buildLocationSearchUrl" in js
+    assert "fetchLocationSearchSuggestions" in js
+    assert "renderLocationSearchLoading" in js
     assert "Joshua Tree National Park" in js
+    assert "Cascade Range" in js
     assert "parseCoordinateQuery" in js
     assert "refreshOnlineLocationSuggestions" in js
     assert "/api/location-search" in js
+    assert "score: Number.isFinite(serverScore)" in js
+    assert "location-suggestion-status" in css
     assert "flyToLocationSuggestion" in js
     assert "latLonToUtm" in js
     assert "latLonToMgrs" in js
@@ -403,6 +476,8 @@ def test_map_location_search_sets_context_and_center_grid() -> None:
     assert "location_confirmed: bool = False" in app_source
     assert '@app.get("/api/location-search"' in app_source
     assert "LOCATION_SEARCH_URL" in app_source
+    assert "LOCATION_INTENT_PREFIX_RE" in app_source
+    assert "_score_online_location" in app_source
     assert "Planner-confirmed mission map focus" in app_source
     assert "Move the map to the mission AO" in app_source
     assert "use the map location search" in prompt

--- a/tests/test_llm_dev_stream.py
+++ b/tests/test_llm_dev_stream.py
@@ -36,6 +36,9 @@ class _FakeAsyncClient:
     def stream(self, *_args: object, **_kwargs: Any) -> _FakeStreamContext:
         return _FakeStreamContext(self.response)
 
+    async def post(self, *_args: object, **_kwargs: Any) -> object:
+        return self.response
+
 
 class _TokenResponse:
     status_code = 200
@@ -51,6 +54,17 @@ class _ErrorResponse:
 
     async def aread(self) -> bytes:
         return b'{"error":"model missing"}'
+
+
+class _ClaudeResponse:
+    status_code = 200
+    text = '{"content":[{"type":"text","text":"Claude source recommendation."}]}'
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, object]:
+        return {"content": [{"type": "text", "text": "Claude source recommendation."}]}
 
 
 async def _collect_stream(response: object) -> str:
@@ -94,6 +108,44 @@ async def test_prompt_stream_reports_ollama_http_errors(monkeypatch: pytest.Monk
     assert "model missing" in body
 
 
+@pytest.mark.asyncio
+async def test_prompt_stream_can_use_claude_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    _FakeAsyncClient.response = _ClaudeResponse()
+    monkeypatch.setattr(kmh_app.httpx, "AsyncClient", _FakeAsyncClient)
+
+    response = await kmh_app.prompt_ollama_stream(
+        kmh_app.PromptRequest(
+            prompt="Recommend sources.",
+            llm_provider="claude",
+            cloud_model="claude-sonnet-4-20250514",
+            cloud_api_key="sk-ant-test",
+        )
+    )
+
+    body = await _collect_stream(response)
+
+    assert '"provider": "claude"' in body
+    assert "Waiting for Claude API response" in body
+    assert "Claude source recommendation." in body
+    assert '"type": "done"' in body
+
+
+@pytest.mark.asyncio
+async def test_prompt_stream_reports_missing_claude_key() -> None:
+    response = await kmh_app.prompt_ollama_stream(
+        kmh_app.PromptRequest(
+            prompt="Recommend sources.",
+            llm_provider="claude",
+            cloud_model="claude-sonnet-4-20250514",
+        )
+    )
+
+    body = await _collect_stream(response)
+
+    assert '"type": "error"' in body
+    assert "Claude API key required" in body
+
+
 def test_imagery_sourcing_prompt_uses_socratic_dialogue() -> None:
     request = kmh_app.PromptRequest(
         prompt="Build a water access package for a foot patrol.",
@@ -122,6 +174,7 @@ def test_source_recommendation_questions_prioritize_source_scope() -> None:
     )
     questions = " ".join(recommendation.clarifying_questions).lower()
 
+    assert "move the map" in questions
     assert "movement" in questions
     assert "water" in questions
     assert "bounding box" not in questions
@@ -143,6 +196,54 @@ def test_planner_workflow_hides_ao_until_sources_are_confirmed() -> None:
     assert "state.sourceConfirmed = true" in js
 
 
+def test_model_provider_menu_supports_local_and_claude() -> None:
+    html = kmh_app.INDEX_FILE.read_text(encoding="utf-8")
+    css = (kmh_app.STATIC_DIR / "styles.css").read_text(encoding="utf-8")
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+    app_source = Path(kmh_app.__file__).read_text(encoding="utf-8")
+
+    for token in [
+        'id="modelProviderBtn"',
+        'id="modelProviderMenu"',
+        'id="providerSelect"',
+        'id="topModelSelect"',
+        'id="claudeModelSelect"',
+        'id="claudeApiKeyInput"',
+        "Claude API",
+        "claude-sonnet-4-20250514",
+    ]:
+        assert token in html
+
+    for token in [
+        ".top-provider-shell",
+        ".chip-button",
+        ".provider-menu",
+        ".provider-actions",
+    ]:
+        assert token in css
+
+    for token in [
+        "teraLlmProvider",
+        "teraClaudeApiKey",
+        "applyProviderSelection",
+        "llm_provider",
+        "cloud_model",
+        "cloud_api_key",
+        "Claude API key required",
+    ]:
+        assert token in js
+
+    for token in [
+        "ANTHROPIC_API_URL",
+        "ANTHROPIC_VERSION",
+        "CLAUDE_MODEL",
+        "claude_default_model",
+        "_post_claude_message",
+        "_extract_claude_response_text",
+    ]:
+        assert token in app_source
+
+
 def test_planner_workflow_has_carousel_and_resizable_ao_handles() -> None:
     html = kmh_app.INDEX_FILE.read_text(encoding="utf-8")
     js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
@@ -156,6 +257,150 @@ def test_planner_workflow_has_carousel_and_resizable_ao_handles() -> None:
     assert "getPickedAreaHandle" in js
     assert "getResizeAnchorPoint" in js
     assert "finishAreaResize" in js
+
+
+def test_source_planner_degrades_without_false_inference_failure() -> None:
+    html = kmh_app.INDEX_FILE.read_text(encoding="utf-8")
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+
+    assert "FALLBACK_SOURCE_CATALOG" in js
+    assert "buildClientSourceRecommendation" in js
+    assert "Planner fallback" in js
+    assert "Source planner unavailable" in js
+    assert "Planning source package" in js
+    assert "Local model offline; rules active" in js
+    assert "deterministic source advisor" in js
+    assert "plan the needed package" in html
+
+    for stale_label in [
+        "Inference failed",
+        "Source inference failed",
+        "Inferring source package",
+        "Source catalog not loaded",
+        "No source catalog loaded",
+        "Source catalog failed",
+        "Ollama lookup failed",
+        "Model lookup failed",
+    ]:
+        assert stale_label not in js
+        assert stale_label not in html
+
+
+def test_esri_queryable_terrain_is_available_for_download_fallbacks() -> None:
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+    prompt = (
+        Path("prompts/local_model_prompts/imagery_sourcing_local_model_system_prompt.md")
+        .read_text(encoding="utf-8")
+    )
+
+    source = kmh_app.SOURCE_BY_ID["esri_world_elevation"]
+
+    assert source.category == "terrain"
+    assert source.stream_status == "queryable-online"
+    assert source.download_status == "download-required"
+    assert "elevation_samples" in source.derived_layers
+    assert "esri_world_elevation" in js
+    assert "Esri World Elevation Terrain" in js
+    assert "queryable-online" in js
+    assert "download-required" in js
+    assert "Esri World Elevation Terrain is a queryable online fallback" in prompt
+
+    recommendation = kmh_app._infer_source_recommendation(
+        "Need a terrain route that avoids steep exposed terrain.",
+        None,
+    )
+    assert "esri_world_elevation" in recommendation.required_source_ids
+    assert "esri_world_elevation" in recommendation.selected_source_ids
+
+
+def test_chat_streaming_does_not_force_scroll_when_reader_moves_up() -> None:
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+
+    assert "CHAT_AUTOSCROLL_THRESHOLD_PX" in js
+    assert "function isChatPinnedToBottom()" in js
+    assert "function maybeScrollChatToBottom" in js
+    assert "const shouldFollowNewMessage = isChatPinnedToBottom();" in js
+    assert "const shouldFollowStream = isChatPinnedToBottom();" in js
+    assert "maybeScrollChatToBottom(shouldFollowStream);" in js
+    assert js.count("els.chatLog.scrollTop = els.chatLog.scrollHeight;") == 1
+
+
+def test_header_title_precedes_kicker_and_map_imports_kml_overlays() -> None:
+    html = kmh_app.INDEX_FILE.read_text(encoding="utf-8")
+    css = (kmh_app.STATIC_DIR / "styles.css").read_text(encoding="utf-8")
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+
+    assert html.index("<h1>TERA Source Planner</h1>") < html.index(
+        '<div class="eyebrow">Mission data sourcing workspace</div>'
+    )
+    assert 'id="importOverlayBtn"' in html
+    assert 'id="overlayFileInput"' in html
+    assert 'accept=".kml,.kmz' in html
+    assert ".file-input" in css
+
+    assert "overlayDataSource" in js
+    assert "async function importMapOverlay" in js
+    assert "Cesium.KmlDataSource.load" in js
+    assert "state.viewer.dataSources.add(dataSource)" in js
+    assert "state.viewer.flyTo(state.overlayDataSource" in js
+    assert 'els.importOverlayBtn.addEventListener("click", requestOverlayFile)' in js
+    assert 'els.overlayFileInput.addEventListener("change", onOverlayFileSelected)' in js
+
+
+def test_map_location_search_sets_context_and_center_grid() -> None:
+    html = kmh_app.INDEX_FILE.read_text(encoding="utf-8")
+    css = (kmh_app.STATIC_DIR / "styles.css").read_text(encoding="utf-8")
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+    app_source = Path(kmh_app.__file__).read_text(encoding="utf-8")
+    prompt = (
+        Path("prompts/local_model_prompts/imagery_sourcing_local_model_system_prompt.md")
+        .read_text(encoding="utf-8")
+    )
+
+    assert 'id="locationSearchPanel"' in html
+    assert 'id="locationSearchInput"' in html
+    assert 'id="locationSearchSuggestions"' in html
+    assert 'id="centerGridValue"' in html
+    assert ".map-search-panel" in css
+    assert ".center-grid-panel" in css
+
+    assert "LOCATION_GAZETTEER" in js
+    assert "Joshua Tree National Park" in js
+    assert "parseCoordinateQuery" in js
+    assert "refreshOnlineLocationSuggestions" in js
+    assert "/api/location-search" in js
+    assert "flyToLocationSuggestion" in js
+    assert "latLonToUtm" in js
+    assert "updateCenterGrid()" in js
+    assert "location_confirmed" in js
+    assert "location_focus_label" in js
+    assert 'els.locationSearchForm.addEventListener("submit", onLocationSearchSubmit)' in js
+
+    assert "location_confirmed: bool = False" in app_source
+    assert '@app.get("/api/location-search"' in app_source
+    assert "LOCATION_SEARCH_URL" in app_source
+    assert "Planner-confirmed mission map focus" in app_source
+    assert "Move the map to the mission AO" in app_source
+    assert "use the map location search" in prompt
+
+
+def test_source_recommendation_tolerates_rough_phrasing_and_spelling() -> None:
+    recommendation = kmh_app._infer_source_recommendation(
+        "Need off-line pakage near Joshu Tree for patroll to find watter and avoid steep terain.",
+        None,
+    )
+
+    assert recommendation.mission_focus in {"water-access", "terrain-routing"}
+    assert "osm_extract" in recommendation.required_source_ids
+    assert "esri_world_elevation" in recommendation.required_source_ids
+    assert any(
+        source_id in recommendation.required_source_ids
+        for source_id in ("usgs_3dep", "copernicus_dem")
+    )
+    assert any(
+        source_id in recommendation.required_source_ids
+        for source_id in ("usgs_3dhp", "hydrosheds")
+    )
 
 
 def test_map_ui_does_not_expose_point_pin_overlay() -> None:
@@ -206,6 +451,13 @@ def test_source_planner_uses_defense_design_system() -> None:
     assert "body.panel-collapsed .workspace-shell" in css
     assert "grid-template-columns: minmax(0, 1fr);" in css
     assert 'els.workspaceShell.style.removeProperty("--panel-width")' in js
+    assert "body.is-resizing-panel" in css
+    assert "user-select: none !important;" in css
+    assert "touch-action: none;" in css
+    assert "clearDocumentSelection" in js
+    assert "event.preventDefault();" in js
+    assert 'document.body.classList.add("is-resizing-panel")' in js
+    assert 'document.body.classList.remove("is-resizing-panel")' in js
 
     forbidden_tokens = [
         "IBM Plex Sans",

--- a/tests/test_llm_dev_stream.py
+++ b/tests/test_llm_dev_stream.py
@@ -77,7 +77,7 @@ class _ClaudeResponse:
 
 class _ModelsResponse:
     status_code = 200
-    text = '{"data":[{"id":"claude-sonnet-4-20250514","type":"model"}]}'
+    text = '{"data":[{"id":"claude-sonnet-4-6","type":"model"}]}'
 
     def raise_for_status(self) -> None:
         return None
@@ -86,7 +86,7 @@ class _ModelsResponse:
         return {
             "data": [
                 {
-                    "id": "claude-sonnet-4-20250514",
+                    "id": "claude-sonnet-4-6",
                     "type": "model",
                 }
             ]
@@ -267,20 +267,25 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
     for token in [
         'id="modelProviderBtn"',
         'id="modelProviderMenu"',
+        'id="atakAgentBtn"',
+        'id="atakMirrorPanel"',
         'id="providerSelect"',
         'id="topModelSelect"',
         'id="claudeModelSelect"',
         'id="claudeApiKeyInput"',
         "Auto: Claude -> Local",
         "Claude API",
-        "claude-sonnet-4-20250514",
+        "claude-sonnet-4-6",
         "Claude Sonnet 4.6",
+        "TERA ATAK Link",
         "claude-opus-4-1-20250805",
     ]:
         assert token in html
 
     for token in [
         ".top-provider-shell",
+        ".atak-mirror-panel",
+        ".atak-mirror-event",
         ".chip-button",
         ".provider-menu",
         ".provider-actions",
@@ -289,6 +294,11 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
 
     for token in [
         "teraLlmProvider",
+        "activateAtakLocalAgent",
+        "atakMirrorPanel",
+        "/api/jetson/atak-agent/activate",
+        "/api/jetson/atak-agent/mirror",
+        "gemma3:4b",
         "teraClaudeApiKey",
         "serverClaudeKeyAvailable",
         "hasClaudeProviderCredential",
@@ -312,6 +322,13 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
         "CLAUDE_MODEL",
         "CLAUDE_MODEL_ALIASES",
         "CLAUDE_MODEL_FALLBACKS",
+        "JetsonAtakActivateRequest",
+        "JetsonAtakModeResponse",
+        "TERA_ATAK_MODEL",
+        "JETSON_ATAK_MODE",
+        "activate_jetson_atak_agent",
+        "jetson_atak_agent_mirror",
+        "_append_atak_mirror_event",
         "default_provider",
         "claude_default_model",
         "anthropic_api_key_configured",
@@ -328,8 +345,9 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
 
 
 def test_claude_model_labels_normalize_to_current_sonnet() -> None:
-    assert kmh_app._normalize_claude_model("Claude Sonnet 4.6") == "claude-sonnet-4-20250514"
-    assert kmh_app._normalize_claude_model("claude-sonnet-4.6") == "claude-sonnet-4-20250514"
+    assert kmh_app._normalize_claude_model("Claude Sonnet 4.6") == "claude-sonnet-4-6"
+    assert kmh_app._normalize_claude_model("claude-sonnet-4.6") == "claude-sonnet-4-6"
+    assert kmh_app._normalize_claude_model("claude-sonnet-4-6") == "claude-sonnet-4-6"
     assert kmh_app._normalize_claude_model("claude-sonnet-4-20250514") == "claude-sonnet-4-20250514"
     assert kmh_app._normalize_claude_model("Claude Opus 4.1") == "claude-opus-4-1-20250805"
     assert kmh_app._normalize_claude_model("Claude Opus 4.7") == "claude-opus-4-1-20250805"
@@ -343,7 +361,7 @@ def test_local_model_detection_prefers_installed_gemma_alias() -> None:
         "gemma3:4b",
     ]
 
-    assert kmh_app._select_ollama_default_model(models) == "gemma4:e4b"
+    assert kmh_app._select_ollama_default_model(models) == "gemma3:4b"
 
 
 def test_location_search_prefers_curated_cascades_match() -> None:
@@ -522,6 +540,44 @@ def test_backend_provider_sequence_is_claude_then_ollama() -> None:
     assert kmh_app._provider_sequence(
         kmh_app.PromptRequest(prompt="x", llm_provider="claude")
     ) == ["claude", "ollama"]
+
+
+@pytest.mark.asyncio
+async def test_atak_activation_forces_auto_prompts_to_local_gemma(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    original_mode = kmh_app.JETSON_ATAK_MODE.copy()
+    original_active_model = kmh_app.ACTIVE_OLLAMA_MODEL
+    original_active_base_url = kmh_app.ACTIVE_OLLAMA_BASE_URL
+
+    async def fake_fetch_models(_base_url: str) -> list[str]:
+        return ["gemma3:4b"]
+
+    monkeypatch.setenv("TERA_ATAK_MIRROR_LOG", str(tmp_path / "atak-mirror.jsonl"))
+    monkeypatch.setattr(kmh_app, "TERA_ATAK_ACTIVATE_COMMAND", "")
+    monkeypatch.setattr(kmh_app, "_fetch_ollama_models_from", fake_fetch_models)
+
+    try:
+        response = await kmh_app.activate_jetson_atak_agent(
+            kmh_app.JetsonAtakActivateRequest()
+        )
+
+        assert response.active is True
+        assert response.model == "gemma3:4b"
+        assert response.provider == "ollama"
+        assert response.events
+        assert kmh_app._provider_sequence(
+            kmh_app.PromptRequest(prompt="x", llm_provider="auto")
+        ) == ["ollama"]
+        assert await kmh_app._resolve_ollama_model(
+            kmh_app.PromptRequest(prompt="x")
+        ) == "gemma3:4b"
+    finally:
+        kmh_app.JETSON_ATAK_MODE.clear()
+        kmh_app.JETSON_ATAK_MODE.update(original_mode)
+        kmh_app.ACTIVE_OLLAMA_MODEL = original_active_model
+        kmh_app.ACTIVE_OLLAMA_BASE_URL = original_active_base_url
 
 
 class _ClaudeInvalidModelResponse:

--- a/tests/test_llm_dev_stream.py
+++ b/tests/test_llm_dev_stream.py
@@ -117,7 +117,7 @@ async def test_prompt_stream_can_use_claude_provider(monkeypatch: pytest.MonkeyP
         kmh_app.PromptRequest(
             prompt="Recommend sources.",
             llm_provider="claude",
-            cloud_model="claude-sonnet-4-20250514",
+            cloud_model="Claude Sonnet 4.6",
             cloud_api_key="sk-ant-test",
         )
     )
@@ -136,7 +136,7 @@ async def test_prompt_stream_reports_missing_claude_key() -> None:
         kmh_app.PromptRequest(
             prompt="Recommend sources.",
             llm_provider="claude",
-            cloud_model="claude-sonnet-4-20250514",
+            cloud_model="claude-sonnet-4-6",
         )
     )
 
@@ -210,7 +210,8 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
         'id="claudeModelSelect"',
         'id="claudeApiKeyInput"',
         "Claude API",
-        "claude-sonnet-4-20250514",
+        "claude-sonnet-4-6",
+        "Claude Sonnet 4.6",
     ]:
         assert token in html
 
@@ -225,6 +226,8 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
     for token in [
         "teraLlmProvider",
         "teraClaudeApiKey",
+        "serverClaudeKeyAvailable",
+        "anthropic_api_key_configured",
         "applyProviderSelection",
         "void loadModels();",
         "Detected local model:",
@@ -239,13 +242,22 @@ def test_model_provider_menu_supports_local_and_claude() -> None:
         "ANTHROPIC_API_URL",
         "ANTHROPIC_VERSION",
         "CLAUDE_MODEL",
+        "CLAUDE_MODEL_ALIASES",
         "claude_default_model",
+        "anthropic_api_key_configured",
+        "_normalize_claude_model",
         "_select_ollama_default_model",
         "Auto-detected installed Gemma model",
         "_post_claude_message",
         "_extract_claude_response_text",
     ]:
         assert token in app_source
+
+
+def test_claude_model_labels_normalize_to_current_sonnet() -> None:
+    assert kmh_app._normalize_claude_model("Claude Sonnet 4.6") == "claude-sonnet-4-6"
+    assert kmh_app._normalize_claude_model("claude-sonnet-4.6") == "claude-sonnet-4-6"
+    assert kmh_app._normalize_claude_model("claude-sonnet-4-20250514") == "claude-sonnet-4-6"
 
 
 def test_local_model_detection_prefers_installed_gemma_alias() -> None:
@@ -264,6 +276,17 @@ def test_location_search_prefers_curated_cascades_match() -> None:
     assert suggestions
     assert suggestions[0].name == "Cascade Range, WA/OR/BC"
     assert suggestions[0].score > 0
+
+
+def test_location_search_parses_google_maps_coordinate_links() -> None:
+    suggestion = kmh_app._coordinate_location_suggestion(
+        "https://www.google.com/maps/place/test/data=!3m1!4b1!4m6!3m5!8m2!3d47.8021!4d-123.6044"
+    )
+
+    assert suggestion is not None
+    assert suggestion.source == "coordinate-query"
+    assert suggestion.lat == 47.8021
+    assert suggestion.lon == -123.6044
 
 
 def test_planner_workflow_has_carousel_and_resizable_ao_handles() -> None:
@@ -288,7 +311,7 @@ def test_planner_keeps_scope_questions_in_agent_response_only() -> None:
 
     assert "ensureClarifyingQuestions" in js
     assert "state.workflowStageIndex = 1;" in js
-    assert "Use the advisor response to scope, then confirm sources." in js
+    assert "Confirm sources when ready." in js
     assert "### Scope Check" in js
     assert 'data-workflow-slide="questions"' not in html
     assert 'id="clarifyingQuestions"' not in html
@@ -326,6 +349,17 @@ def test_data_package_empty_state_does_not_repeat_chat_instruction() -> None:
     assert "Describe the mission in chat to begin source planning." not in html
 
 
+def test_chat_panel_hides_advisor_header_and_status_noise() -> None:
+    html = kmh_app.INDEX_FILE.read_text(encoding="utf-8")
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+
+    assert "<h2>Source Advisor</h2>" not in html
+    assert '<div class="visually-hidden">' in html
+    assert 'id="requestStatus" class="section-meta" aria-live="polite"' in html
+    assert "Use the advisor response" not in js
+    assert "Deterministic advisor response shown (" not in js
+
+
 def test_source_planner_degrades_without_false_inference_failure() -> None:
     html = kmh_app.INDEX_FILE.read_text(encoding="utf-8")
     js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
@@ -336,7 +370,7 @@ def test_source_planner_degrades_without_false_inference_failure() -> None:
     assert "Source planner unavailable" in js
     assert "Planning source package" in js
     assert "Local model offline; rules active" in js
-    assert "deterministic fallback" in js
+    assert "deterministic planner response" in js
     assert "plan the needed package" in html
 
     for stale_label in [
@@ -358,15 +392,19 @@ def test_prompt_submission_tries_selected_provider_then_local_then_deterministic
 
     assert "streamAssistantProvider" in js
     assert "resolveLocalModelForFallback" in js
-    assert "Claude failed; trying local Ollama fallback" in js
-    assert "Claude key missing; trying local Ollama fallback" in js
-    assert "local fallback after Claude failure" in js
-    assert "Model providers unavailable; deterministic advisor response shown" in js
+    assert "Trying local model fallback" in js
+    assert "Claude request failed. Check key, model access, or network." in js
+    assert "deterministic planner response" in js
+    assert "Model providers unavailable; deterministic planner response shown." in js
     assert 'provider === "ollama" && !state.localModelAvailable' not in js
+    assert "Claude failed; trying local Ollama fallback" not in js
+    assert "Claude key missing; trying local Ollama fallback" not in js
+    assert "local fallback after Claude failure" not in js
+    assert "Model providers unavailable; deterministic advisor response shown (" not in js
 
     claude_attempt = js.index('provider: "claude"')
     local_attempt = js.index('provider: "ollama"')
-    deterministic = js.index("Model providers unavailable; deterministic advisor response shown")
+    deterministic = js.index("deterministic planner response")
 
     assert claude_attempt < local_attempt < deterministic
 
@@ -420,14 +458,26 @@ def test_header_title_precedes_kicker_and_map_imports_kml_overlays() -> None:
     )
     assert 'id="importOverlayBtn"' in html
     assert 'id="overlayFileInput"' in html
+    assert 'id="mapModeToggleBtn"' in html
     assert 'accept=".kml,.kmz' in html
+    assert "jszip@3.10.1" in html
     assert ".file-input" in css
+    assert ".map-mode-toggle" in css
 
     assert "overlayDataSource" in js
     assert "async function importMapOverlay" in js
+    assert "sceneMode: Cesium.SceneMode.SCENE2D" in js
+    assert "function setMapMode" in js
+    assert "Cesium.ScreenSpaceEventType.MIDDLE_DOWN" in js
+    assert "async function readOverlayFileText" in js
+    assert "function parseKmlToGeoJson" in js
+    assert "Cesium.GeoJsonDataSource.load" in js
+    assert "function styleOverlayDataSource" in js
+    assert "function loadNativeOverlayDataSource" in js
     assert "Cesium.KmlDataSource.load" in js
     assert "state.viewer.dataSources.add(dataSource)" in js
     assert "state.viewer.flyTo(state.overlayDataSource" in js
+    assert 'els.mapModeToggleBtn.addEventListener("click", toggleMapMode)' in js
     assert 'els.importOverlayBtn.addEventListener("click", requestOverlayFile)' in js
     assert 'els.overlayFileInput.addEventListener("change", onOverlayFileSelected)' in js
 
@@ -478,6 +528,26 @@ def test_map_location_search_sets_context_and_center_grid() -> None:
     assert "LOCATION_SEARCH_URL" in app_source
     assert "LOCATION_INTENT_PREFIX_RE" in app_source
     assert "_score_online_location" in app_source
+    assert "GOOGLE_MAPS_API_KEY" in app_source
+    assert "GOOGLE_PLACES_AUTOCOMPLETE_URL" in app_source
+    assert "GOOGLE_PLACE_DETAILS_URL_BASE" in app_source
+    assert "GOOGLE_PLACES_TEXT_SEARCH_URL" in app_source
+    assert "_google_places_autocomplete_suggestions" in app_source
+    assert "_google_place_details_suggestion" in app_source
+    assert "_google_places_location_suggestions" in app_source
+    assert "includeQueryPredictions" in app_source
+    assert "suggestions.placePrediction.place" in app_source
+    assert "X-Goog-FieldMask" in app_source
+    assert "google-places" in app_source
+    assert "q: str = Query(min_length=1" in app_source
+    assert "parseGoogleMapsCoordinateQuery" in js
+    assert "!3d" in js
+    assert "!4d" in js
+    assert "locationSearchDetail" in js
+    assert "googleMapsSearchUrl" in js
+    assert "Open Google Maps search" in js
+    assert "cleanedQuery.length < 1" in js
+    assert "cleanedQuery.length < 2" not in js
     assert "Planner-confirmed mission map focus" in app_source
     assert "Move the map to the mission AO" in app_source
     assert "use the map location search" in prompt

--- a/tests/test_llm_dev_stream.py
+++ b/tests/test_llm_dev_stream.py
@@ -259,6 +259,26 @@ def test_planner_workflow_has_carousel_and_resizable_ao_handles() -> None:
     assert "finishAreaResize" in js
 
 
+def test_planner_opens_questions_and_uses_compact_source_checklist() -> None:
+    css = (kmh_app.STATIC_DIR / "styles.css").read_text(encoding="utf-8")
+    js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
+
+    assert "ensureClarifyingQuestions" in js
+    assert "state.workflowStageIndex = 1;" in js
+    assert "Use Questions to scope, then confirm sources." in js
+    assert "Next questions:" not in js
+
+    assert 'article.className = "source-item compact-source-item";' in js
+    assert 'article.title = `${source.category} | ${formatSourceStatus(source)}`;' in js
+    assert 'purpose.className = "source-purpose"' not in js
+    assert 'meta.className = "source-meta"' not in js
+
+    assert "--text-base: 12px;" in css
+    assert "max-height: min(18vh, 180px);" in css
+    assert "grid-template-columns: auto minmax(0, 1fr);" in css
+    assert "min-height: 76px;" in css
+
+
 def test_source_planner_degrades_without_false_inference_failure() -> None:
     html = kmh_app.INDEX_FILE.read_text(encoding="utf-8")
     js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")

--- a/tests/test_llm_dev_stream.py
+++ b/tests/test_llm_dev_stream.py
@@ -371,6 +371,10 @@ def test_map_location_search_sets_context_and_center_grid() -> None:
     assert "/api/location-search" in js
     assert "flyToLocationSuggestion" in js
     assert "latLonToUtm" in js
+    assert "latLonToMgrs" in js
+    assert "utmToMgrs" in js
+    assert "MGRS " in js
+    assert "MGRS_COLUMN_LETTER_SETS" in js
     assert "updateCenterGrid()" in js
     assert "location_confirmed" in js
     assert "location_focus_label" in js


### PR DESCRIPTION
Rebased Kyle's khick/source-planner-ui-polish onto current main while he was away. Net: 7 commits, +6462/-263, 15 files. CI parity: 278/278 tests green, ruff check + format-check clean.

## What landed

- `atak/README.md` + `atak/scripts/run_jetson_gemma_server.sh` + `atak/scripts/test_jetson_link.sh` — **Jetson-as-server pattern** (Ben needs this for the plugin → Jetson flow)
- `llm_dev_kmh/static/*` — TERA Source Planner UI (2D/3D toggle, MGRS conversion, Cesium tokens, Google Maps integration, clarifying questions handling)
- `llm_dev_kmh/geo_algorithms.py` — pathfinding + terrain analysis
- `prompts/local_model_prompts/imagery_sourcing_local_model_system_prompt.md` — refreshed prompt
- `tests/test_llm_dev_stream.py` — extended test coverage

## Conflicts resolved

- `Makefile`: union of .PHONY targets (kept main's `shellcheck-syntax run-https gen-cert firewall*` + added Kyle's `atak-link-server atak-link-test`)
- `llm_dev_kmh/tera_gemma/chat_tera_gemma.py`: identical content on both sides (Kyle authored it; same file landed via #73), pure metadata add/add — took either side
- `.gitignore`: clean three-way merge

## Why this rebase happened

Kyle stepped away mid-task; Ben needs the Jetson server scripts to wire up the plugin → Jetson flow. Rebased with the original commit attribution preserved (Kyle is co-author on each commit). Kyle, free to amend / re-rebase yourself when you're back.

Closes the gap toward Phase-3 demo (Jetson speaks both ways).