### PR TITLE
feat(atak): Jetson Gemma proof server + ATAK link-test scripts (from Kyle)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help onboard catchup install install-crypto install-voice fmt lint test security shellcheck-syntax ci run run-https gen-cert tcpdump-demo audit-log demo-proofs inject-demo sign-bench demo eval clean protect-branch firewall firewall-remove firewall-status
+.PHONY: help onboard catchup install install-crypto install-voice fmt lint test security shellcheck-syntax ci run run-https gen-cert atak-link-server atak-link-test tcpdump-demo audit-log demo-proofs inject-demo sign-bench demo eval clean protect-branch firewall firewall-remove firewall-status
 .DEFAULT_GOAL := help
 
 ifeq ($(OS),Windows_NT)
@@ -121,6 +121,13 @@ firewall-remove: ## Remove the TERA port 8000 firewall block
 
 firewall-status: ## Check if port 8000 firewall rule is active
 	@powershell -ExecutionPolicy Bypass -File infra/firewall_dev.ps1 status
+
+atak-link-server: install ## Start Jetson Gemma proof server for ATAK plugin link tests
+	bash atak/scripts/run_jetson_gemma_server.sh
+
+atak-link-test: ## Test Samsung/ATAK-device LAN reachability to Jetson. Pass JETSON_IP=...
+	@test -n "$(JETSON_IP)" || (echo "Usage: make atak-link-test JETSON_IP=<jetson-wifi-ip> [PORT=8080]" >&2; exit 2)
+	bash atak/scripts/test_jetson_link.sh "$(JETSON_IP)" "$(if $(PORT),$(PORT),8080)"
 
 tcpdump-demo: ## Open tcpdump no-outbound monitor + audit log scroll for the security proof
 	@bash infra/security_demo_monitors.sh

