### PR TITLE
fix(deploy): run planner docker as package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache
+.mypy_cache
+.ruff_cache
+node_modules
+llm_dev_kmh/uvicorn-*.log
+llm_dev_kmh/uvicorn-*.err.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   llm-dev-kmh:
     build:
-      context: ./llm_dev_kmh
+      context: .
+      dockerfile: llm_dev_kmh/Dockerfile
     ports:
       - "8080:8080"
     environment:

--- a/llm_dev_kmh/Dockerfile
+++ b/llm_dev_kmh/Dockerfile
@@ -6,11 +6,12 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-COPY requirements.txt ./
+COPY llm_dev_kmh/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . ./
+COPY llm_dev_kmh ./llm_dev_kmh
+COPY prompts ./prompts
 
 EXPOSE 8080
 
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "llm_dev_kmh.app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/tests/test_llm_dev_stream.py
+++ b/tests/test_llm_dev_stream.py
@@ -446,6 +446,19 @@ def test_user_chat_transcript_hides_prompt_context_appendix() -> None:
     assert 'focus: ${sourceContext.mission_focus}' not in js
 
 
+def test_llm_dev_docker_runs_package_import_path() -> None:
+    repo_root = Path(kmh_app.__file__).resolve().parents[1]
+    compose = (repo_root / "docker-compose.yml").read_text(encoding="utf-8")
+    dockerfile = (repo_root / "llm_dev_kmh" / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "context: ." in compose
+    assert "dockerfile: llm_dev_kmh/Dockerfile" in compose
+    assert "COPY llm_dev_kmh ./llm_dev_kmh" in dockerfile
+    assert "COPY prompts ./prompts" in dockerfile
+    assert '"llm_dev_kmh.app:app"' in dockerfile
+    assert '"app:app"' not in dockerfile
+
+
 def test_prompt_composer_clears_after_submit_is_accepted() -> None:
     js = (kmh_app.STATIC_DIR / "app.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Summary:
- Build llm_dev_kmh from the repo root so Docker preserves the llm_dev_kmh package import path.
- Run uvicorn with llm_dev_kmh.app:app and include local model prompt files in the image.
- Add a static regression test for the Docker import path.

Test Plan:
- .\.venv\Scripts\python.exe -m pytest tests/test_llm_dev_stream.py -q
- Docker build not run locally because Docker CLI is not installed on this Windows machine; Jetson should validate via make jetson-compose-refresh.