### PR TITLE
chore(deploy): add Jetson compose refresh script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help onboard catchup install install-crypto install-voice fmt lint test security shellcheck-syntax ci run run-https gen-cert atak-link-server atak-link-test tcpdump-demo audit-log demo-proofs inject-demo sign-bench demo eval clean protect-branch firewall firewall-remove firewall-status jetson-autoupdate-install
+.PHONY: help onboard catchup install install-crypto install-voice fmt lint test security shellcheck-syntax ci run run-https gen-cert atak-link-server atak-link-test tcpdump-demo audit-log demo-proofs inject-demo sign-bench demo eval clean protect-branch firewall firewall-remove firewall-status jetson-autoupdate-install jetson-compose-refresh
 .DEFAULT_GOAL := help
 
 ifeq ($(OS),Windows_NT)
@@ -166,6 +166,9 @@ eval: install ## Run the 20-prompt regression set
 
 jetson-autoupdate-install: ## Install systemd services on Jetson to auto-pull origin/main and restart planner
 	@bash deploy/scripts/install_jetson_autoupdate.sh
+
+jetson-compose-refresh: ## On Jetson: pull main and rebuild/restart the planner with Docker Compose
+	@bash deploy/scripts/jetson_compose_refresh.sh
 
 clean: ## Remove venv and caches
 	rm -rf $(VENV) .pytest_cache .ruff_cache .mypy_cache __pycache__

--- a/deploy/scripts/jetson_compose_refresh.sh
+++ b/deploy/scripts/jetson_compose_refresh.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-/home/digitaltrident1/Documents/tera_folder/tera}"
+REMOTE="${REMOTE:-origin}"
+BRANCH="${BRANCH:-main}"
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yml}"
+SERVICE_NAME="${SERVICE_NAME:-llm-dev-kmh}"
+PLANNER_URL="${PLANNER_URL:-http://127.0.0.1:8080}"
+
+cd "$REPO_DIR"
+
+if [[ ! -d .git ]]; then
+  echo "[jetson-refresh] not a git repo: $REPO_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "[jetson-refresh] missing compose file: $REPO_DIR/$COMPOSE_FILE" >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "[jetson-refresh] repo has uncommitted changes; refusing to overwrite them" >&2
+  git status --short >&2
+  exit 1
+fi
+
+compose() {
+  if docker compose version >/dev/null 2>&1; then
+    docker compose -f "$COMPOSE_FILE" "$@"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    docker-compose -f "$COMPOSE_FILE" "$@"
+  else
+    echo "[jetson-refresh] docker compose was not found" >&2
+    exit 1
+  fi
+}
+
+echo "[jetson-refresh] repo: $REPO_DIR"
+echo "[jetson-refresh] branch: $BRANCH"
+
+if [[ "$(git branch --show-current)" != "$BRANCH" ]]; then
+  git fetch --quiet "$REMOTE" "$BRANCH"
+  git switch "$BRANCH" 2>/dev/null || git switch --track "$REMOTE/$BRANCH"
+fi
+
+if command -v make >/dev/null 2>&1; then
+  make catchup
+else
+  git fetch --all --prune --quiet
+  git pull --ff-only "$REMOTE" "$BRANCH"
+fi
+
+head_short="$(git rev-parse --short HEAD)"
+echo "[jetson-refresh] now at $head_short"
+
+if ! grep -q 'id="atakAgentBtn"' llm_dev_kmh/static/index.html; then
+  echo "[jetson-refresh] warning: ATAK Local button marker not found in static HTML" >&2
+fi
+
+if systemctl list-unit-files tera-planner.service >/dev/null 2>&1; then
+  echo "[jetson-refresh] stopping tera-planner.service to free port 8080"
+  sudo systemctl stop tera-planner.service || true
+fi
+
+echo "[jetson-refresh] rebuilding and restarting Docker Compose service"
+compose down --remove-orphans
+compose up --build -d "$SERVICE_NAME"
+
+echo "[jetson-refresh] compose status"
+compose ps
+
+if command -v curl >/dev/null 2>&1; then
+  for _ in $(seq 1 30); do
+    if curl -fsS "$PLANNER_URL/" >/tmp/tera-planner-index.html; then
+      break
+    fi
+    sleep 1
+  done
+
+  if grep -q 'id="atakAgentBtn"' /tmp/tera-planner-index.html; then
+    echo "[jetson-refresh] OK: new planner is serving ATAK Local button at $PLANNER_URL"
+  else
+    echo "[jetson-refresh] warning: planner responded, but ATAK Local button was not found" >&2
+    echo "[jetson-refresh] inspect logs with: docker compose -f $COMPOSE_FILE logs -f $SERVICE_NAME" >&2
+  fi
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,13 @@ services:
       - "8080:8080"
     environment:
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
-      OLLAMA_MODEL: ${OLLAMA_MODEL:-gemma2:2b}
+      OLLAMA_MODEL: ${OLLAMA_MODEL:-gemma3:4b}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      CLAUDE_MODEL: ${CLAUDE_MODEL:-claude-sonnet-4-6}
+      TERA_ATAK_MODEL: ${TERA_ATAK_MODEL:-gemma3:4b}
+      TERA_ATAK_AGENT_PROFILE: ${TERA_ATAK_AGENT_PROFILE:-tera-atak-live}
+      TERA_ATAK_DEVICE_URL: ${TERA_ATAK_DEVICE_URL:-}
+      TERA_ATAK_AGENT_COMMAND: ${TERA_ATAK_AGENT_COMMAND:-}
       REQUEST_TIMEOUT_S: ${REQUEST_TIMEOUT_S:-120}
       CESIUM_ION_TOKEN: ${CESIUM_ION_TOKEN:-}
     extra_hosts:


### PR DESCRIPTION
Summary:
- add deploy/scripts/jetson_compose_refresh.sh for repeatable Jetson pull + Docker Compose rebuilds
- wire make jetson-compose-refresh
- align repo-root docker-compose defaults with the TERA/ATAK local agent app

Test Plan:
- bash -n deploy/scripts/jetson_compose_refresh.sh
- git diff --cached --check before commit

Notes:
- make is not installed in this Windows shell, so I could not run make shellcheck-syntax locally.
- A manual all-script bash -n sweep on this Windows checkout is blocked by pre-existing CRLF parsing in infra/audit_log_scroll.sh; the new script itself parses cleanly.