### PR TITLE
docs(demo): consolidate demo clips into <repo>/docs/demo-clips/ (gitignored)

### DIFF
--- a/docs/demo-clips/README.md
+++ b/docs/demo-clips/README.md
@@ -1,0 +1,36 @@
+# Demo Clips — Local-Only
+
+> **This directory is gitignored** (`*.mov`, `*.mp4`, `*.webm`, `*.mkv`, `*.m4a`, `*.mp3`, `*.flac`, `*.wav`). Only this README and a `.gitkeep` live in version control. The clips themselves stay on the recorder's laptop and (post-recording) in the team Drive folder + an unlisted YouTube channel for pitch-day fallback.
+>
+> **Why not commit?** Repo bloat (the ATAK plugin SDK incident at ~117 MB is the cautionary tale). YouTube unlisted serves the dissemination need at a fraction of the friction.
+
+## Filename convention
+
+`HHMM-<lane>-<short-desc>.<ext>`
+
+- `HHMM` = 24-hour time the clip was recorded (Pacific). Files sort chronologically.
+- `<lane>` = `voice`, `security`, `atak`, `crypto`, `hardware`, `agent`, etc.
+- `<short-desc>` = kebab-cased one-liner.
+
+Examples:
+- `2230-atak-plugin-mvp-demo.mov`
+- `2346-voice-severity-audio-test.mov`
+- `0500-voice-severity-pitch-mode.mov`
+
+## Index
+
+The canonical recording index lives in [`../demo-recording-plan.md`](../demo-recording-plan.md). Update there when you record a new clip; this directory is just where the binary lives until it lands in the team Drive folder + YouTube.
+
+## Workflow per clip
+
+1. Record locally (OBS / QuickTime).
+2. Save to this directory with the filename convention above.
+3. Update `docs/demo-recording-plan.md` table with the local filename + lane + description.
+4. Upload to YouTube unlisted (post-Sun-1300 cutover) and add the URL to the same table.
+5. Optionally drop a copy in the team Drive folder for cross-team review.
+
+## Cross-references
+
+- `docs/demo-recording-plan.md` — canonical recording index + pitch-day fallback rules.
+- PRD §12 — live pitch flow this material backs up.
+- `.gitignore` — the rule keeping these binaries out of git.

--- a/docs/demo-recording-plan.md
+++ b/docs/demo-recording-plan.md
@@ -6,9 +6,9 @@
 
 ## Storage convention
 
-Recordings stay off the public repo and out of the codebase. Team-wide approach:
+Recordings stay off the public repo and out of the codebase, but during dev they live in a known project subdirectory so the team can find them without hunting `~/Desktop`. Team-wide approach:
 
-1. **Local on the recorder's laptop:** `~/Desktop/tera-demo-clips/` (host-level gitignore safety net).
+1. **Local on the recorder's laptop:** `<repo>/docs/demo-clips/` (gitignored at the `*.mov`/`*.mp4`/`*.webm`/`*.mkv`/`*.m4a`/`*.mp3`/`*.flac`/`*.wav` patterns — directory tracked via `.gitkeep` + `README.md`, binaries never committed). See `docs/demo-clips/README.md` for filename conventions and per-clip workflow.
 2. **Team backup:** shared Drive folder (link in team Signal channel, not committed here — Drive folder URL changes per quarter).
 3. **Pitch-day distribution:** YouTube unlisted upload **before** Sun 1300 (cut-over from "team backup" to "publicly fetchable URL" so the submission packaging step can include direct links).
 
@@ -33,23 +33,24 @@ Already on disk under different names? Rename in-place; nothing in this doc refe
 
 | # | Recorded | Title | Length (rough) | Local filename | YouTube URL | Script that produced it |
 |---|----------|-------|----------------|----------------|-------------|--------------------------|
