### PR TITLE
Update ATAK plugin Jetson chat integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help onboard catchup install install-crypto install-voice fmt lint test security shellcheck-syntax ci run run-https gen-cert atak-link-server atak-link-test tcpdump-demo audit-log demo-proofs inject-demo sign-bench demo eval clean protect-branch firewall firewall-remove firewall-status jetson-autoupdate-install jetson-compose-refresh
+.PHONY: help onboard catchup install install-crypto install-voice fmt lint test security shellcheck-syntax ci run run-https gen-cert atak-link-server atak-link-test atak-plugin-build atak-plugin-install tcpdump-demo audit-log demo-proofs inject-demo sign-bench demo eval clean protect-branch firewall firewall-remove firewall-status jetson-autoupdate-install jetson-compose-refresh
 .DEFAULT_GOAL := help
 
 ifeq ($(OS),Windows_NT)
@@ -128,6 +128,12 @@ atak-link-server: install ## Start Jetson Gemma proof server for ATAK plugin lin
 atak-link-test: ## Test Samsung/ATAK-device LAN reachability to Jetson. Pass JETSON_IP=...
 	@test -n "$(JETSON_IP)" || (echo "Usage: make atak-link-test JETSON_IP=<jetson-wifi-ip> [PORT=8080]" >&2; exit 2)
 	bash atak/scripts/test_jetson_link.sh "$(JETSON_IP)" "$(if $(PORT),$(PORT),8080)"
+
+atak-plugin-build: ## Build the ATAK plugin CIV release APK
+	cd atak/plugin && ./scripts/build_release.sh
+
+atak-plugin-install: ## Build if needed and install the ATAK plugin to an attached device
+	cd atak/plugin && ./scripts/install_device.sh
 
 tcpdump-demo: ## Open tcpdump no-outbound monitor + audit log scroll for the security proof
 	@bash infra/security_demo_monitors.sh

--- a/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
+++ b/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
@@ -149,13 +149,12 @@ public class TERAPlugin implements IPlugin {
         final TextView response = teraView.findViewById(R.id.tera_response);
         final StringBuilder chatHistory = new StringBuilder();
         final StringBuilder hostState = new StringBuilder();
-        final StringBuilder portState = new StringBuilder("8080");
         final boolean[] ttsEnabled = new boolean[] { false };
         final boolean[] listening = new boolean[] { false };
 
         hostButton.setText(R.string.host_local);
         hostButton.setOnClickListener(v -> showHostPopup(
-                hostButton, hostState, portState, status, connectionStatus));
+                hostButton, hostState, status, connectionStatus));
         infoButton.setOnClickListener(v -> showInfoPopup(infoButton));
         voiceMessage.setOnClickListener(v -> toggleVoiceInput(
                 voiceMessage, chatInput, status, listening));
@@ -173,7 +172,7 @@ public class TERAPlugin implements IPlugin {
                 return;
             }
             String host = hostState.toString();
-            String endpoint = buildEndpoint(host, portState.toString());
+            String endpoint = buildEndpoint(host);
             JSONObject mapContext = buildMapContext();
 
             appendChatLine(chatHistory, host.isEmpty() ? "Operator (local)" : "Operator (" + host + ")", message);
@@ -207,7 +206,7 @@ public class TERAPlugin implements IPlugin {
         });
     }
 