--- a/atak/README.md
+++ b/atak/README.md
@@ -1,0 +1,164 @@
+# ATAK Jetson Link Test
+
+This lane currently contains the LAN test harness for proving that a Samsung
+device running ATAK/TERA can reach the Jetson over WiFi and receive a response
+from the local Gemma/Ollama path.
+
+The Android ATAK plugin skeleton is not present in this checkout beyond
+`.gitkeep`, so these scripts are the reproducible connectivity probe and the
+request shape the plugin should issue once the Java/Gradle files are restored.
+
+## What Was Added
+
+- `atak/scripts/run_jetson_gemma_server.sh` starts the Jetson-side FastAPI proof
+  harness at `0.0.0.0:8080` and points it at local Ollama.
+- `atak/scripts/test_jetson_link.sh` sends the same HTTP request the ATAK plugin
+  should send to the Jetson.
+- `Makefile` targets `atak-link-server` and `atak-link-test` wrap those scripts.
+
+The test endpoint is:
+
+```text
+http://<JETSON_WIFI_IP>:8080/api/prompt
+```
+
+The server expects Ollama on the Jetson at:
+
+```text
+http://127.0.0.1:11434
+```
+
+Default model:
+
+```text
+gemma3:4b
+```
+
+## Jetson Setup
+
+Run these on the Jetson.
+
+1. Connect the Jetson to the same WiFi network as the Samsung ATAK device.
+
+2. Confirm Ollama is installed:
+
+   ```bash
+   ollama --version
+   ```
+
+3. Pull the model before going offline if it is not installed:
+
+   ```bash
+   ollama list
+   ollama pull gemma3:4b
+   ```
+
+4. From the repo root, install Python dependencies if needed:
+
+   ```bash
+   python3.11 -m venv .venv
+   . .venv/bin/activate
+   python -m pip install --upgrade pip
+   python -m pip install -e .
+   ```
+
+5. Start the Jetson link server:
+
+   ```bash
+   bash atak/scripts/run_jetson_gemma_server.sh
+   ```
+
+   Equivalent make target:
+
+   ```bash
+   make atak-link-server
+   ```
+
+6. Find the Jetson WiFi IP:
+
+   ```bash
+   hostname -I
+   ip -4 addr show
+   ```
+
+   Use the address on the WiFi interface, for example `192.168.1.42`.
+
+7. Verify locally on the Jetson:
+
+   ```bash
+   curl -s http://127.0.0.1:8080/health
+   ```
+
+8. Verify the Gemma endpoint locally:
+
+   ```bash
+   curl -s -X POST http://127.0.0.1:8080/api/prompt \
+     -H "Content-Type: application/json" \
+     -d '{"prompt":"TERA ATAK link test. Reply briefly.","model":"gemma3:4b","llm_provider":"ollama","agent_profile":"tera-atak-link-test"}'
+   ```
+
+## ATAK Device Setup
+
+Use this first from Android Termux or another shell on the Samsung device. This
+proves the same network path the ATAK plugin will use.
+
+1. Connect the Samsung device to the same WiFi network as the Jetson.
+
+2. Install Termux if you need a shell, then install curl:
+
+   ```bash
+   pkg install curl python
+   ```
+
+3. Run the link test, replacing the IP with the Jetson WiFi IP:
+
+   ```bash
+   bash atak/scripts/test_jetson_link.sh 192.168.1.42 8080
+   ```
+
+   If running from a dev laptop instead of the phone:
+
+   ```bash
+   make atak-link-test JETSON_IP=192.168.1.42
+   ```
+
+4. Expected output starts with:
+
+   ```text
+   SUCCESS: TERA ATAK link reached Jetson Gemma endpoint.
+   ```
+
+5. In the ATAK plugin, configure the same values:
+
+   ```text
+   Jetson IP: <JETSON_WIFI_IP>
+   Port: 8080
+   Endpoint: /api/prompt
+   Model: gemma3:4b
+   ```
+
+6. The plugin should POST this JSON:
+
+   ```json
+   {
+     "prompt": "TERA ATAK link test. Reply with JSON containing status, model, and one short readiness sentence.",
+     "model": "gemma3:4b",
+     "llm_provider": "ollama",
+     "agent_profile": "tera-atak-link-test"
+   }
+   ```
+
+7. Treat HTTP 200 with a non-empty `response` field as success.
+
+## Troubleshooting
+
+- If `http://<JETSON_IP>:8080/health` fails from the phone, check that both
+  devices are on the same WiFi subnet and that the Jetson server is bound to
+  `0.0.0.0`.
+- If health works but `/api/prompt` fails, check `ollama serve` and
+  `ollama list` on the Jetson.
+- If the first prompt is slow, run it once on the Jetson first to warm the
+  model.
+- If the phone cannot reach TCP 8080, allow inbound TCP 8080 on the Jetson
+  firewall for the test window.
+- This is a same-WiFi LAN proof. It is not the final Phase 3 WiFi-off hero path.

