### PR TITLE
chore(atak): 104 — pick newest APK by modtime in install_device.sh

### DIFF
--- a/atak/plugin/scripts/install_device.sh
+++ b/atak/plugin/scripts/install_device.sh
@@ -3,11 +3,19 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-APK="$(find app/build/outputs/apk/civ/release -maxdepth 1 -name '*.apk' -print 2>/dev/null | sort | tail -n 1)"
+# Pick the newest APK by modification time so a freshly-rebuilt artifact is
+# preferred over a stale-but-lexicographically-later leftover (e.g. v1.2.10
+# would lex-sort before v1.2.2 with the previous `sort | tail` form). `ls -t`
+# is portable across macOS (BSD) and Jetson (GNU).
+pick_latest_apk() {
+  ls -1t app/build/outputs/apk/civ/release/*.apk 2>/dev/null | head -n 1
+}
+
+APK="$(pick_latest_apk)"
 
 if [[ -z "$APK" || ! -f "$APK" ]]; then
   ./scripts/build_release.sh
-  APK="$(find app/build/outputs/apk/civ/release -maxdepth 1 -name '*.apk' -print | sort | tail -n 1)"
+  APK="$(pick_latest_apk)"
 fi
 
 adb install -r "$APK"


### PR DESCRIPTION
## Summary

`atak/plugin/scripts/install_device.sh` was selecting the APK to push via
`find … *.apk | sort | tail -n 1`, which is lexicographic order — a 1.2.10
APK would lex-sort *before* 1.2.2 and silently install the older build.
Swap to `ls -1t` so the most-recently-built artifact wins. Tiny helper
function so we don't repeat the path twice. `ls -t` is portable across
macOS (BSD) and Jetson (GNU).

## Why this is trivial

Single 12-line shell diff in one file (`atak/plugin/scripts/install_device.sh`),
no behaviour change for the happy path of a single fresh APK, no new deps.
`bash -n` parses cleanly; `make shellcheck-syntax`, `make lint`, and `make test`
(332 tests) all pass.

Closes #104.