-    private void showHostPopup(Button hostButton, StringBuilder hostState, StringBuilder portState,
+    private void showHostPopup(Button hostButton, StringBuilder hostState,
                                TextView status, TextView connectionStatus) {
         LinearLayout content = new LinearLayout(hostButton.getContext());
         content.setOrientation(LinearLayout.VERTICAL);
@@ -235,47 +234,35 @@ public class TERAPlugin implements IPlugin {
         hostEdit.setPadding(dp(10), 0, dp(10), 0);
         hostEdit.setSelectAllOnFocus(false);
 
-        EditText portEdit = new EditText(hostButton.getContext());
-        portEdit.setSingleLine(true);
-        portEdit.setInputType(InputType.TYPE_CLASS_NUMBER);
-        portEdit.setHint(R.string.host_port_hint);
-        portEdit.setText(portState.toString());
-        portEdit.setTextSize(13);
-        portEdit.setTextColor(Color.BLACK);
-        portEdit.setHintTextColor(Color.GRAY);
-        portEdit.setBackgroundResource(R.drawable.host_input_bg);
-        portEdit.setPadding(dp(10), 0, dp(10), 0);
+        TextView result = new TextView(hostButton.getContext());
+        result.setTextColor(Color.WHITE);
+        result.setTextSize(14);
+        result.setLineSpacing(dp(2), 1.0f);
+        result.setPadding(0, dp(10), 0, 0);
+        result.setVisibility(View.GONE);
 
         LinearLayout actions = new LinearLayout(hostButton.getContext());
         actions.setOrientation(LinearLayout.HORIZONTAL);
         actions.setPadding(0, dp(10), 0, 0);
 
-        Button apply = new Button(hostButton.getContext());
-        apply.setText(R.string.host_popup_apply);
-        apply.setTextSize(12);
+        Button connect = new Button(hostButton.getContext());
+        connect.setText(R.string.host_popup_connect);
+        connect.setTextSize(12);
 
         Button useLocal = new Button(hostButton.getContext());
         useLocal.setText(R.string.host_popup_local);
         useLocal.setTextSize(12);
 
-        Button test = new Button(hostButton.getContext());
-        test.setText(R.string.host_popup_test);
-        test.setTextSize(12);
-
-        actions.addView(apply, new LinearLayout.LayoutParams(0,
+        actions.addView(connect, new LinearLayout.LayoutParams(0,
                 LinearLayout.LayoutParams.WRAP_CONTENT, 1));
         actions.addView(useLocal, new LinearLayout.LayoutParams(0,
-                LinearLayout.LayoutParams.WRAP_CONTENT, 1));
-        actions.addView(test, new LinearLayout.LayoutParams(0,
                 LinearLayout.LayoutParams.WRAP_CONTENT, 1));
 
         content.addView(title);
         content.addView(hostEdit, new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 dp(38)));
-        content.addView(portEdit, new LinearLayout.LayoutParams(
-                LinearLayout.LayoutParams.MATCH_PARENT,
-                dp(38)));
+        content.addView(result);
         content.addView(actions);
 
         PopupWindow popup = new PopupWindow(content, dp(300),
@@ -287,51 +274,42 @@ public class TERAPlugin implements IPlugin {
                 | WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
         popup.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(Color.TRANSPARENT));
 
-        apply.setOnClickListener(v -> {
-            hostState.setLength(0);
-            hostState.append(hostEdit.getText().toString().trim());
-            portState.setLength(0);
-            portState.append(normalizedPort(portEdit.getText().toString()));
-            hostButton.setText(hostState.length() == 0
-                    ? pluginContext.getString(R.string.host_local)
-                    : hostState.toString());
-            status.setText(hostState.length() == 0
-                    ? "Host set to local."
-                    : "Host set to " + hostState);
-            popup.dismiss();
-        });
-
         useLocal.setOnClickListener(v -> {
             hostState.setLength(0);
-            portState.setLength(0);
-            portState.append("8080");
             hostButton.setText(R.string.host_local);
             status.setText("Host set to local.");
             popup.dismiss();
         });
 
-        test.setOnClickListener(v -> {
+        connect.setOnClickListener(v -> {
             String host = hostEdit.getText().toString().trim();
-            String port = normalizedPort(portEdit.getText().toString());
-            String endpoint = buildEndpoint(host, port);
+            String endpoint = buildEndpoint(host);
             hideKeyboard(hostEdit);
-            test.setEnabled(false);
-            test.setText("...");
+            connect.setEnabled(false);
+            connect.setText("...");
             connectionStatus.setText(R.string.connection_connecting);
             status.setText("Testing Jetson connection...");
+            result.setVisibility(View.VISIBLE);
+            result.setText("Testing:\n" + endpoint);
             TeraPlanClient.checkJetson(endpoint, new TeraPlanClient.Callback() {
                 @Override
                 public void onComplete(boolean ok, String message) {
                     mainHandler.post(() -> {
-                        test.setEnabled(true);
-                        test.setText(R.string.host_popup_test);
+                        connect.setEnabled(true);
+                        connect.setText(R.string.host_popup_connect);
                         connectionStatus.setText(ok
                                 ? R.string.connection_online
                                 : R.string.connection_error);
                         status.setText(message);
-                        showMessagePopup(hostButton.getRootView(),
-                                ok ? "Jetson Connected" : "Jetson Connection Failed",
-                                message + "\n\nEndpoint:\n" + endpoint);
+                        result.setText(message + "\n\nEndpoint:\n" + endpoint);
+                        if (ok) {
+                            hostState.setLength(0);
+                            hostState.append(host);
+                            hostButton.setText(hostState.length() == 0
+                                    ? pluginContext.getString(R.string.host_local)
+                                    : hostState.toString());
+                            popup.dismiss();
+                        }
                     });
                 }
             });
@@ -469,7 +447,7 @@ public class TERAPlugin implements IPlugin {
         }
     }
 
-    private String buildEndpoint(String host, String port) {
+    private String buildEndpoint(String host) {
         if (host == null || host.trim().isEmpty()) {
             return pluginContext.getString(R.string.endpoint_hint);
         }
@@ -477,7 +455,7 @@ public class TERAPlugin implements IPlugin {
         String endpoint = host.trim();
         if (!endpoint.startsWith("http://") && !endpoint.startsWith("https://")) {
             if (!endpoint.contains(":")) {
-                endpoint = endpoint + ":" + normalizedPort(port);
+                endpoint = endpoint + ":8080";
             }
             endpoint = "http://" + endpoint;
         }
@@ -485,13 +463,6 @@ public class TERAPlugin implements IPlugin {
             endpoint = endpoint + pluginContext.getString(R.string.endpoint_path);
         }
         return endpoint;
-    }
-
-    private String normalizedPort(String port) {
-        if (port == null || port.trim().isEmpty()) {
-            return "8080";
-        }
-        return port.trim();
     }
 
     private JSONObject buildMapContext() {

--- a/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
+++ b/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
@@ -314,16 +314,24 @@ public class TERAPlugin implements IPlugin {
             String host = hostEdit.getText().toString().trim();
             String port = normalizedPort(portEdit.getText().toString());
             String endpoint = buildEndpoint(host, port);
+            hideKeyboard(hostEdit);
+            test.setEnabled(false);
+            test.setText("...");
             connectionStatus.setText(R.string.connection_connecting);
             status.setText("Testing Jetson connection...");
             TeraPlanClient.checkJetson(endpoint, new TeraPlanClient.Callback() {
                 @Override
                 public void onComplete(boolean ok, String message) {
                     mainHandler.post(() -> {
+                        test.setEnabled(true);
+                        test.setText(R.string.host_popup_test);
                         connectionStatus.setText(ok
                                 ? R.string.connection_online
                                 : R.string.connection_error);
                         status.setText(message);
+                        showMessagePopup(hostButton.getRootView(),
+                                ok ? "Jetson Connected" : "Jetson Connection Failed",
+                                message + "\n\nEndpoint:\n" + endpoint);
                     });
                 }
             });
@@ -544,6 +552,11 @@ public class TERAPlugin implements IPlugin {
     }
 
     private void showInfoPopup(View anchor) {
+        showMessagePopup(anchor, pluginContext.getString(R.string.tera_info_title),
+                pluginContext.getString(R.string.tera_info_message));
+    }
+
+    private void showMessagePopup(View anchor, String titleText, String messageText) {
         LinearLayout content = new LinearLayout(anchor.getContext());
         content.setOrientation(LinearLayout.VERTICAL);
         int padding = dp(12);
@@ -551,24 +564,41 @@ public class TERAPlugin implements IPlugin {
         content.setBackgroundResource(R.drawable.status_bar_bg);
 
         TextView title = new TextView(anchor.getContext());
-        title.setText(R.string.tera_info_title);
+        title.setText(titleText);
         title.setTextColor(Color.WHITE);
         title.setTextSize(15);
         title.setTypeface(null, android.graphics.Typeface.BOLD);
 
         TextView message = new TextView(anchor.getContext());
-        message.setText(R.string.tera_info_message);
+        message.setText(messageText);
         message.setTextColor(Color.WHITE);
-        message.setTextSize(13);
+        message.setTextSize(14);
+        message.setLineSpacing(dp(2), 1.0f);
         message.setPadding(0, dp(8), 0, 0);
+
+        Button close = new Button(anchor.getContext());
+        close.setText("OK");
+        close.setTextSize(12);
 
         content.addView(title);
         content.addView(message);
+        content.addView(close, new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT));
 
-        PopupWindow popup = new PopupWindow(content, dp(260), LinearLayout.LayoutParams.WRAP_CONTENT, true);
+        PopupWindow popup = new PopupWindow(content, dp(320), LinearLayout.LayoutParams.WRAP_CONTENT, true);
         popup.setOutsideTouchable(true);
         popup.setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(Color.TRANSPARENT));
-        popup.showAsDropDown(anchor, -dp(226), dp(6));
+        close.setOnClickListener(v -> popup.dismiss());
+        popup.showAtLocation(anchor.getRootView(), Gravity.CENTER, 0, 0);
+    }
+
+    private void hideKeyboard(View view) {
+        InputMethodManager imm = (InputMethodManager) pluginContext.getSystemService(
+                Context.INPUT_METHOD_SERVICE);
+        if (imm != null) {
+            imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+        }
     }
 
     private int dp(int value) {

--- a/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
+++ b/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
@@ -24,6 +24,14 @@ import android.widget.TextView;
 
 import com.atak.plugins.impl.PluginContextProvider;
 import com.atak.plugins.impl.PluginLayoutInflater;
+import com.atakmap.android.maps.MapView;
+import com.atakmap.android.maps.Marker;
+import com.atakmap.coremap.maps.coords.GeoBounds;
+import com.atakmap.coremap.maps.coords.GeoPoint;
+import com.atakmap.coremap.maps.coords.GeoPointMetaData;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import gov.tak.api.plugin.IPlugin;
 import gov.tak.api.plugin.IServiceController;
@@ -141,11 +149,13 @@ public class TERAPlugin implements IPlugin {
         final TextView response = teraView.findViewById(R.id.tera_response);
         final StringBuilder chatHistory = new StringBuilder();
         final StringBuilder hostState = new StringBuilder();
+        final StringBuilder portState = new StringBuilder("8080");
         final boolean[] ttsEnabled = new boolean[] { false };
         final boolean[] listening = new boolean[] { false };
 
         hostButton.setText(R.string.host_local);
-        hostButton.setOnClickListener(v -> showHostPopup(hostButton, hostState, status));
+        hostButton.setOnClickListener(v -> showHostPopup(
+                hostButton, hostState, portState, status, connectionStatus));
         infoButton.setOnClickListener(v -> showInfoPopup(infoButton));
         voiceMessage.setOnClickListener(v -> toggleVoiceInput(
                 voiceMessage, chatInput, status, listening));
@@ -163,7 +173,8 @@ public class TERAPlugin implements IPlugin {
                 return;
             }
             String host = hostState.toString();
-            String endpoint = buildEndpoint(host);
+            String endpoint = buildEndpoint(host, portState.toString());
+            JSONObject mapContext = buildMapContext();
 
             appendChatLine(chatHistory, host.isEmpty() ? "Operator (local)" : "Operator (" + host + ")", message);
             transcript.setText(chatHistory.toString());
@@ -177,6 +188,7 @@ public class TERAPlugin implements IPlugin {
             TeraPlanClient.requestPlan(
                     endpoint,
                     message,
+                    mapContext,
                     new TeraPlanClient.Callback() {
                         @Override
                         public void onComplete(boolean ok, String message) {
@@ -195,7 +207,8 @@ public class TERAPlugin implements IPlugin {
         });
     }
 
-    private void showHostPopup(Button hostButton, StringBuilder hostState, TextView status) {
+    private void showHostPopup(Button hostButton, StringBuilder hostState, StringBuilder portState,
+                               TextView status, TextView connectionStatus) {
         LinearLayout content = new LinearLayout(hostButton.getContext());
         content.setOrientation(LinearLayout.VERTICAL);
         int padding = dp(12);
@@ -222,6 +235,17 @@ public class TERAPlugin implements IPlugin {
         hostEdit.setPadding(dp(10), 0, dp(10), 0);
         hostEdit.setSelectAllOnFocus(false);
 
+        EditText portEdit = new EditText(hostButton.getContext());
+        portEdit.setSingleLine(true);
+        portEdit.setInputType(InputType.TYPE_CLASS_NUMBER);
+        portEdit.setHint(R.string.host_port_hint);
+        portEdit.setText(portState.toString());
+        portEdit.setTextSize(13);
+        portEdit.setTextColor(Color.BLACK);
+        portEdit.setHintTextColor(Color.GRAY);
+        portEdit.setBackgroundResource(R.drawable.host_input_bg);
+        portEdit.setPadding(dp(10), 0, dp(10), 0);
+
         LinearLayout actions = new LinearLayout(hostButton.getContext());
         actions.setOrientation(LinearLayout.HORIZONTAL);
         actions.setPadding(0, dp(10), 0, 0);
@@ -234,13 +258,22 @@ public class TERAPlugin implements IPlugin {
         useLocal.setText(R.string.host_popup_local);
         useLocal.setTextSize(12);
 
+        Button test = new Button(hostButton.getContext());
+        test.setText(R.string.host_popup_test);
+        test.setTextSize(12);
+
         actions.addView(apply, new LinearLayout.LayoutParams(0,
                 LinearLayout.LayoutParams.WRAP_CONTENT, 1));
         actions.addView(useLocal, new LinearLayout.LayoutParams(0,
                 LinearLayout.LayoutParams.WRAP_CONTENT, 1));
+        actions.addView(test, new LinearLayout.LayoutParams(0,
+                LinearLayout.LayoutParams.WRAP_CONTENT, 1));
 
         content.addView(title);
         content.addView(hostEdit, new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                dp(38)));
+        content.addView(portEdit, new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 dp(38)));
         content.addView(actions);
@@ -257,6 +290,8 @@ public class TERAPlugin implements IPlugin {
         apply.setOnClickListener(v -> {
             hostState.setLength(0);
             hostState.append(hostEdit.getText().toString().trim());
+            portState.setLength(0);
+            portState.append(normalizedPort(portEdit.getText().toString()));
             hostButton.setText(hostState.length() == 0
                     ? pluginContext.getString(R.string.host_local)
                     : hostState.toString());
@@ -268,9 +303,30 @@ public class TERAPlugin implements IPlugin {
 
         useLocal.setOnClickListener(v -> {
             hostState.setLength(0);
+            portState.setLength(0);
+            portState.append("8080");
             hostButton.setText(R.string.host_local);
             status.setText("Host set to local.");
             popup.dismiss();
+        });
+
+        test.setOnClickListener(v -> {
+            String host = hostEdit.getText().toString().trim();
+            String port = normalizedPort(portEdit.getText().toString());
+            String endpoint = buildEndpoint(host, port);
+            connectionStatus.setText(R.string.connection_connecting);
+            status.setText("Testing Jetson connection...");
+            TeraPlanClient.checkJetson(endpoint, new TeraPlanClient.Callback() {
+                @Override
+                public void onComplete(boolean ok, String message) {
+                    mainHandler.post(() -> {
+                        connectionStatus.setText(ok
+                                ? R.string.connection_online
+                                : R.string.connection_error);
+                        status.setText(message);
+                    });
+                }
+            });
         });
 
         popup.showAtLocation(hostButton.getRootView(),
@@ -405,7 +461,7 @@ public class TERAPlugin implements IPlugin {
         }
     }
 
-    private String buildEndpoint(String host) {
+    private String buildEndpoint(String host, String port) {
         if (host == null || host.trim().isEmpty()) {
             return pluginContext.getString(R.string.endpoint_hint);
         }
@@ -413,7 +469,7 @@ public class TERAPlugin implements IPlugin {
         String endpoint = host.trim();
         if (!endpoint.startsWith("http://") && !endpoint.startsWith("https://")) {
             if (!endpoint.contains(":")) {
-                endpoint = endpoint + ":8080";
+                endpoint = endpoint + ":" + normalizedPort(port);
             }
             endpoint = "http://" + endpoint;
         }
@@ -421,6 +477,70 @@ public class TERAPlugin implements IPlugin {
             endpoint = endpoint + pluginContext.getString(R.string.endpoint_path);
         }
         return endpoint;
+    }
+
+    private String normalizedPort(String port) {
+        if (port == null || port.trim().isEmpty()) {
+            return "8080";
+        }
+        return port.trim();
+    }
+
+    private JSONObject buildMapContext() {
+        try {
+            MapView mapView = MapView.getMapView();
+            if (mapView == null) {
+                return null;
+            }
+
+            JSONObject context = new JSONObject();
+            GeoPointMetaData centerMeta = mapView.getCenterPoint();
+            if (centerMeta != null && centerMeta.get() != null && centerMeta.get().isValid()) {
+                context.put("camera", pointToJson(centerMeta.get()));
+            }
+
+            GeoBounds bounds = mapView.getBounds();
+            if (bounds != null) {
+                JSONObject viewBounds = new JSONObject();
+                viewBounds.put("west", bounds.getWest());
+                viewBounds.put("south", bounds.getSouth());
+                viewBounds.put("east", bounds.getEast());
+                viewBounds.put("north", bounds.getNorth());
+                GeoPoint center = bounds.getCenter(null);
+                if (center != null && center.isValid()) {
+                    viewBounds.put("center_lat", center.getLatitude());
+                    viewBounds.put("center_lon", center.getLongitude());
+                }
+                context.put("view_bounds", viewBounds);
+            }
+
+            Marker self = mapView.getSelfMarker();
+            if (self != null && self.getPoint() != null && self.getPoint().isValid()) {
+                JSONObject selectedArea = new JSONObject();
+                GeoPoint selfPoint = self.getPoint();
+                selectedArea.put("west", selfPoint.getLongitude());
+                selectedArea.put("south", selfPoint.getLatitude());
+                selectedArea.put("east", selfPoint.getLongitude());
+                selectedArea.put("north", selfPoint.getLatitude());
+                selectedArea.put("center_lat", selfPoint.getLatitude());
+                selectedArea.put("center_lon", selfPoint.getLongitude());
+                context.put("selected_area", selectedArea);
+            }
+
+            return context.length() == 0 ? null : context;
+        } catch (JSONException e) {
+            return null;
+        }
+    }
+
+    private JSONObject pointToJson(GeoPoint point) throws JSONException {
+        JSONObject json = new JSONObject();
+        json.put("lat", point.getLatitude());
+        json.put("lon", point.getLongitude());
+        if (point.isAltitudeValid()) {
+            json.put("height_m", point.getAltitude());
+        }
+        return json;
     }
 
     private void showInfoPopup(View anchor) {

--- a/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
+++ b/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
@@ -145,8 +145,6 @@ public class TERAPlugin implements IPlugin {
         final View sendMessage = teraView.findViewById(R.id.tera_send_message);
         final View voiceMessage = teraView.findViewById(R.id.tera_voice_message);
         final View ttsToggle = teraView.findViewById(R.id.tera_tts_toggle);
-        final TextView status = teraView.findViewById(R.id.tera_status);
-        final TextView response = teraView.findViewById(R.id.tera_response);
         final StringBuilder chatHistory = new StringBuilder();
         final StringBuilder hostState = new StringBuilder();
         final boolean[] ttsEnabled = new boolean[] { false };
@@ -154,16 +152,16 @@ public class TERAPlugin implements IPlugin {
 
         hostButton.setText(R.string.host_local);
         hostButton.setOnClickListener(v -> showHostPopup(
-                hostButton, hostState, status, connectionStatus));
+                hostButton, hostState, connectionStatus));
         infoButton.setOnClickListener(v -> showInfoPopup(infoButton));
         voiceMessage.setOnClickListener(v -> toggleVoiceInput(
-                voiceMessage, chatInput, status, listening));
+                voiceMessage, chatInput, listening));
         ttsToggle.setOnClickListener(v -> {
             ttsEnabled[0] = !ttsEnabled[0];
             ttsToggle.setBackgroundResource(ttsEnabled[0]
                     ? R.drawable.chat_icon_button_selected_bg
                     : R.drawable.chat_icon_button_bg);
-            status.setText(ttsEnabled[0] ? "Text-to-speech enabled." : "Text-to-speech disabled.");
+            connectionStatus.setText(ttsEnabled[0] ? "TTS on" : "TTS off");
         });
 
         sendMessage.setOnClickListener(v -> {
@@ -181,8 +179,6 @@ public class TERAPlugin implements IPlugin {
             chatInput.setText("");
             sendMessage.setEnabled(false);
             connectionStatus.setText(R.string.connection_connecting);
-            status.setText(R.string.status_sending);
-            response.setText("");
 
             TeraPlanClient.requestPlan(
                     endpoint,
@@ -196,7 +192,6 @@ public class TERAPlugin implements IPlugin {
                                 connectionStatus.setText(ok
                                         ? R.string.connection_online
                                         : R.string.connection_error);
-                                status.setText(ok ? "Agent response received." : "Agent request failed.");
                                 appendChatLine(chatHistory, ok ? "Agent" : "Error", message);
                                 transcript.setText(chatHistory.toString());
                                 scrollChatToBottom(chatScroll);
@@ -207,7 +202,7 @@ public class TERAPlugin implements IPlugin {
     }
 
     private void showHostPopup(Button hostButton, StringBuilder hostState,
-                               TextView status, TextView connectionStatus) {
+                               TextView connectionStatus) {
         LinearLayout content = new LinearLayout(hostButton.getContext());
         content.setOrientation(LinearLayout.VERTICAL);
         int padding = dp(12);
@@ -277,7 +272,7 @@ public class TERAPlugin implements IPlugin {
         useLocal.setOnClickListener(v -> {
             hostState.setLength(0);
             hostButton.setText(R.string.host_local);
-            status.setText("Host set to local.");
+            connectionStatus.setText(R.string.connection_offline);
             popup.dismiss();
         });
 
@@ -325,10 +320,9 @@ public class TERAPlugin implements IPlugin {
         }, 100);
     }
 
-    private void toggleVoiceInput(View voiceButton, EditText chatInput, TextView status,
-                                  boolean[] listening) {
+    private void toggleVoiceInput(View voiceButton, EditText chatInput, boolean[] listening) {
         if (!SpeechRecognizer.isRecognitionAvailable(pluginContext)) {
-            status.setText("Speech recognition is not available on this device.");
+            chatInput.setHint("Speech recognition unavailable");
             return;
         }
 
@@ -338,7 +332,7 @@ public class TERAPlugin implements IPlugin {
             }
             listening[0] = false;
             voiceButton.setBackgroundResource(R.drawable.chat_icon_button_bg);
-            status.setText("Voice input stopped.");
+            chatInput.setHint(R.string.chat_input_hint);
             return;
         }
 
@@ -347,12 +341,12 @@ public class TERAPlugin implements IPlugin {
             speechRecognizer.setRecognitionListener(new RecognitionListener() {
                 @Override
                 public void onReadyForSpeech(Bundle params) {
-                    status.setText(R.string.status_listening);
+                    chatInput.setHint(R.string.status_listening);
                 }
 
                 @Override
                 public void onBeginningOfSpeech() {
-                    status.setText("Listening...");
+                    chatInput.setHint(R.string.status_listening);
                 }
 
                 @Override
@@ -367,14 +361,14 @@ public class TERAPlugin implements IPlugin {
                 public void onEndOfSpeech() {
                     listening[0] = false;
                     voiceButton.setBackgroundResource(R.drawable.chat_icon_button_bg);
-                    status.setText("Processing voice input...");
+                    chatInput.setHint("Processing voice...");
                 }
 
                 @Override
                 public void onError(int error) {
                     listening[0] = false;
                     voiceButton.setBackgroundResource(R.drawable.chat_icon_button_bg);
-                    status.setText("Voice input failed: " + speechErrorMessage(error));
+                    chatInput.setHint("Voice failed: " + speechErrorMessage(error));
                 }
 
                 @Override
@@ -384,12 +378,12 @@ public class TERAPlugin implements IPlugin {
                     java.util.ArrayList<String> matches = results.getStringArrayList(
                             SpeechRecognizer.RESULTS_RECOGNITION);
                     if (matches == null || matches.isEmpty()) {
-                        status.setText("No voice input detected.");
+                        chatInput.setHint("No voice detected");
                         return;
                     }
                     chatInput.setText(matches.get(0));
                     chatInput.setSelection(chatInput.getText().length());
-                    status.setText("Voice input added to chat.");
+                    chatInput.setHint(R.string.chat_input_hint);
                 }
 
                 @Override
@@ -416,7 +410,7 @@ public class TERAPlugin implements IPlugin {
 
         listening[0] = true;
         voiceButton.setBackgroundResource(R.drawable.chat_icon_button_selected_bg);
-        status.setText(R.string.status_listening);
+        chatInput.setHint(R.string.status_listening);
         speechRecognizer.startListening(intent);
     }
 

--- a/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
+++ b/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
@@ -288,7 +288,6 @@ public class TERAPlugin implements IPlugin {
             connect.setEnabled(false);
             connect.setText("...");
             connectionStatus.setText(R.string.connection_connecting);
-            status.setText("Testing Jetson connection...");
             result.setVisibility(View.VISIBLE);
             result.setText("Testing:\n" + endpoint);
             TeraPlanClient.checkJetson(endpoint, new TeraPlanClient.Callback() {
@@ -300,7 +299,6 @@ public class TERAPlugin implements IPlugin {
                         connectionStatus.setText(ok
                                 ? R.string.connection_online
                                 : R.string.connection_error);
-                        status.setText(message);
                         result.setText(message + "\n\nEndpoint:\n" + endpoint);
                         if (ok) {
                             hostState.setLength(0);

--- a/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TeraPlanClient.java
+++ b/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TeraPlanClient.java
@@ -26,7 +26,22 @@ final class TeraPlanClient {
     private TeraPlanClient() {
     }
 
-    static void requestPlan(String endpoint, String prompt, Callback callback) {
+    static void checkJetson(String endpoint, Callback callback) {
+        EXECUTOR.execute(() -> {
+            if (endpoint == null || !endpoint.startsWith("http")) {
+                callback.onComplete(false, "Endpoint must start with http:// or https://");
+                return;
+            }
+
+            String healthError = checkHealth(endpoint.trim());
+            callback.onComplete(healthError == null, healthError == null
+                    ? "Jetson health check passed."
+                    : healthError);
+        });
+    }
+
+    static void requestPlan(String endpoint, String prompt, JSONObject mapContext,
+                            Callback callback) {
         EXECUTOR.execute(() -> {
             HttpURLConnection connection = null;
             try {
@@ -53,7 +68,7 @@ final class TeraPlanClient {
                 connection.setRequestProperty("Content-Type", "application/json");
                 connection.setDoOutput(true);
 
-                String payload = buildPromptPayload(prompt.trim(), null);
+                String payload = buildPromptPayload(prompt.trim(), mapContext);
                 byte[] body = payload.getBytes(StandardCharsets.UTF_8);
                 connection.setFixedLengthStreamingMode(body.length);
 

--- a/atak/plugin/app/src/main/res/layout/main_layout.xml
+++ b/atak/plugin/app/src/main/res/layout/main_layout.xml
@@ -142,20 +142,4 @@
 
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/tera_status"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="9dp"
-            android:text="@string/status_ready"
-            android:textSize="13sp" />
-
-        <TextView
-            android:id="@+id/tera_response"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="7dp"
-            android:text=""
-            android:textSize="13sp" />
-
 </LinearLayout>

--- a/atak/plugin/app/src/main/res/values/strings.xml
+++ b/atak/plugin/app/src/main/res/values/strings.xml
@@ -7,10 +7,12 @@
     <string name="endpoint_hint">http://127.0.0.1:8080/api/prompt</string>
     <string name="endpoint_path">/api/prompt</string>
     <string name="host_input_hint">192.168.4.1</string>
+    <string name="host_port_hint">8080</string>
     <string name="host_local">local</string>
     <string name="host_popup_title">Jetson IP</string>
     <string name="host_popup_apply">APPLY</string>
     <string name="host_popup_local">USE LOCAL</string>
+    <string name="host_popup_test">TEST</string>
     <string name="model_selection_label">Model</string>
     <string name="connection_offline">Offline</string>
     <string name="connection_connecting">Connecting</string>

--- a/atak/plugin/app/src/main/res/values/strings.xml
+++ b/atak/plugin/app/src/main/res/values/strings.xml
@@ -7,12 +7,10 @@
     <string name="endpoint_hint">http://127.0.0.1:8080/api/prompt</string>
     <string name="endpoint_path">/api/prompt</string>
     <string name="host_input_hint">192.168.4.1</string>
-    <string name="host_port_hint">8080</string>
     <string name="host_local">local</string>
     <string name="host_popup_title">Jetson IP</string>
-    <string name="host_popup_apply">APPLY</string>
+    <string name="host_popup_connect">CONNECT</string>
     <string name="host_popup_local">USE LOCAL</string>
-    <string name="host_popup_test">TEST</string>
     <string name="model_selection_label">Model</string>
     <string name="connection_offline">Offline</string>
     <string name="connection_connecting">Connecting</string>

--- a/atak/plugin/scripts/install_device.sh
+++ b/atak/plugin/scripts/install_device.sh
@@ -3,10 +3,11 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-APK="app/build/outputs/apk/civ/release/ATAK-Plugin-TERA-0.1--5.7.0-civ-release.apk"
+APK="$(find app/build/outputs/apk/civ/release -maxdepth 1 -name '*.apk' -print 2>/dev/null | sort | tail -n 1)"
 
-if [[ ! -f "$APK" ]]; then
+if [[ -z "$APK" || ! -f "$APK" ]]; then
   ./scripts/build_release.sh
+  APK="$(find app/build/outputs/apk/civ/release -maxdepth 1 -name '*.apk' -print | sort | tail -n 1)"
 fi
 
 adb install -r "$APK"


### PR DESCRIPTION
## Summary
- targets the Jetson Gemma /api/prompt endpoint on port 8080
- adds Jetson health checks and clearer response validation
- adds host connect flow with IP-only input and no visible port field
- sends ATAK map context with chat requests
- removes bottom sidebar status text so chat input is the lowest item
- adds make targets for ATAK plugin build/install

## Verification
- bash -n atak/scripts/run_jetson_gemma_server.sh
- bash -n atak/scripts/test_jetson_link.sh
- zsh -n atak/plugin/scripts/install_device.sh
- ./gradlew assembleCivRelease