### PR TITLE
fix(atak): three follow-ups from #94 review

### DIFF
--- a/atak/README.md
+++ b/atak/README.md
@@ -94,7 +94,7 @@ Run these on the Jetson.
    ```bash
    curl -s -X POST http://127.0.0.1:8080/api/prompt \
      -H "Content-Type: application/json" \
-     -d '{"prompt":"TERA ATAK link test. Reply briefly.","model":"gemma3:4b","llm_provider":"ollama","agent_profile":"tera-atak-link-test"}'
+     -d '{"prompt":"TERA ATAK link test. Reply briefly.","model":"gemma3:4b","llm_provider":"ollama","agent_profile":"tera-atak-live"}'
    ```
 
 ## ATAK Device Setup
@@ -144,7 +144,7 @@ proves the same network path the ATAK plugin will use.
      "prompt": "TERA ATAK link test. Reply with JSON containing status, model, and one short readiness sentence.",
      "model": "gemma3:4b",
      "llm_provider": "ollama",
-     "agent_profile": "tera-atak-link-test"
+     "agent_profile": "tera-atak-live"
    }
    ```
 

--- a/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
+++ b/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TERAPlugin.java
@@ -467,9 +467,11 @@ public class TERAPlugin implements IPlugin {
             }
 
             JSONObject context = new JSONObject();
+            boolean cameraSet = false;
             GeoPointMetaData centerMeta = mapView.getCenterPoint();
             if (centerMeta != null && centerMeta.get() != null && centerMeta.get().isValid()) {
                 context.put("camera", pointToJson(centerMeta.get()));
+                cameraSet = true;
             }
 
             GeoBounds bounds = mapView.getBounds();
@@ -487,17 +489,16 @@ public class TERAPlugin implements IPlugin {
                 context.put("view_bounds", viewBounds);
             }
 
-            Marker self = mapView.getSelfMarker();
-            if (self != null && self.getPoint() != null && self.getPoint().isValid()) {
-                JSONObject selectedArea = new JSONObject();
-                GeoPoint selfPoint = self.getPoint();
-                selectedArea.put("west", selfPoint.getLongitude());
-                selectedArea.put("south", selfPoint.getLatitude());
-                selectedArea.put("east", selfPoint.getLongitude());
-                selectedArea.put("north", selfPoint.getLatitude());
-                selectedArea.put("center_lat", selfPoint.getLatitude());
-                selectedArea.put("center_lon", selfPoint.getLongitude());
-                context.put("selected_area", selectedArea);
+            // Self-marker is only useful as a camera fallback when the map view
+            // doesn't expose a valid center. Never stuff it into selected_area as
+            // a zero-area rectangle: the server treats selected_area as the
+            // user-confirmed AO and feeds it into manifest bounds + prompt
+            // language, so a degenerate pin there distorts downstream behaviour.
+            if (!cameraSet) {
+                Marker self = mapView.getSelfMarker();
+                if (self != null && self.getPoint() != null && self.getPoint().isValid()) {
+                    context.put("camera", pointToJson(self.getPoint()));
+                }
             }
 
             return context.length() == 0 ? null : context;

--- a/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TeraPlanClient.java
+++ b/atak/plugin/app/src/main/java/TacticalEdgeRouteAgent/plugin/TeraPlanClient.java
@@ -226,7 +226,7 @@ final class TeraPlanClient {
         payload.put("prompt", prompt);
         payload.put("model", "gemma3:4b");
         payload.put("llm_provider", "ollama");
-        payload.put("agent_profile", "tera-atak-link-test");
+        payload.put("agent_profile", "tera-atak-live");
         if (mapContext != null) {
             payload.put("map_context", mapContext);
         }

--- a/atak/plugin/scripts/install_device.sh
+++ b/atak/plugin/scripts/install_device.sh
@@ -3,11 +3,23 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-APK="$(find app/build/outputs/apk/civ/release -maxdepth 1 -name '*.apk' -print 2>/dev/null | sort | tail -n 1)"
+# Pick the newest APK by modification time so a freshly-rebuilt artifact is
+# always preferred over a stale-but-lexicographically-later leftover. ``ls -t``
+# is portable across macOS (BSD) and Jetson (GNU) without relying on GNU-only
+# ``find -printf '%T@'``.
+pick_latest_apk() {
+  local dir="app/build/outputs/apk/civ/release"
+  if [[ ! -d "$dir" ]]; then
+    return 0
+  fi
+  ls -1t "$dir"/*.apk 2>/dev/null | head -n 1
+}
+
+APK="$(pick_latest_apk)"
 
 if [[ -z "$APK" || ! -f "$APK" ]]; then
   ./scripts/build_release.sh
-  APK="$(find app/build/outputs/apk/civ/release -maxdepth 1 -name '*.apk' -print | sort | tail -n 1)"
+  APK="$(pick_latest_apk)"
 fi
 
 adb install -r "$APK"

--- a/atak/scripts/test_jetson_link.sh
+++ b/atak/scripts/test_jetson_link.sh
@@ -59,7 +59,7 @@ if ! curl -fsS --connect-timeout "${CONNECT_TIMEOUT}" --max-time 10 "${HEALTH_UR
   exit 1
 fi
 
-BODY="$(printf '{"prompt":%s,"model":%s,"llm_provider":"ollama","agent_profile":"tera-atak-link-test"}' \
+BODY="$(printf '{"prompt":%s,"model":%s,"llm_provider":"ollama","agent_profile":"tera-atak-live"}' \
   "$(printf '%s' "${PROMPT}" | "${PYTHON_BIN}" -c 'import json,sys; print(json.dumps(sys.stdin.read()))')" \
   "$(printf '%s' "${MODEL}" | "${PYTHON_BIN}" -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")"
 

--- a/llm_dev_kmh/app.py
+++ b/llm_dev_kmh/app.py
@@ -5150,6 +5150,17 @@ AGENT_PROFILE_PROMPTS: dict[str, str] = {
         Give practical, safety-oriented recommendations.
         """
     ).strip(),
+    "tera-atak-live": dedent(
+        """
+        You are TERA's live ATAK routing copilot running on a Jetson next to the
+        operator. Requests arrive from the ATAK plugin with structured map context
+        (camera, view_bounds, optional selected AO). Focus on concise, actionable
+        terrain-aware routing: route selection, slope, elevation change, cover,
+        trails, water access, shelter, and obstacles visible in the provided map
+        context. Prefer short operational recommendations grounded in the current
+        map view rather than long source-discovery dialogue.
+        """
+    ).strip(),
 }
 
 PROMPT_FAMILY_GUIDANCE: dict[str, str] = {

--- a/tests/test_llm_dev_stream.py
+++ b/tests/test_llm_dev_stream.py
@@ -229,6 +229,33 @@ def test_imagery_sourcing_prompt_uses_socratic_dialogue() -> None:
     assert "Socratic questions to ask next" in system_prompt
 
 
+def test_tera_atak_live_profile_uses_routing_prompt_and_keeps_mirror_flow() -> None:
+    """Regression: the ATAK plugin sends ``tera-atak-live``; that string must
+    resolve to a routing-flavored system prompt (not the imagery-sourcing
+    fallback) *and* still route through the ATAK mirror flow because
+    ``_request_is_atak_mirror_candidate`` substring-matches on ``"atak"``.
+    Follow-up to #94.
+    """
+    assert "tera-atak-live" in kmh_app.AGENT_PROFILE_PROMPTS
+    profile_prompt = kmh_app.AGENT_PROFILE_PROMPTS["tera-atak-live"]
+    fallback_prompt = kmh_app.AGENT_PROFILE_PROMPTS["imagery-sourcing"]
+    assert profile_prompt != fallback_prompt
+    assert "routing" in profile_prompt.lower()
+
+    request = kmh_app.PromptRequest(
+        prompt="Plan a low-exposure route to the ridge.",
+        agent_profile="tera-atak-live",
+    )
+    system_prompt = kmh_app._build_system_prompt(request)
+    assert profile_prompt in system_prompt
+    # The imagery-sourcing fallback prompt content must NOT be substituted in
+    # place of the ATAK profile prompt (the bug the review flagged).
+    assert fallback_prompt not in system_prompt
+    # Mirror flow still triggers for this profile string (substring "atak").
+    assert kmh_app._request_is_atak_mirror_candidate(request) is True
+    assert kmh_app._mirror_source_for_request(request) == "atak-plugin"
+
+
 def test_manifest_bounds_falls_back_to_view_bounds_when_selected_area_is_null() -> None:
     """Regression: the ATAK plugin no longer stuffs the operator self-marker
     into ``selected_area`` as a zero-area rectangle (#94 follow-up). Confirm

--- a/tests/test_llm_dev_stream.py
+++ b/tests/test_llm_dev_stream.py
@@ -229,6 +229,45 @@ def test_imagery_sourcing_prompt_uses_socratic_dialogue() -> None:
     assert "Socratic questions to ask next" in system_prompt
 
 
+def test_manifest_bounds_falls_back_to_view_bounds_when_selected_area_is_null() -> None:
+    """Regression: the ATAK plugin no longer stuffs the operator self-marker
+    into ``selected_area`` as a zero-area rectangle (#94 follow-up). Confirm
+    the server still formats manifest bounds from ``view_bounds`` when
+    ``selected_area`` is None, and US-context inference degrades gracefully.
+    """
+    context = kmh_app.MapContext(
+        selected_area=None,
+        camera=kmh_app.MapPoint(lat=38.89, lon=-77.03),
+        view_bounds=kmh_app.ViewBounds(
+            west=-77.05,
+            south=38.87,
+            east=-77.01,
+            north=38.91,
+            center_lat=38.89,
+            center_lon=-77.03,
+        ),
+        location_confirmed=True,
+    )
+
+    formatted = kmh_app._format_manifest_bounds(context)
+    assert formatted is not None
+    assert formatted["west"] == -77.05
+    assert formatted["east"] == -77.01
+
+    bounds = kmh_app._manifest_bounds_from_context(context)
+    assert bounds is not None
+    assert bounds.west == -77.05
+    assert bounds.north == 38.91
+
+    # With no selected_area and no US keywords, US-context inference still
+    # works off view_bounds when location_confirmed is set.
+    assert kmh_app._infer_is_us_context("plan a route", context) is True
+
+    # And a fully-null map_context is a no-op rather than an exception.
+    assert kmh_app._format_manifest_bounds(None) is None
+    assert kmh_app._manifest_bounds_from_context(None) is None
+
+
 def test_source_recommendation_questions_prioritize_source_scope() -> None:
     recommendation = kmh_app._infer_source_recommendation(
         "Build an offline package for a patrol to find reliable water while avoiding steep exposed terrain.",


### PR DESCRIPTION
Follow-up to PR #94 (merged at `c404d30`) and tracked under #79. Three
small, independently-committed fixes that came out of the post-merge
review. Green `make test` + `make lint` locally.

## Fixes (one commit each)

### 1. `fix(atak): stop sending operator self-marker as zero-area selected_area`

**Before:** `buildMapContext()` packed the operator self-marker into
`map_context.selected_area` as `{west=east=lon, south=north=lat}` — a
degenerate zero-area rectangle. The server treats `selected_area` as
the user-confirmed AO and feeds it into `_format_manifest_bounds`,
`_manifest_bounds_from_context`, `_infer_is_us_context`, and AO-confirmed
system-prompt language, so a zero-area pin there distorted manifest
bounds and prompt wording.

**After:** `selected_area` is left `null` when only the self-marker is
known. The self-marker is only used as a `camera` fallback when the map
view doesn't expose a valid center. `view_bounds` still carries the
visible AO, which is exactly what the server falls back to for manifest
bounds / US-context inference. (Strategy **(a)** from the task.)

Regression test: `tests/test_llm_dev_stream.py::test_manifest_bounds_falls_back_to_view_bounds_when_selected_area_is_null`.

### 2. `fix(atak): use registered tera-atak-live agent_profile for plugin requests`

**Before:** `TeraPlanClient.buildPromptPayload` hard-coded
`agent_profile = "tera-atak-link-test"`, which is not a key in
`AGENT_PROFILE_PROMPTS`. The server's `_build_system_prompt` silently
fell back to the `imagery-sourcing` profile — wrong content for a
routing demo. The ATAK mirror flow still triggered because
`_request_is_atak_mirror_candidate` substring-matches on `"atak"`.

**After:** The client sends `tera-atak-live`, which is already the
canonical name in `docker-compose.yml`, `llm_dev_kmh/static/app.js`,
`llm_dev_kmh/static/index.html`, and the `TERA_ATAK_AGENT_PROFILE`
default. A matching `tera-atak-live` entry is registered in
`AGENT_PROFILE_PROMPTS` with routing-appropriate guidance. The
substring `"atak"` is preserved, so the mirror flow still routes.

**Strategy choice:** I had to use **(b)** — strategy (a)
(`terrain-route`) would have broken `_request_is_atak_mirror_candidate`
(confirmed by reading `app.py:2571-2580`, which checks `"atak" in profile`).

`atak/README.md` curl example and `atak/scripts/test_jetson_link.sh`
were updated to the same string so anyone smoke-testing the endpoint
exercises what the plugin actually sends.

Regression test: `tests/test_llm_dev_stream.py::test_tera_atak_live_profile_uses_routing_prompt_and_keeps_mirror_flow`
— asserts (1) profile is registered, (2) its prompt (not the
imagery-sourcing fallback) is substituted into the system prompt, and
(3) `_request_is_atak_mirror_candidate` + `_mirror_source_for_request`
still match for this string.

### 3. `chore(atak): pick newest APK by modtime in install_device.sh`

**Before:** `find ... -name '*.apk' | sort | tail -n 1` returned the
lexicographically-last filename rather than the newest modtime.

**After:** `ls -1t "$dir"/*.apk | head -n 1` via a `pick_latest_apk`
helper. Portable across macOS (dev laptop) and Jetson (GNU) — GNU-only
`find -printf '%T@'` would have broken the `make atak-plugin-install`
flow when run from macOS. `bash -n` clean (this is gated by
`tests/test_shell_scripts.py`).

## Test plan

- [x] `make test` — 321 passed, 0 failed
- [x] `make lint` — ruff check, ruff format, and mypy all clean
- [ ] Green CI on this branch
- [ ] Manual smoke on Jetson: `make jetson-compose-refresh` then hit
      `/api/prompt` with the updated README curl example; confirm the
      system prompt uses the new `tera-atak-live` routing content
- [ ] Manual smoke with the ATAK plugin: verify a request with no
      confirmed AO sets `selected_area=null` on the wire (only `camera`
      / `view_bounds` populated)

## Not in scope

Findings #1, #4, #5, #7 from the #94 review are either nits or already
correct — left alone per "do not touch code outside the three fixes'
scope."

## Note for Jon while reviewing

While reading the `selected_area` → manifest bounds path I noticed one
additional adjacent risk worth tracking separately (not fixed here):
`_infer_is_us_context` only trusts `selected_area` / `view_bounds` when
`location_confirmed=True` OR `selected_area` is set. The ATAK plugin
doesn't currently set `location_confirmed`, so after this PR
US-context inference for ATAK requests relies entirely on prompt-text
keywords. That's fine for the demo (the web planner sets the flag; the
plugin's prompt content usually names the AO), but if downstream
behavior starts depending on imagery-source selection for ATAK
requests, we'll want the plugin to also send `location_confirmed=True`
once the operator pans to their AO. Happy to file as a separate issue
if you want.