--- a/atak/scripts/run_jetson_gemma_server.sh
+++ b/atak/scripts/run_jetson_gemma_server.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+HOST="${TERA_ATAK_TEST_HOST:-0.0.0.0}"
+PORT="${TERA_ATAK_TEST_PORT:-8080}"
+MODEL="${OLLAMA_MODEL:-${TERA_GEMMA_MODEL:-gemma3:4b}}"
+OLLAMA_BASE_URL="${OLLAMA_BASE_URL:-http://127.0.0.1:11434}"
+OLLAMA_LOG="${TERA_OLLAMA_LOG:-/tmp/tera-ollama.log}"
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "error: curl is required on the Jetson." >&2
+  exit 1
+fi
+
+if ! command -v ollama >/dev/null 2>&1; then
+  echo "error: ollama is required on the Jetson." >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 is required on the Jetson." >&2
+  exit 1
+fi
+
+start_ollama_if_needed() {
+  if curl -fsS --max-time 2 "${OLLAMA_BASE_URL}/api/tags" >/dev/null 2>&1; then
+    return
+  fi
+
+  case "${OLLAMA_BASE_URL}" in
+    http://127.0.0.1:11434|http://localhost:11434)
+      echo "Ollama is not responding at ${OLLAMA_BASE_URL}; starting ollama serve..."
+      OLLAMA_HOST=127.0.0.1:11434 ollama serve >"${OLLAMA_LOG}" 2>&1 &
+      ;;
+    *)
+      echo "error: Ollama is not responding at ${OLLAMA_BASE_URL}." >&2
+      echo "Start Ollama manually or set OLLAMA_BASE_URL to the reachable local URL." >&2
+      exit 1
+      ;;
+  esac
+
+  for _ in $(seq 1 40); do
+    if curl -fsS --max-time 2 "${OLLAMA_BASE_URL}/api/tags" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 0.25
+  done
+
+  echo "error: started ollama serve, but ${OLLAMA_BASE_URL} did not become ready." >&2
+  echo "ollama log: ${OLLAMA_LOG}" >&2
+  exit 1
+}
+
+start_ollama_if_needed
+
+if ! ollama show "${MODEL}" >/dev/null 2>&1; then
+  echo "error: Ollama model ${MODEL} is not installed." >&2
+  echo "Before going offline, run: ollama pull ${MODEL}" >&2
+  exit 1
+fi
+
+cd "${REPO_ROOT}"
+
+if [ -x ".venv/bin/uvicorn" ]; then
+  UVICORN_CMD=(".venv/bin/uvicorn")
+elif command -v uvicorn >/dev/null 2>&1; then
+  UVICORN_CMD=("uvicorn")
+else
+  UVICORN_CMD=("python3" "-m" "uvicorn")
+fi
+
+echo "TERA ATAK Jetson link server"
+echo "repo: ${REPO_ROOT}"
+echo "ollama: ${OLLAMA_BASE_URL}"
+echo "model: ${MODEL}"
+echo "bind: ${HOST}:${PORT}"
+echo
+echo "Use the Jetson WiFi IP from one of these commands on the ATAK device:"
+echo "  hostname -I"
+echo "  ip -4 addr show"
+echo
+echo "Health URL: http://<JETSON_WIFI_IP>:${PORT}/health"
+echo "Prompt URL: http://<JETSON_WIFI_IP>:${PORT}/api/prompt"
+echo
+
+export OLLAMA_BASE_URL
+export OLLAMA_MODEL="${MODEL}"
+
+exec "${UVICORN_CMD[@]}" llm_dev_kmh.app:app --host "${HOST}" --port "${PORT}"