-| S1 | Sat 22:54 | CoT Track Injection Demo — 3 scenarios (unsigned reject / tampered reject / signed accept) | ~60-90s | `satriyo_demo_security_1.mp4` *(rename suggested: `2254-security-cot-inject-demo.mp4`)* | TBD | `security/cot_inject_demo.py` ・ `make inject-demo` |
-| S2 | Sat 22:59 | Attack-Vector Rejection — 5 regression tests (issue #25) | ~45-60s | `satriyo_security_demo_2.mp4` | TBD | `security/test_security_regressions.py` ・ `pytest security/test_security_regressions.py -v` |
-| S3 | Sat 23:00 | Sign Benchmark — 1000 ML-DSA-65 round-trips, 0.128 ms avg (39× under PRD §11.2 target) | ~30-45s | `satriyo_security_demo_3.mp4` | TBD | `crypto/sign_bench.py` ・ `make sign-bench` |
-| S4 | Sat 23:02 | Security Scan — Bandit + pip-audit clean across all lanes | ~30-45s | `satriyo_security_demo_4.mp4` | TBD | `make security` |
-| S5 | Sat 23:04 | Structured Query Validator — live blocking of 3 attack types (injection / privesc / exfil) | ~30-45s | `satriyo_security_demo_5.mp4` | TBD | `security/structured_query_validator.py` |
+| S1 | Sat 22:54 | CoT Track Injection Demo — 3 scenarios (unsigned reject / tampered reject / signed accept) | ~60-90s | `2254-security-cot-inject-demo.mp4` *(currently on Satriyo's laptop as `satriyo_demo_security_1.mp4` — rename when moving into `docs/demo-clips/`)* | TBD | `security/cot_inject_demo.py` ・ `make inject-demo` |
+| S2 | Sat 22:59 | Attack-Vector Rejection — 5 regression tests (issue #25) | ~45-60s | `2259-security-attack-vector-rejection.mp4` *(was `satriyo_security_demo_2.mp4`)* | TBD | `security/test_security_regressions.py` ・ `pytest security/test_security_regressions.py -v` |
+| S3 | Sat 23:00 | Sign Benchmark — 1000 ML-DSA-65 round-trips, 0.128 ms avg (39× under PRD §11.2 target) | ~30-45s | `2300-crypto-sign-bench.mp4` *(was `satriyo_security_demo_3.mp4`)* | TBD | `crypto/sign_bench.py` ・ `make sign-bench` |
+| S4 | Sat 23:02 | Security Scan — Bandit + pip-audit clean across all lanes | ~30-45s | `2302-security-scan.mp4` *(was `satriyo_security_demo_4.mp4`)* | TBD | `make security` |
+| S5 | Sat 23:04 | Structured Query Validator — live blocking of 3 attack types (injection / privesc / exfil) | ~30-45s | `2304-security-structured-query-validator.mp4` *(was `satriyo_security_demo_5.mp4`)* | TBD | `security/structured_query_validator.py` |
 
 ### ATAK lane (P4 — Ben)
 
 | # | Recorded | Title | Length | Local filename | YouTube URL | Script / scenario |
 |---|----------|-------|--------|----------------|-------------|-------------------|
-| B1 | Sat ~22:30 | ATAK plugin MVP — no-model hookup demo | ~30-60s | `atak-plugin-mvp-demo.mov` (in `~/Desktop/tera-demo-clips/` per `77efdbc` commit message) | TBD | Manual ATAK plugin walkthrough |
+| B1 | Sat 22:30 | ATAK plugin MVP — no-model hookup demo | ~30-60s | `2230-atak-plugin-mvp-demo.mov` (in `docs/demo-clips/`, gitignored, ~84 MB) | TBD | Manual ATAK plugin walkthrough |
 
 ### Voice / agent lane (P1 — Jon)
 
-| # | Title | Status |
-|---|-------|--------|
-| J1 | Self-narrating severity demo (judge-facing) | Code shipped via PR #76 + #78 (`scripts/demo_voice.py --severity-demo --pitch-mode`); no recording captured yet. Plan: capture Sun 0500-0700 once Jetson is running so we have voice + pitch-mode side by side. |
+| # | Recorded | Title | Length | Local filename | YouTube URL | Script that produced it |
+|---|----------|-------|--------|----------------|-------------|--------------------------|
+| J1 | Sat 23:46 | Severity demo — audio test capture (first OBS recording, sanity check) | ~30s | `2346-voice-severity-audio-test.mov` (in `docs/demo-clips/`, gitignored, ~2.7 MB) | TBD | `scripts/demo_voice.py --severity-demo` |
+| J2 | TBD | Severity demo — judge-facing pitch capture (with narration) | ~30-45s | `<HHMM>-voice-severity-pitch.mov` | TBD | `scripts/demo_voice.py --severity-demo` |
 
 ### Hardware / Jetson lane (P3 — Kyle)
 
@@ -93,7 +94,7 @@ The hackathon submission asks for a **1-minute YouTube video**. That's a *cut*, 
 
 ## After-event archive
 
-- Sun 1700 (post-winners): all recordings move from `~/Desktop/tera-demo-clips/` to the team's permanent Drive folder.
+- Sun 1700 (post-winners): all recordings move from `<repo>/docs/demo-clips/` to the team's permanent Drive folder. The local repo directory stays empty so future devs see the README without 100+ MB of stale clips.
 - Sun 1700: anyone who wants to retain a personal copy makes a personal Drive backup before the shared folder is cleaned up.
 - Mon: any recordings we want public become public-on-YouTube + linked from the post-mortem README. Anything sensitive stays unlisted forever.
 


### PR DESCRIPTION
Storage-convention follow-up to PR #87. Keeps the policy from PR #84 (binaries out of git) but moves the in-flight location from \`~/Desktop/tera-demo-clips/\` to \`<repo>/docs/demo-clips/\` so the team can find recordings without hunting.

## Changes

- **\`docs/demo-clips/\`** new directory with \`.gitkeep\` + \`README.md\` documenting the workflow per clip, filename convention, and gitignore policy.
- **\`docs/demo-recording-plan.md\`** updated:
  - Storage convention points at \`<repo>/docs/demo-clips/\`.
  - All per-clip index entries renamed to the \`HHMM-<lane>-<desc>\` convention.
  - Voice/agent lane (J1) now logs the 23:46 audio-test recording; J2 reserved for the judge-facing pitch capture.
  - After-event archive flushes \`<repo>/docs/demo-clips/\` on Sun 1700 (was \`~/Desktop\`).

## Files NOT in this PR (gitignored on purpose)

- \`docs/demo-clips/2230-atak-plugin-mvp-demo.mov\` (~84 MB) — Ben
- \`docs/demo-clips/2346-voice-severity-audio-test.mov\` (~2.7 MB) — Jon

Both verified as valid ISO QuickTime (ftyp box present). They play.

## Cross-refs

- PR #84 — gitignore rule
- PR #87 — original demo-recording-plan
- Issue #82 — recording session tracking