### PR TITLE
fix(make): dedupe atak-link-* targets after #85/#86 collision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,13 +129,6 @@ atak-link-test: ## Test Samsung/ATAK-device LAN reachability to Jetson. Pass JET
 	@test -n "$(JETSON_IP)" || (echo "Usage: make atak-link-test JETSON_IP=<jetson-wifi-ip> [PORT=8080]" >&2; exit 2)
 	bash atak/scripts/test_jetson_link.sh "$(JETSON_IP)" "$(if $(PORT),$(PORT),8080)"
 
-atak-link-server: install ## Start Jetson Gemma proof server for ATAK plugin link tests
-	bash atak/scripts/run_jetson_gemma_server.sh
-
-atak-link-test: ## Test Samsung/ATAK-device LAN reachability to Jetson. Pass JETSON_IP=...
-	@test -n "$(JETSON_IP)" || (echo "Usage: make atak-link-test JETSON_IP=<jetson-wifi-ip> [PORT=8080]" >&2; exit 2)
-	bash atak/scripts/test_jetson_link.sh "$(JETSON_IP)" "$(if $(PORT),$(PORT),8080)"
-
 tcpdump-demo: ## Open tcpdump no-outbound monitor + audit log scroll for the security proof
 	@bash infra/security_demo_monitors.sh
 


### PR DESCRIPTION
## Why

PR #86 and PR #85 both added \`atak-link-server\` / \`atak-link-test\` recipes. Both merged to \`main\`, leaving two identical definitions in the Makefile and producing this warning every time anyone runs \`make\` (including \`make catchup\`):

\`\`\`
Makefile:133: warning: overriding recipe for target 'atak-link-server'
Makefile:126: warning: ignoring old recipe for target 'atak-link-server'
Makefile:136: warning: overriding recipe for target 'atak-link-test'
Makefile:129: warning: ignoring old recipe for target 'atak-link-test'
\`\`\`

## What

Collapse to a single canonical definition. No behavior change — the recipes were byte-identical.

## Test
- \`make help\` runs without warnings
- \`grep -c '^atak-link-server' Makefile\` -> 1
- \`grep -c '^atak-link-test' Makefile\` -> 1