--- a/atak/scripts/test_jetson_link.sh
+++ b/atak/scripts/test_jetson_link.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  atak/scripts/test_jetson_link.sh <JETSON_IP> [PORT]
+
+Environment overrides:
+  OLLAMA_MODEL              Model name sent to the Jetson. Default: gemma3:4b
+  TERA_ATAK_TEST_PROMPT     Prompt sent to /api/prompt.
+  TERA_ATAK_CONNECT_S       TCP connect timeout. Default: 5
+  TERA_ATAK_TIMEOUT_S       Full prompt timeout. Default: 180
+
+Example:
+  atak/scripts/test_jetson_link.sh 192.168.1.42 8080
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -lt 1 ]; then
+  usage >&2
+  exit 2
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "error: curl is required. On Android, install Termux and run: pkg install curl" >&2
+  exit 1
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+else
+  echo "error: python is required for JSON escaping." >&2
+  echo "On Android Termux, run: pkg install python" >&2
+  exit 1
+fi
+
+JETSON_IP="$1"
+PORT="${2:-8080}"
+MODEL="${OLLAMA_MODEL:-gemma3:4b}"
+CONNECT_TIMEOUT="${TERA_ATAK_CONNECT_S:-5}"
+REQUEST_TIMEOUT="${TERA_ATAK_TIMEOUT_S:-180}"
+PROMPT="${TERA_ATAK_TEST_PROMPT:-TERA ATAK link test. Reply with JSON containing status, model, and one short readiness sentence.}"
+
+BASE_URL="http://${JETSON_IP}:${PORT}"
+HEALTH_URL="${BASE_URL}/health"
+PROMPT_URL="${BASE_URL}/api/prompt"
+
+if ! curl -fsS --connect-timeout "${CONNECT_TIMEOUT}" --max-time 10 "${HEALTH_URL}" >/dev/null; then
+  echo "FAIL: could not reach Jetson health endpoint: ${HEALTH_URL}" >&2
+  echo "Check same WiFi, Jetson IP, firewall, and that uvicorn is bound to 0.0.0.0." >&2
+  exit 1
+fi
+
+BODY="$(printf '{"prompt":%s,"model":%s,"llm_provider":"ollama","agent_profile":"tera-atak-link-test"}' \
+  "$(printf '%s' "${PROMPT}" | "${PYTHON_BIN}" -c 'import json,sys; print(json.dumps(sys.stdin.read()))')" \
+  "$(printf '%s' "${MODEL}" | "${PYTHON_BIN}" -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")"
+
+TMP_RESPONSE="$(mktemp)"
+trap 'rm -f "${TMP_RESPONSE}"' EXIT
+
+HTTP_CODE="$(
+  curl -sS \
+    --connect-timeout "${CONNECT_TIMEOUT}" \
+    --max-time "${REQUEST_TIMEOUT}" \
+    -o "${TMP_RESPONSE}" \
+    -w "%{http_code}" \
+    -X POST "${PROMPT_URL}" \
+    -H "Content-Type: application/json" \
+    -d "${BODY}"
+)"
+
+if [ "${HTTP_CODE}" != "200" ]; then
+  echo "FAIL: Jetson prompt endpoint returned HTTP ${HTTP_CODE}: ${PROMPT_URL}" >&2
+  cat "${TMP_RESPONSE}" >&2
+  echo >&2
+  exit 1
+fi
+
+if ! grep -q '"response"' "${TMP_RESPONSE}"; then
+  echo "FAIL: Jetson returned HTTP 200 but no response field." >&2
+  cat "${TMP_RESPONSE}" >&2
+  echo >&2
+  exit 1
+fi
+
+echo "SUCCESS: TERA ATAK link reached Jetson Gemma endpoint."
+echo "health: ${HEALTH_URL}"
+echo "prompt: ${PROMPT_URL}"
+echo "model: ${MODEL}"
+echo
+cat "${TMP_RESPONSE}"
+echo


### PR DESCRIPTION
Cherry-picks the ATAK lane bits from Kyle's `khick/source-planner-ui-polish` so Ben can pull them via `make catchup` and wire the plugin's HTTP path. Kyle stepped away; rest of his branch (Cesium UI, geo_algorithms, Source Planner UI) waits for his return.
## What lands
- `atak/scripts/run_jetson_gemma_server.sh` — Jetson FastAPI proof server on `0.0.0.0:8080` → local Ollama, verifies `gemma3:4b`
- `atak/scripts/test_jetson_link.sh` — Samsung/ATAK-device path test (`/health` + `/api/prompt` POST). Usage: `bash test_jetson_link.sh <JETSON_IP> [PORT]`
- `atak/README.md` — setup, runbook, expected request JSON, same-WiFi limitation
- `Makefile`: `atak-link-server` + `atak-link-test` targets
## Run order Ben needs
**On Jetson:**
ollama list # confirm gemma3:4b make atak-link-server # starts server on :8080 hostname -I # get WiFi IP

**On Samsung/ATAK device (same WiFi):**
make atak-link-test JETSON_IP=

Plugin config:
Jetson IP: <JETSON_IP> Port: 8080 Endpoint: /api/prompt Model: gemma3:4b


## Test plan
- [x] `bash -n atak/scripts/*.sh` parse-clean (covered by `make ci` shellcheck-syntax gate from #65)
- [x] 243/243 tests pass; ruff check + format-check + mypy clean
- [ ] Live Jetson run (Kyle/Ben's laptop)
- [ ] Live Samsung-side reachability test
## Attribution
Kyle authored these (commit `a02bedc` on `khick/source-planner-ui-polish`). Cherry-picked here because Ben is blocked on the plugin → Jetson wiring right now; rest of Kyle's branch needs his sign-off.